### PR TITLE
feat(viewer): add contextual diagnostics drawer

### DIFF
--- a/packages/ui/src/app-devices.test.tsx
+++ b/packages/ui/src/app-devices.test.tsx
@@ -535,6 +535,38 @@ describe("Devices app integration", () => {
 		expect(document.getElementById("refreshStatus")?.textContent).not.toContain("updated");
 	});
 
+	it("keeps Projects refresh failed until a later Projects load succeeds", async () => {
+		const { state } = await import("./lib/state");
+		state.activeTab = "projects";
+		mocks.loadProjectsData.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(5_100);
+		});
+		expect(document.getElementById("refreshStatus")?.dataset.refreshState).toBe("error");
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(5_100);
+		});
+		expect(document.getElementById("refreshStatus")?.dataset.refreshState).toBe("idle");
+	});
+
+	it("keeps Sharing refresh failed until a later Sharing load succeeds", async () => {
+		const { state } = await import("./lib/state");
+		state.activeTab = "sharing";
+		mocks.loadRecipientPolicySharingData.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(5_100);
+		});
+		expect(document.getElementById("refreshStatus")?.dataset.refreshState).toBe("error");
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(5_100);
+		});
+		expect(document.getElementById("refreshStatus")?.dataset.refreshState).toBe("idle");
+	});
+
 	it("uses a fresh Devices inventory instead of accepting cached Sync ownership", async () => {
 		const { state } = await import("./lib/state");
 		state.lastDeviceIdentityInventory = {

--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -10,6 +10,12 @@
 declare const __CODEMEM_GIT_COMMIT__: string;
 
 import { createRecipientPolicySharingLoader } from "./app-sharing";
+import {
+	closeDiagnosticsDrawer,
+	coordinatedRefreshDiagnosticsDrawer,
+	initDiagnosticsEntryPoints,
+	mountDiagnosticsDrawer,
+} from "./components/diagnostics";
 import { mountToastHost } from "./components/primitives/toast";
 import * as api from "./lib/api";
 import type { ProjectScopeInventoryProject } from "./lib/api/sync";
@@ -221,7 +227,7 @@ function setLegacyUpgradeNotice(open: boolean, summary?: LegacyUpgradeReviewSumm
 function maybeShowLegacyUpgradeNotice(summary: LegacyUpgradeReviewSummary | null) {
 	if (!summary || legacyUpgradeNoticeShown || isLegacyUpgradeNoticeDismissed()) return;
 	legacyUpgradeNoticeShown = true;
-	setLegacyUpgradeNotice(true, summary);
+	closeDiagnosticsDrawer(() => setLegacyUpgradeNotice(true, summary));
 }
 
 async function checkLegacyUpgradeNotice() {
@@ -257,6 +263,7 @@ function scheduleReconnectLoop() {
 	if (reconnecting) return;
 	reconnecting = true;
 	stopPolling();
+	closeDiagnosticsDrawer();
 	setRefreshStatus("error", "(reconnecting)");
 	setReconnectOverlay(
 		true,
@@ -703,6 +710,44 @@ $select("projectFilter")?.addEventListener("change", () => {
 
 let refreshDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
+async function loadGlobalRefreshData(): Promise<void> {
+	await Promise.all([
+		loadHealthData(),
+		loadConfigData(),
+		coordinatedRefreshDiagnosticsDrawer().catch(() => undefined),
+	]);
+}
+
+function appendTabRefreshTasks(
+	promises: Promise<unknown>[],
+	refreshTab: TabId,
+	recordBooleanResult: (succeeded: boolean) => void,
+): void {
+	if (refreshTab === "feed") {
+		const coordinatorGeneration = beginStandaloneCoordinatorAdminStatusRefresh();
+		promises.push(
+			refreshCoordinatorAdminStatusForGeneration(coordinatorGeneration),
+			loadFeedData(),
+		);
+	}
+	if (refreshTab === "projects") {
+		promises.push(loadProjectsData().then(recordBooleanResult));
+	}
+	if (refreshTab === "sharing") {
+		promises.push(loadRecipientPolicySharingData().then(recordBooleanResult));
+	}
+	if (refreshTab === "devices") {
+		promises.push(loadDevicesData().then(recordBooleanResult));
+	}
+	if ((refreshTab === "advanced" && state.advancedSection === "sync") || refreshTab === "health") {
+		promises.push(loadSyncData());
+	}
+	if (refreshTab === "advanced" && state.advancedSection === "teams") {
+		promises.push(loadCoordinatorAdminData());
+	}
+	if (state.syncPairingOpen) promises.push(loadPairingData());
+}
+
 async function refresh() {
 	if (reconnecting) return;
 	// Debounce rapid calls (tab switch + hash change + visibility)
@@ -720,50 +765,12 @@ async function doRefresh() {
 
 	try {
 		setRefreshStatus("refreshing");
-
 		const refreshTab = state.activeTab;
-
-		// Always load health data (for the header health dot) and config
-		const promises: Promise<unknown>[] = [loadHealthData(), loadConfigData()];
-		let devicesRefreshSucceeded = true;
-		if (refreshTab === "feed") {
-			const coordinatorGeneration = beginStandaloneCoordinatorAdminStatusRefresh();
-			promises.push(refreshCoordinatorAdminStatusForGeneration(coordinatorGeneration));
-		}
-
-		// Load tab-specific data
-		if (refreshTab === "feed") {
-			promises.push(loadFeedData());
-		}
-		if (refreshTab === "projects") {
-			promises.push(loadProjectsData());
-		}
-		if (refreshTab === "sharing") {
-			promises.push(loadRecipientPolicySharingData());
-		}
-		if (refreshTab === "devices") {
-			promises.push(
-				loadDevicesData().then((succeeded) => {
-					devicesRefreshSucceeded = succeeded;
-				}),
-			);
-		}
-		// Sync data is needed by Advanced Sync and Health (health cards derive sync state).
-		if (
-			(refreshTab === "advanced" && state.advancedSection === "sync") ||
-			refreshTab === "health"
-		) {
-			promises.push(loadSyncData());
-		}
-		if (refreshTab === "advanced" && state.advancedSection === "teams") {
-			promises.push(loadCoordinatorAdminData());
-		}
-
-		// Load pairing if open
-		if (state.syncPairingOpen) {
-			promises.push(loadPairingData());
-		}
-
+		const promises: Promise<unknown>[] = [loadGlobalRefreshData()];
+		let activeTabRefreshSucceeded = true;
+		appendTabRefreshTasks(promises, refreshTab, (succeeded) => {
+			activeTabRefreshSucceeded = activeTabRefreshSucceeded && succeeded;
+		});
 		await Promise.all(promises);
 		maybeShowLegacyUpgradeNotice(readLegacyUpgradeReviewSummary(state.lastSyncLegacySharedReview));
 		const nextTab = resolveAccessibleTab(state.activeTab, state.lastCoordinatorAdminStatus);
@@ -771,7 +778,7 @@ async function doRefresh() {
 			setActiveTab(nextTab);
 		}
 		renderTabs(state.activeTab);
-		setRefreshStatus(devicesRefreshSucceeded ? "idle" : "error");
+		setRefreshStatus(activeTabRefreshSucceeded ? "idle" : "error");
 	} catch {
 		const ready = await isViewerReady();
 		if (!ready) {
@@ -795,6 +802,8 @@ initState();
 // Toast host — mount first so early notices (from tab init etc.) land.
 const toastRoot = document.getElementById("toastRoot");
 if (toastRoot) mountToastHost(toastRoot);
+const diagnosticsDrawerRoot = document.getElementById("diagnosticsDrawerMount");
+if (diagnosticsDrawerRoot) mountDiagnosticsDrawer(diagnosticsDrawerRoot);
 const legacyTeamSetupRoot = document.getElementById("legacyTeamSetupMount");
 if (legacyTeamSetupRoot) {
 	mountLegacyTeamSetupDialog(legacyTeamSetupRoot, {
@@ -824,6 +833,7 @@ initTabs();
 // Tab modules
 initFeedTab();
 initHealthTab();
+initDiagnosticsEntryPoints();
 initProjectsTab(() => refresh(), { onOpenTeamSetup: openLegacyTeamSetup });
 initSyncTab(() => refresh());
 initCoordinatorAdminTab();

--- a/packages/ui/src/components/diagnostics/close-coordination.test.ts
+++ b/packages/ui/src/components/diagnostics/close-coordination.test.ts
@@ -1,0 +1,12 @@
+import { expect, it, vi } from "vitest";
+import { closeDiagnosticsDrawer } from ".";
+
+it("runs coordinated modal work after the diagnostics close turn", async () => {
+	const afterClose = vi.fn();
+
+	closeDiagnosticsDrawer(afterClose);
+
+	expect(afterClose).not.toHaveBeenCalled();
+	await Promise.resolve();
+	expect(afterClose).toHaveBeenCalledOnce();
+});

--- a/packages/ui/src/components/diagnostics/index.test.tsx
+++ b/packages/ui/src/components/diagnostics/index.test.tsx
@@ -1,0 +1,580 @@
+import { type ComponentChildren, render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DiagnosticEvent, DiagnosticEventsResponse } from "../../lib/api";
+import { DiagnosticEventsRequestError } from "../../lib/api/diagnostics";
+
+const dialogControls = vi.hoisted(() => ({
+	onCloseAutoFocus: undefined as undefined | ((event: { preventDefault: () => void }) => void),
+	onOpenAutoFocus: undefined as undefined | ((event: { preventDefault: () => void }) => void),
+	onOpenChange: undefined as undefined | ((open: boolean) => void),
+}));
+
+vi.mock("../primitives/radix-dialog", () => ({
+	RadixDialog: (props: {
+		children?: ComponentChildren;
+		contentId: string;
+		onCloseAutoFocus?: (event: { preventDefault: () => void }) => void;
+		onOpenAutoFocus?: (event: { preventDefault: () => void }) => void;
+		onOpenChange: (open: boolean) => void;
+		open: boolean;
+	}) => {
+		dialogControls.onCloseAutoFocus = props.onCloseAutoFocus;
+		dialogControls.onOpenAutoFocus = props.onOpenAutoFocus;
+		dialogControls.onOpenChange = props.onOpenChange;
+		return props.open ? (
+			<div id={props.contentId} role="dialog">
+				{props.children}
+			</div>
+		) : null;
+	},
+	RadixDialogTitle: (props: { children?: ComponentChildren; id?: string; tabIndex?: number }) => (
+		<h2 {...props}>{props.children}</h2>
+	),
+}));
+
+import {
+	closeDiagnosticsDrawer,
+	coordinatedRefreshDiagnosticsDrawer,
+	initDiagnosticsEntryPoints,
+	mountDiagnosticsDrawer,
+	openDiagnosticsDrawer,
+} from ".";
+
+function event(id: string, overrides: Partial<DiagnosticEvent> = {}): DiagnosticEvent {
+	return {
+		id,
+		occurred_at: "2026-09-07T12:00:00.000Z",
+		severity: "warning",
+		subsystem: "capture",
+		code: "capture_backlog_growing",
+		message: "The capture queue is growing.",
+		...overrides,
+	};
+}
+
+function response(
+	items: DiagnosticEvent[] = [],
+	nextCursor: string | null = null,
+): DiagnosticEventsResponse {
+	return {
+		contract_version: 1,
+		items,
+		next_cursor: nextCursor,
+		redacted: true,
+		generated_at: "2026-09-07T12:00:01.000Z",
+	};
+}
+
+function setup(loadEvents = vi.fn().mockResolvedValue(response())) {
+	document.body.innerHTML = `
+		<button aria-current="page" class="tab-btn" id="tabBtn-health">Health</button>
+		<button class="tab-btn" id="tabBtn-advanced">Advanced</button>
+		<button id="healthOpenDiagnostics">View diagnostics</button>
+		<button id="syncOpenDiagnostics">Recent sync events</button>
+		<div id="diagnosticsDrawerMount"></div>
+	`;
+	const mount = document.getElementById("diagnosticsDrawerMount");
+	if (!(mount instanceof HTMLElement)) throw new Error("diagnostics mount missing");
+	act(() => mountDiagnosticsDrawer(mount, { loadEvents }));
+	return { loadEvents, mount };
+}
+
+function button(label: string): HTMLButtonElement {
+	const match = [...document.querySelectorAll<HTMLButtonElement>("button")].find(
+		(candidate) => candidate.textContent === label,
+	);
+	if (!match) throw new Error(`button missing: ${label}`);
+	return match;
+}
+
+afterEach(() => {
+	const mount = document.getElementById("diagnosticsDrawerMount");
+	if (mount) act(() => render(null, mount));
+	document.body.innerHTML = "";
+	dialogControls.onCloseAutoFocus = undefined;
+	dialogControls.onOpenAutoFocus = undefined;
+	dialogControls.onOpenChange = undefined;
+	vi.restoreAllMocks();
+});
+
+describe("diagnostics drawer", () => {
+	it("opens from Health unfiltered and Advanced filtered to sync", async () => {
+		const { loadEvents } = setup();
+		initDiagnosticsEntryPoints();
+
+		act(() => button("View diagnostics").click());
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(1));
+		expect(loadEvents).toHaveBeenLastCalledWith(expect.objectContaining({ subsystem: undefined }));
+		act(() => button("Close").click());
+
+		act(() => button("Recent sync events").click());
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(2));
+		expect(loadEvents).toHaveBeenLastCalledWith(expect.objectContaining({ subsystem: ["sync"] }));
+		expect(
+			document.querySelector<HTMLSelectElement>('[aria-label="Diagnostic subsystem"]')?.value,
+		).toBe("sync");
+		expect(document.body.textContent).toContain("Showing sync events");
+
+		await vi.waitFor(() =>
+			expect(document.body.textContent).toContain("No events match the recent retained window"),
+		);
+		expect(button("Reset filters")).toBeInstanceOf(HTMLButtonElement);
+		act(() => button("Reset filters").click());
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(3));
+		expect(loadEvents).toHaveBeenLastCalledWith(expect.objectContaining({ subsystem: undefined }));
+	});
+
+	it("focuses the title, aborts on close, and restores trigger focus", async () => {
+		let requestSignal: AbortSignal | undefined;
+		const loadEvents = vi.fn(
+			(options: { signal?: AbortSignal }) =>
+				new Promise<DiagnosticEventsResponse>(() => {
+					requestSignal = options.signal;
+				}),
+		);
+		setup(loadEvents);
+		const trigger = button("View diagnostics");
+		trigger.focus();
+
+		act(() => openDiagnosticsDrawer({ trigger }));
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(1));
+		act(() => dialogControls.onOpenAutoFocus?.({ preventDefault: vi.fn() }));
+		expect(document.activeElement?.id).toBe("diagnosticsDrawerTitle");
+
+		act(() => button("Close").click());
+		expect(requestSignal?.aborted).toBe(true);
+		act(() => dialogControls.onCloseAutoFocus?.({ preventDefault: vi.fn() }));
+		expect(document.activeElement).toBe(trigger);
+		expect(document.getElementById("diagnosticsDrawer")).toBeNull();
+	});
+
+	it("restores focus to Health when the invoking control no longer exists", async () => {
+		setup();
+		const transientTrigger = document.createElement("button");
+		document.body.appendChild(transientTrigger);
+		act(() => openDiagnosticsDrawer({ trigger: transientTrigger }));
+		await vi.waitFor(() => expect(document.getElementById("diagnosticsDrawer")).not.toBeNull());
+		transientTrigger.remove();
+
+		act(() => button("Close").click());
+		act(() => dialogControls.onCloseAutoFocus?.({ preventDefault: vi.fn() }));
+
+		expect(document.activeElement?.id).toBe("tabBtn-health");
+	});
+});
+
+describe("diagnostics drawer fallback focus and dismiss", () => {
+	it("falls back to the current Advanced tab when the trigger becomes hidden", async () => {
+		setup();
+		document.getElementById("tabBtn-health")?.removeAttribute("aria-current");
+		document.getElementById("tabBtn-advanced")?.setAttribute("aria-current", "page");
+		const hiddenParent = document.createElement("div");
+		const trigger = document.createElement("button");
+		hiddenParent.appendChild(trigger);
+		document.body.appendChild(hiddenParent);
+		act(() => openDiagnosticsDrawer({ trigger }));
+		await vi.waitFor(() => expect(document.getElementById("diagnosticsDrawer")).not.toBeNull());
+		hiddenParent.hidden = true;
+
+		act(() => button("Close").click());
+		act(() => dialogControls.onCloseAutoFocus?.({ preventDefault: vi.fn() }));
+
+		expect(document.activeElement?.id).toBe("tabBtn-advanced");
+	});
+
+	it("closes through the Radix open-change callback", async () => {
+		let requestSignal: AbortSignal | undefined;
+		const loadEvents = vi.fn(
+			(options: { signal?: AbortSignal }) =>
+				new Promise<DiagnosticEventsResponse>(() => {
+					requestSignal = options.signal;
+				}),
+		);
+		setup(loadEvents);
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.getElementById("diagnosticsDrawer")).not.toBeNull());
+
+		act(() => dialogControls.onOpenChange?.(false));
+
+		expect(requestSignal?.aborted).toBe(true);
+		expect(document.getElementById("diagnosticsDrawer")).toBeNull();
+	});
+});
+
+describe("diagnostics drawer automatic refresh", () => {
+	it("pauses coordinated refresh and fetches immediately on resume", async () => {
+		const { loadEvents } = setup(vi.fn().mockResolvedValue(response([event("one")])));
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(1));
+
+		act(() => button("Pause updates").click());
+		await coordinatedRefreshDiagnosticsDrawer();
+		expect(loadEvents).toHaveBeenCalledTimes(1);
+		expect(document.body.textContent).toContain("Updates are paused");
+
+		act(() => button("Resume updates").click());
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(2));
+	});
+
+	it("preserves loaded history and its cursor when resuming updates", async () => {
+		const loadEvents = vi
+			.fn()
+			.mockResolvedValueOnce(response([event("newest")], "older-one"))
+			.mockResolvedValueOnce(response([event("older")], "older-two"))
+			.mockResolvedValueOnce(response([event("new-after-resume"), event("newest")]))
+			.mockResolvedValueOnce(response([]));
+		setup(loadEvents);
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(button("Load older").disabled).toBe(false));
+		act(() => button("Load older").click());
+		await vi.waitFor(() => expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(2));
+
+		act(() => button("Pause updates").click());
+		act(() => button("Resume updates").click());
+
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(3));
+		expect(loadEvents.mock.calls[2]?.[0].cursor).toBeUndefined();
+		await vi.waitFor(() => expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(3));
+		expect(button("Load older").disabled).toBe(false);
+		act(() => button("Load older").click());
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(4));
+		expect(loadEvents.mock.calls[3]?.[0]).toEqual(expect.objectContaining({ cursor: "older-two" }));
+	});
+
+	it("does not run coordinated refresh while the page is hidden", async () => {
+		const { loadEvents } = setup(vi.fn().mockResolvedValue(response([event("one")])));
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(1));
+		vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+
+		await coordinatedRefreshDiagnosticsDrawer();
+
+		expect(loadEvents).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("diagnostics drawer paused actions", () => {
+	it("allows retry and filter requests while paused", async () => {
+		const loadEvents = vi
+			.fn()
+			.mockResolvedValueOnce(response([event("one")]))
+			.mockRejectedValueOnce(new Error("refresh failed"))
+			.mockResolvedValue(response([event("two")]));
+		setup(loadEvents);
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(1));
+		await act(async () => coordinatedRefreshDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).not.toBeNull());
+		act(() => button("Pause updates").click());
+
+		act(() => button("Retry").click());
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(3));
+		const severity = document.querySelector<HTMLSelectElement>(
+			'[aria-label="Diagnostic severity"]',
+		);
+		if (!severity) throw new Error("severity filter missing");
+		severity.value = "error";
+		act(() => {
+			severity.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(4));
+		expect(loadEvents).toHaveBeenLastCalledWith(expect.objectContaining({ severity: ["error"] }));
+	});
+
+	it("clears loading when pausing an in-flight initial request", async () => {
+		let requestSignal: AbortSignal | undefined;
+		const loadEvents = vi.fn(
+			(options: { signal?: AbortSignal }) =>
+				new Promise<DiagnosticEventsResponse>(() => {
+					requestSignal = options.signal;
+				}),
+		);
+		setup(loadEvents);
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.querySelector(".diagnostics-loading")).not.toBeNull());
+
+		act(() => button("Pause updates").click());
+
+		expect(requestSignal?.aborted).toBe(true);
+		expect(document.querySelector(".diagnostics-loading")).toBeNull();
+		expect(document.body.textContent).toContain("Updates are paused");
+	});
+});
+
+describe("diagnostics drawer updates and pagination", () => {
+	it("replaces mutable fields for a known event id during polling", async () => {
+		const refreshedEvent = event("one", {
+			severity: "error",
+			message: "The capture queue is blocked.",
+		});
+		const loadEvents = vi
+			.fn()
+			.mockResolvedValueOnce(response([event("one")], "older"))
+			.mockResolvedValueOnce(response([refreshedEvent]));
+		setup(loadEvents);
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.body.textContent).toContain("queue is growing"));
+
+		await act(async () => coordinatedRefreshDiagnosticsDrawer());
+
+		expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(1);
+		expect(document.body.textContent).toContain("queue is blocked");
+		expect(document.body.textContent).not.toContain("queue is growing");
+	});
+
+	it("queues polled events while reading older rows and shows them on request", async () => {
+		const loadEvents = vi
+			.fn()
+			.mockResolvedValueOnce(response([event("one")], "older"))
+			.mockResolvedValueOnce(response([event("two"), event("one")]));
+		setup(loadEvents);
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.body.textContent).toContain("capture_backlog_growing"));
+		const list = document.querySelector<HTMLElement>(".diagnostics-event-list");
+		if (!list) throw new Error("event list missing");
+		list.scrollTop = 100;
+
+		await act(async () => coordinatedRefreshDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Show 1 new event"));
+		expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(1);
+
+		act(() => button("Show 1 new event").click());
+		expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(2);
+	});
+
+	it("loads and reconciles technical details for queued server events", async () => {
+		const known = event("known");
+		const queued = event("queued");
+		const loadEvents = vi
+			.fn()
+			.mockResolvedValueOnce(response([known], "older"))
+			.mockResolvedValueOnce(response([queued, known], "older"))
+			.mockResolvedValueOnce(
+				response(
+					[{ ...known, technical_detail: { available: true, text: "known detail" } }],
+					"technical-next",
+				),
+			)
+			.mockResolvedValueOnce(
+				response([{ ...queued, technical_detail: { available: true, text: "queued detail" } }]),
+			);
+		setup(loadEvents);
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(1));
+		const list = document.querySelector<HTMLElement>(".diagnostics-event-list");
+		if (!list) throw new Error("event list missing");
+		list.scrollTop = 100;
+		await act(async () => coordinatedRefreshDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Show 1 new event"));
+
+		act(() => button("Reveal technical details").click());
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(4));
+		expect(loadEvents.mock.calls[3]?.[0]).toEqual(
+			expect.objectContaining({ cursor: "technical-next", includeTechnical: true }),
+		);
+		act(() => button("Show 1 new event").click());
+
+		expect(document.body.textContent).toContain("queued detail");
+	});
+
+	it("removes queued events when a top-of-list poll promotes them", async () => {
+		const loadEvents = vi
+			.fn()
+			.mockResolvedValueOnce(response([event("one")], "older"))
+			.mockResolvedValue(response([event("two"), event("one")]));
+		setup(loadEvents);
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(1));
+		const list = document.querySelector<HTMLElement>(".diagnostics-event-list");
+		if (!list) throw new Error("event list missing");
+		list.scrollTop = 100;
+		await act(async () => coordinatedRefreshDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Show 1 new event"));
+
+		list.scrollTop = 0;
+		await act(async () => coordinatedRefreshDiagnosticsDrawer());
+
+		expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(2);
+		expect(document.body.textContent).not.toContain("Show 1 new event");
+	});
+
+	it("keeps stale rows on failure and retries without exposing exception text", async () => {
+		const loadEvents = vi
+			.fn()
+			.mockResolvedValueOnce(response([event("one")]))
+			.mockRejectedValueOnce(new Error("private database path"))
+			.mockResolvedValueOnce(response([event("two")]));
+		setup(loadEvents);
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(1));
+
+		await act(async () => coordinatedRefreshDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).not.toBeNull());
+		expect(document.body.textContent).toContain("Showing stale events");
+		expect(document.body.textContent).not.toContain("private database path");
+		expect(document.querySelector('[aria-live="polite"]')?.textContent).toBe("");
+
+		act(() => button("Retry").click());
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(3));
+		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).toBeNull());
+	});
+
+	it("reloads the first page when an older-page cursor is rejected", async () => {
+		const loadEvents = vi
+			.fn()
+			.mockResolvedValueOnce(response([event("one")], "stale-cursor"))
+			.mockRejectedValueOnce(new DiagnosticEventsRequestError(400, "Bad Request"))
+			.mockResolvedValueOnce(
+				response([event("two", { message: "Fresh diagnostics page." })], "fresh-cursor"),
+			);
+		setup(loadEvents);
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(button("Load older").disabled).toBe(false));
+
+		act(() => button("Load older").click());
+
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(3));
+		expect(loadEvents.mock.calls[1]?.[0]).toEqual(
+			expect.objectContaining({ cursor: "stale-cursor" }),
+		);
+		expect(loadEvents.mock.calls[2]?.[0].cursor).toBeUndefined();
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Fresh diagnostics page."));
+		expect(document.querySelector('[role="alert"]')).toBeNull();
+	});
+});
+
+describe("diagnostics drawer retry history", () => {
+	it("polls on retry so stale older history remains visible", async () => {
+		const loadEvents = vi
+			.fn()
+			.mockResolvedValueOnce(
+				response([
+					event("newest", { message: "Newest retained event." }),
+					event("older", {
+						occurred_at: "2026-09-07T11:00:00.000Z",
+						message: "Older retained event.",
+					}),
+				]),
+			)
+			.mockRejectedValueOnce(new Error("refresh failed"))
+			.mockResolvedValueOnce(response([event("recovered", { message: "Recovered event." })]));
+		setup(loadEvents);
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(2));
+		await act(async () => coordinatedRefreshDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).not.toBeNull());
+
+		act(() => button("Retry").click());
+
+		await vi.waitFor(() => expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(3));
+		expect(document.body.textContent).toContain("Newest retained event.");
+		expect(document.body.textContent).toContain("Older retained event.");
+		expect(document.body.textContent).toContain("Recovered event.");
+	});
+});
+
+describe("diagnostics drawer filters and pagination", () => {
+	it("refetches for filters and technical reveal, then bounds older pagination", async () => {
+		const firstPage = Array.from({ length: 50 }, (_, index) => event(`first-${index}`));
+		const olderPage = Array.from({ length: 250 }, (_, index) => event(`older-${index}`));
+		const loadEvents = vi
+			.fn()
+			.mockResolvedValueOnce(response(firstPage, "cursor-one"))
+			.mockResolvedValueOnce(response([event("error", { severity: "error" })], "cursor-filter"))
+			.mockResolvedValueOnce(
+				response(
+					[
+						event("error", {
+							severity: "error",
+							technical_detail: { available: true, text: "bounded detail" },
+						}),
+					],
+					null,
+				),
+			)
+			.mockResolvedValueOnce(response(olderPage, "cursor-two"));
+		setup(loadEvents);
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(1));
+
+		const severity = document.querySelector<HTMLSelectElement>(
+			'[aria-label="Diagnostic severity"]',
+		);
+		if (!severity) throw new Error("severity filter missing");
+		severity.value = "error";
+		act(() => {
+			severity.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(2));
+		expect(loadEvents).toHaveBeenLastCalledWith(expect.objectContaining({ severity: ["error"] }));
+
+		await vi.waitFor(() => expect(button("Reveal technical details").disabled).toBe(false));
+		act(() => button("Reveal technical details").click());
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(3));
+		expect(loadEvents).toHaveBeenLastCalledWith(
+			expect.objectContaining({ includeTechnical: true }),
+		);
+		await vi.waitFor(() => expect(document.body.textContent).toContain("bounded detail"));
+
+		act(() => button("Load older").click());
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(4));
+		expect(loadEvents.mock.calls[3]?.[0]).toEqual(
+			expect.objectContaining({ cursor: "cursor-filter", includeTechnical: true }),
+		);
+		await vi.waitFor(() =>
+			expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(200),
+		);
+	});
+});
+
+describe("diagnostics drawer recovery navigation", () => {
+	it("closes and resets before following an allowlisted recovery hash", async () => {
+		window.location.hash = "";
+		const recoveryEvent = event("recovery", {
+			recovery: { href: "#health", label: "Open Health" },
+		});
+		const { loadEvents } = setup(vi.fn().mockResolvedValue(response([recoveryEvent])));
+		act(() => openDiagnosticsDrawer({ subsystem: "sync" }));
+		await vi.waitFor(() => expect(document.querySelector("a.diagnostics-recovery")).not.toBeNull());
+		const recoveryLink = document.querySelector<HTMLAnchorElement>("a.diagnostics-recovery");
+		if (!recoveryLink) throw new Error("recovery link missing");
+
+		act(() => recoveryLink.click());
+
+		expect(document.getElementById("diagnosticsDrawer")).toBeNull();
+		await vi.waitFor(() => expect(window.location.hash).toBe("#health"));
+		await vi.waitFor(() => expect(document.activeElement?.id).toBe("tabBtn-health"));
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(2));
+		expect(loadEvents).toHaveBeenLastCalledWith(
+			expect.objectContaining({ includeTechnical: false, subsystem: undefined }),
+		);
+	});
+
+	it("can be closed externally when reconnecting", async () => {
+		setup();
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.getElementById("diagnosticsDrawer")).not.toBeNull());
+
+		act(() => closeDiagnosticsDrawer());
+
+		expect(document.getElementById("diagnosticsDrawer")).toBeNull();
+	});
+
+	it("does not render anchors for unknown or missing recovery hrefs", async () => {
+		const unknownHref = {
+			...event("unknown"),
+			recovery: { href: "javascript:alert(1)", label: "Unsafe" },
+		} as unknown as DiagnosticEvent;
+		const commandOnly = event("command", {
+			recovery: { command: "codemem status", label: "Inspect status" },
+		});
+		setup(vi.fn().mockResolvedValue(response([unknownHref, commandOnly])));
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(2));
+
+		expect(document.querySelector("a.diagnostics-recovery")).toBeNull();
+		expect(document.body.textContent).toContain("codemem status");
+	});
+});

--- a/packages/ui/src/components/diagnostics/index.tsx
+++ b/packages/ui/src/components/diagnostics/index.tsx
@@ -1,0 +1,67 @@
+import { render } from "preact";
+import { useEffect } from "preact/hooks";
+import { loadDiagnosticEvents } from "../../lib/api/diagnostics";
+import {
+	type DiagnosticsDrawerDependencies,
+	type OpenDiagnosticsDrawerOptions,
+	useDiagnosticsDrawer,
+} from "./use-diagnostics-drawer";
+import { DiagnosticsDrawerView } from "./view";
+
+type DrawerCommands = {
+	open: (options?: OpenDiagnosticsDrawerOptions) => void;
+	refresh: () => Promise<void>;
+	close: () => void;
+};
+
+let commands: DrawerCommands | null = null;
+
+function DiagnosticsDrawerHost({ dependencies }: { dependencies: DiagnosticsDrawerDependencies }) {
+	const controller = useDiagnosticsDrawer(dependencies.loadEvents ?? loadDiagnosticEvents);
+	useEffect(() => {
+		const registeredCommands = {
+			open: controller.open,
+			refresh: controller.refresh,
+			close: controller.close,
+		};
+		commands = registeredCommands;
+		return () => {
+			if (commands === registeredCommands) commands = null;
+		};
+	}, [controller.open, controller.refresh, controller.close]);
+	return <DiagnosticsDrawerView controller={controller} />;
+}
+
+export function mountDiagnosticsDrawer(
+	mount: HTMLElement,
+	dependencies: DiagnosticsDrawerDependencies = {},
+): void {
+	render(<DiagnosticsDrawerHost dependencies={dependencies} />, mount);
+}
+
+export function openDiagnosticsDrawer(options: OpenDiagnosticsDrawerOptions = {}): void {
+	commands?.open(options);
+}
+
+export function closeDiagnosticsDrawer(afterClose?: () => void): void {
+	commands?.close();
+	if (afterClose) queueMicrotask(afterClose);
+}
+
+export async function coordinatedRefreshDiagnosticsDrawer(): Promise<void> {
+	await commands?.refresh();
+}
+
+export function initDiagnosticsEntryPoints(): void {
+	document.getElementById("healthOpenDiagnostics")?.addEventListener("click", (event) => {
+		openDiagnosticsDrawer({ trigger: event.currentTarget as HTMLElement });
+	});
+	document.getElementById("syncOpenDiagnostics")?.addEventListener("click", (event) => {
+		openDiagnosticsDrawer({
+			subsystem: "sync",
+			trigger: event.currentTarget as HTMLElement,
+		});
+	});
+}
+
+export type { DiagnosticsDrawerDependencies, OpenDiagnosticsDrawerOptions };

--- a/packages/ui/src/components/diagnostics/poll-catchup.test.ts
+++ b/packages/ui/src/components/diagnostics/poll-catchup.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DiagnosticEvent, DiagnosticEventsResponse } from "../../lib/api/diagnostics";
+import { loadPollCatchup } from "./poll-catchup";
+
+function event(id: string): DiagnosticEvent {
+	return {
+		id,
+		occurred_at: "2026-09-07T12:00:00.000Z",
+		severity: "warning",
+		subsystem: "capture",
+		code: "capture_backlog_growing",
+		message: "The capture queue is growing.",
+	};
+}
+
+function response(ids: string[], nextCursor: string | null): DiagnosticEventsResponse {
+	return {
+		contract_version: 1,
+		items: ids.map(event),
+		next_cursor: nextCursor,
+		redacted: true,
+		generated_at: "2026-09-07T12:00:01.000Z",
+	};
+}
+
+describe("diagnostics poll catch-up", () => {
+	it("fetches bounded pages until reaching the existing contiguous history", async () => {
+		const first = Array.from({ length: 50 }, (_, index) => `new-${100 - index}`);
+		const second = Array.from({ length: 50 }, (_, index) => `new-${50 - index}`);
+		const loadEvents = vi
+			.fn()
+			.mockResolvedValueOnce(response(first, "page-two"))
+			.mockResolvedValueOnce(response(second, "page-three"))
+			.mockResolvedValueOnce(response(["known"], "below-known"));
+
+		const result = await loadPollCatchup({
+			loadEvents,
+			request: { limit: 50 },
+			existingRows: [event("known")],
+			existingNextCursor: "existing-older",
+		});
+
+		expect(loadEvents).toHaveBeenCalledTimes(3);
+		expect(loadEvents.mock.calls[1]?.[0].cursor).toBe("page-two");
+		expect(loadEvents.mock.calls[2]?.[0].cursor).toBe("page-three");
+		expect(result.items).toHaveLength(101);
+		expect(result.next_cursor).toBe("existing-older");
+	});
+
+	it("continues past a mutable known row that moved into the first page", async () => {
+		const movedKnown = {
+			...event("known"),
+			occurred_at: "2026-09-07T12:05:00.000Z",
+		};
+		const first = Array.from({ length: 49 }, (_, index) => `new-first-${index}`);
+		const second = Array.from({ length: 50 }, (_, index) => `new-second-${index}`);
+		const loadEvents = vi
+			.fn()
+			.mockResolvedValueOnce({
+				...response(first, "page-two"),
+				items: [movedKnown, ...first.map(event)],
+			})
+			.mockResolvedValueOnce(response(second, "page-three"))
+			.mockResolvedValueOnce(response(["known"], "below-known"));
+
+		const result = await loadPollCatchup({
+			loadEvents,
+			request: { limit: 50 },
+			existingRows: [event("known")],
+			existingNextCursor: "existing-older",
+		});
+
+		expect(loadEvents).toHaveBeenCalledTimes(3);
+		expect(loadEvents.mock.calls[1]?.[0].cursor).toBe("page-two");
+		expect(loadEvents.mock.calls[2]?.[0].cursor).toBe("page-three");
+		expect(result.items.find((item) => item.id === "known")?.occurred_at).toBe(
+			movedKnown.occurred_at,
+		);
+		expect(result.next_cursor).toBe("existing-older");
+	});
+
+	it("returns a gap cursor when a burst fills the client cap before overlap", async () => {
+		const loadEvents = vi.fn();
+		for (let page = 0; page < 4; page += 1) {
+			const ids = Array.from({ length: 50 }, (_, index) => `new-${page}-${index}`);
+			loadEvents.mockResolvedValueOnce(response(ids, `page-${page + 2}`));
+		}
+
+		const result = await loadPollCatchup({
+			loadEvents,
+			request: { limit: 50 },
+			existingRows: [event("known")],
+			existingNextCursor: "existing-older",
+		});
+
+		expect(loadEvents).toHaveBeenCalledTimes(4);
+		expect(result.items).toHaveLength(200);
+		expect(result.next_cursor).toBe("page-5");
+	});
+
+	it("keeps the catch-up cursor when merging would trim cached rows", async () => {
+		const newRows = Array.from({ length: 50 }, (_, index) => `new-${index}`);
+		const knownRows = Array.from({ length: 50 }, (_, index) => `known-${index}`);
+		const loadEvents = vi.fn().mockResolvedValue(response([...newRows, ...knownRows], "gap"));
+		const existingRows = Array.from({ length: 200 }, (_, index) => event(`known-${index}`));
+
+		const result = await loadPollCatchup({
+			loadEvents,
+			request: { limit: 100 },
+			existingRows,
+			existingNextCursor: "below-cache",
+		});
+
+		expect(result.next_cursor).toBe("gap");
+	});
+});

--- a/packages/ui/src/components/diagnostics/poll-catchup.ts
+++ b/packages/ui/src/components/diagnostics/poll-catchup.ts
@@ -1,0 +1,54 @@
+import type {
+	DiagnosticEvent,
+	DiagnosticEventsResponse,
+	LoadDiagnosticEventsOptions,
+	loadDiagnosticEvents,
+} from "../../lib/api/diagnostics";
+import { MAX_ROWS, mergeUnique, PAGE_SIZE } from "./state";
+
+type EventLoader = typeof loadDiagnosticEvents;
+const MAX_POLL_PAGES = Math.ceil(MAX_ROWS / PAGE_SIZE);
+
+type PollCatchupOptions = {
+	loadEvents: EventLoader;
+	request: LoadDiagnosticEventsOptions;
+	existingRows: DiagnosticEvent[];
+	existingNextCursor: string | null;
+};
+
+export async function loadPollCatchup(
+	options: PollCatchupOptions,
+): Promise<DiagnosticEventsResponse> {
+	const knownOrderingTimestamps = new Map(
+		options.existingRows.map((event) => [event.id, event.occurred_at]),
+	);
+	let request = options.request;
+	let combined: DiagnosticEventsResponse | null = null;
+	let pageCount = 0;
+
+	while (true) {
+		const response = await options.loadEvents(request);
+		pageCount += 1;
+		const items = mergeUnique([...(combined?.items ?? []), ...response.items]);
+		combined = { ...response, items };
+		const reachedKnownRow = response.items.some(
+			(event) => knownOrderingTimestamps.get(event.id) === event.occurred_at,
+		);
+		if (knownOrderingTimestamps.size === 0 || reachedKnownRow) {
+			const mergedRows = mergeUnique([...items, ...options.existingRows], MAX_ROWS + 1);
+			const preservesExistingCursor = reachedKnownRow && mergedRows.length <= MAX_ROWS;
+			return {
+				...combined,
+				next_cursor: preservesExistingCursor ? options.existingNextCursor : response.next_cursor,
+			};
+		}
+		if (!response.next_cursor || items.length >= MAX_ROWS || pageCount >= MAX_POLL_PAGES) {
+			return combined;
+		}
+		request = {
+			...options.request,
+			cursor: response.next_cursor,
+			limit: Math.min(PAGE_SIZE, MAX_ROWS - items.length),
+		};
+	}
+}

--- a/packages/ui/src/components/diagnostics/state.test.ts
+++ b/packages/ui/src/components/diagnostics/state.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from "vitest";
+import type { DiagnosticEvent } from "../../lib/api/diagnostics";
+import { diagnosticsDrawerReducer, initialDiagnosticsDrawerState } from "./state";
+
+function event(id: string, occurredAt = "2026-09-07T12:00:00.000Z"): DiagnosticEvent {
+	return {
+		id,
+		occurred_at: occurredAt,
+		severity: "warning",
+		subsystem: "capture",
+		code: "capture_backlog_growing",
+		message: "The capture queue is growing.",
+	};
+}
+
+describe("diagnostics drawer request failures", () => {
+	it("preserves history and pagination after an ordinary older-page failure", () => {
+		const state = {
+			...initialDiagnosticsDrawerState(),
+			open: true,
+			rows: [event("one")],
+			nextCursor: "older",
+			queryRevision: 3,
+		};
+
+		const failed = diagnosticsDrawerReducer(state, {
+			type: "request_failed",
+			mode: "older",
+			restartQuery: false,
+		});
+
+		expect(failed.rows).toEqual(state.rows);
+		expect(failed.nextCursor).toBe("older");
+		expect(failed.queryRevision).toBe(3);
+		expect(failed.error).toBe(true);
+	});
+
+	it("restarts pagination after an invalid older-page cursor", () => {
+		const state = {
+			...initialDiagnosticsDrawerState(),
+			open: true,
+			rows: [event("one")],
+			nextCursor: "stale",
+			queryRevision: 3,
+		};
+
+		const failed = diagnosticsDrawerReducer(state, {
+			type: "request_failed",
+			mode: "older",
+			restartQuery: true,
+		});
+
+		expect(failed.nextCursor).toBeNull();
+		expect(failed.queryRevision).toBe(4);
+	});
+});
+
+describe("diagnostics drawer queued catch-up", () => {
+	it("discards an obsolete queue when a top poll replaces the bounded newest window", () => {
+		const latest = Array.from({ length: 200 }, (_, index) => event(`latest-${index}`));
+		const polled = diagnosticsDrawerReducer(
+			{
+				...initialDiagnosticsDrawerState(),
+				open: true,
+				rows: [event("previous")],
+				queuedRows: [event("stale-queued")],
+			},
+			{
+				type: "request_succeeded",
+				mode: "poll",
+				response: {
+					items: latest,
+					contract_version: 1,
+					redacted: true,
+					next_cursor: "latest-cursor",
+					generated_at: "2026-09-07T12:01:00.000Z",
+				},
+				readingOlder: false,
+			},
+		);
+
+		const shown = diagnosticsDrawerReducer(polled, { type: "show_queued" });
+
+		expect(shown.rows.map((row) => row.id)).toEqual(latest.map((row) => row.id));
+		expect(shown.queuedRows).toEqual([]);
+	});
+
+	it("preserves the loaded-history cursor when showing queued rows does not trim", () => {
+		const state = {
+			...initialDiagnosticsDrawerState(),
+			open: true,
+			rows: [event("known")],
+			queuedRows: [event("new")],
+			queuedNextCursor: "continue-gap",
+			nextCursor: "below-known",
+		};
+
+		const shown = diagnosticsDrawerReducer(state, { type: "show_queued" });
+
+		expect(shown.rows.map((row) => row.id)).toEqual(["new", "known"]);
+		expect(shown.nextCursor).toBe("below-known");
+		expect(shown.queuedNextCursor).toBeUndefined();
+	});
+
+	it("adopts the bounded catch-up cursor when showing queued rows trims history", () => {
+		const state = {
+			...initialDiagnosticsDrawerState(),
+			open: true,
+			rows: Array.from({ length: 200 }, (_, index) => event(`known-${index}`)),
+			queuedRows: [event("new")],
+			queuedNextCursor: "continue-gap",
+			nextCursor: "below-known",
+		};
+
+		const shown = diagnosticsDrawerReducer(state, { type: "show_queued" });
+
+		expect(shown.rows).toHaveLength(200);
+		expect(shown.rows[0]?.id).toBe("new");
+		expect(shown.nextCursor).toBe("continue-gap");
+	});
+
+	it("preserves an older response cursor when queued rows are shown", () => {
+		const initial = {
+			...initialDiagnosticsDrawerState(),
+			open: true,
+			rows: [event("known")],
+			nextCursor: "below-known",
+		};
+		const polled = diagnosticsDrawerReducer(initial, {
+			type: "request_succeeded",
+			mode: "poll",
+			response: {
+				items: [event("new")],
+				contract_version: 1,
+				redacted: true,
+				next_cursor: "continue-gap",
+				generated_at: "2026-09-07T12:01:00.000Z",
+			},
+			readingOlder: true,
+		});
+		const loadedOlder = diagnosticsDrawerReducer(polled, {
+			type: "request_succeeded",
+			mode: "older",
+			response: {
+				items: [event("older")],
+				contract_version: 1,
+				redacted: true,
+				next_cursor: "after-older",
+				generated_at: "2026-09-07T12:02:00.000Z",
+			},
+			readingOlder: true,
+		});
+		expect(loadedOlder.queuedNextCursor).toBe("continue-gap");
+
+		const shown = diagnosticsDrawerReducer(loadedOlder, { type: "show_queued" });
+
+		expect(shown.rows.map((row) => row.id)).toEqual(["new", "known", "older"]);
+		expect(shown.nextCursor).toBe("after-older");
+		expect(shown.queuedNextCursor).toBeUndefined();
+	});
+
+	it("reconciles technical details into queued rows before they are shown", () => {
+		const queued = event("queued");
+		const detailed = { ...queued, technical_detail: { available: true, text: "detail" } };
+		const state = {
+			...initialDiagnosticsDrawerState(),
+			open: true,
+			queuedRows: [queued],
+		};
+
+		const refreshed = diagnosticsDrawerReducer(state, {
+			type: "request_succeeded",
+			mode: "technical",
+			response: {
+				items: [detailed],
+				contract_version: 1,
+				redacted: false,
+				next_cursor: null,
+				generated_at: "2026-09-07T12:01:00.000Z",
+			},
+			readingOlder: true,
+		});
+
+		expect(refreshed.queuedRows).toEqual([detailed]);
+	});
+});
+
+describe("diagnostics drawer mutable relocation", () => {
+	it("queues a known row whose timestamp moves until queued events are shown", () => {
+		const initial = {
+			...initialDiagnosticsDrawerState(),
+			open: true,
+			rows: [
+				event("newer", "2026-09-07T12:04:00.000Z"),
+				event("mutable", "2026-09-07T12:00:00.000Z"),
+				event("older", "2026-09-07T11:00:00.000Z"),
+			],
+		};
+		const moved: DiagnosticEvent = {
+			...event("mutable", "2026-09-07T12:05:00.000Z"),
+			severity: "error",
+			code: "capture_backlog_blocked",
+			message: "The capture queue is blocked.",
+		};
+
+		const polled = diagnosticsDrawerReducer(initial, {
+			type: "request_succeeded",
+			mode: "poll",
+			response: {
+				items: [moved],
+				contract_version: 1,
+				redacted: true,
+				next_cursor: null,
+				generated_at: "2026-09-07T12:06:00.000Z",
+			},
+			readingOlder: true,
+		});
+
+		expect(polled.rows[1]).toEqual({
+			...moved,
+			occurred_at: initial.rows[1]?.occurred_at,
+		});
+		expect(polled.queuedRows).toEqual([moved]);
+
+		const shown = diagnosticsDrawerReducer(polled, { type: "show_queued" });
+
+		expect(shown.rows.map((row) => row.id)).toEqual(["mutable", "newer", "older"]);
+		expect(shown.rows.filter((row) => row.id === "mutable")).toEqual([moved]);
+	});
+
+	it("keeps queued relocation results unique and within the row cap", () => {
+		const rows = Array.from({ length: 200 }, (_, index) => event(`known-${index}`));
+		const moved = event("known-199", "2026-09-07T12:05:00.000Z");
+		const polled = diagnosticsDrawerReducer(
+			{ ...initialDiagnosticsDrawerState(), open: true, rows },
+			{
+				type: "request_succeeded",
+				mode: "poll",
+				response: {
+					items: [event("new"), moved],
+					contract_version: 1,
+					redacted: true,
+					next_cursor: null,
+					generated_at: "2026-09-07T12:06:00.000Z",
+				},
+				readingOlder: true,
+			},
+		);
+
+		const shown = diagnosticsDrawerReducer(polled, { type: "show_queued" });
+
+		expect(shown.rows).toHaveLength(200);
+		expect(new Set(shown.rows.map((row) => row.id)).size).toBe(200);
+		expect(shown.rows.filter((row) => row.id === moved.id)).toEqual([moved]);
+	});
+});
+
+describe("diagnostics drawer technical history", () => {
+	it("merges technical versions into loaded rows without changing history or its cursor", () => {
+		const older = event("older", "2026-09-07T11:00:00.000Z");
+		const state = {
+			...initialDiagnosticsDrawerState(),
+			open: true,
+			includeTechnical: true,
+			rows: [event("newer"), older],
+			nextCursor: "after-loaded-history",
+		};
+		const detailedOlder = { ...older, technical_detail: { available: true, text: "detail" } };
+
+		const refreshed = diagnosticsDrawerReducer(state, {
+			type: "request_succeeded",
+			mode: "technical",
+			response: {
+				items: [event("inserted"), detailedOlder],
+				contract_version: 1,
+				redacted: false,
+				next_cursor: "technical-cursor",
+				generated_at: "2026-09-07T12:01:00.000Z",
+			},
+			readingOlder: true,
+		});
+
+		expect(refreshed.rows).toEqual([state.rows[0], detailedOlder]);
+		expect(refreshed.nextCursor).toBe("after-loaded-history");
+	});
+
+	it("keeps loaded history and permits another reveal after an incomplete refresh", () => {
+		const state = {
+			...initialDiagnosticsDrawerState(),
+			open: true,
+			includeTechnical: true,
+			rows: [event("loaded")],
+			nextCursor: "older",
+		};
+
+		const failed = diagnosticsDrawerReducer(state, {
+			type: "request_failed",
+			mode: "technical",
+			restartQuery: false,
+		});
+
+		expect(failed.rows).toEqual(state.rows);
+		expect(failed.nextCursor).toBe("older");
+		expect(failed.includeTechnical).toBe(false);
+		expect(failed.error).toBe(true);
+	});
+});

--- a/packages/ui/src/components/diagnostics/state.ts
+++ b/packages/ui/src/components/diagnostics/state.ts
@@ -1,0 +1,270 @@
+import type {
+	DiagnosticEvent,
+	DiagnosticEventSeverity,
+	DiagnosticEventSubsystem,
+	DiagnosticEventsResponse,
+} from "../../lib/api/diagnostics";
+
+export const PAGE_SIZE = 50;
+export const MAX_ROWS = 200;
+
+export type RequestMode = "replace" | "poll" | "older" | "technical";
+
+export type DiagnosticsDrawerState = {
+	open: boolean;
+	severity: DiagnosticEventSeverity | "";
+	subsystem: DiagnosticEventSubsystem | "";
+	includeTechnical: boolean;
+	paused: boolean;
+	rows: DiagnosticEvent[];
+	queuedRows: DiagnosticEvent[];
+	queuedNextCursor: string | null | undefined;
+	nextCursor: string | null;
+	generatedAt: string | null;
+	loading: boolean;
+	error: boolean;
+	announcement: string;
+	queryRevision: number;
+	pollRevision: number;
+};
+
+export type DiagnosticsDrawerAction =
+	| {
+			type: "open";
+			severity: DiagnosticEventSeverity | "";
+			subsystem: DiagnosticEventSubsystem | "";
+	  }
+	| { type: "close" }
+	| { type: "set_severity"; severity: DiagnosticEventSeverity | "" }
+	| { type: "set_subsystem"; subsystem: DiagnosticEventSubsystem | "" }
+	| { type: "reset_filters" }
+	| { type: "set_paused"; paused: boolean }
+	| { type: "reveal_technical" }
+	| { type: "request_started"; mode: RequestMode }
+	| {
+			type: "request_succeeded";
+			mode: RequestMode;
+			response: DiagnosticEventsResponse;
+			readingOlder: boolean;
+	  }
+	| { type: "request_failed"; mode: RequestMode; restartQuery: boolean }
+	| { type: "show_queued" };
+
+export function initialDiagnosticsDrawerState(): DiagnosticsDrawerState {
+	return {
+		open: false,
+		severity: "",
+		subsystem: "",
+		includeTechnical: false,
+		paused: false,
+		rows: [],
+		queuedRows: [],
+		queuedNextCursor: undefined,
+		nextCursor: null,
+		generatedAt: null,
+		loading: false,
+		error: false,
+		announcement: "",
+		queryRevision: 0,
+		pollRevision: 0,
+	};
+}
+
+export function mergeUnique(events: DiagnosticEvent[], maximum = MAX_ROWS): DiagnosticEvent[] {
+	const seen = new Set<string>();
+	return events.filter((event) => {
+		if (seen.has(event.id) || seen.size >= maximum) return false;
+		seen.add(event.id);
+		return true;
+	});
+}
+
+function applyRequestFailure(
+	state: DiagnosticsDrawerState,
+	mode: RequestMode,
+	restartQuery: boolean,
+): DiagnosticsDrawerState {
+	const restartPagination = mode === "older" && restartQuery;
+	return {
+		...state,
+		includeTechnical: mode === "technical" ? false : state.includeTechnical,
+		nextCursor: restartPagination ? null : state.nextCursor,
+		loading: false,
+		error: true,
+		announcement: "",
+		queryRevision: restartPagination ? state.queryRevision + 1 : state.queryRevision,
+	};
+}
+
+function replaceQueryState(
+	state: DiagnosticsDrawerState,
+	changes: Partial<Pick<DiagnosticsDrawerState, "severity" | "subsystem">>,
+): DiagnosticsDrawerState {
+	return {
+		...state,
+		...changes,
+		rows: [],
+		queuedRows: [],
+		queuedNextCursor: undefined,
+		nextCursor: null,
+		generatedAt: null,
+		loading: false,
+		error: false,
+		announcement: "",
+		queryRevision: state.queryRevision + 1,
+	};
+}
+
+function reconcilePolledRow(
+	current: DiagnosticEvent,
+	incoming: DiagnosticEvent | undefined,
+	preservePosition: boolean,
+): DiagnosticEvent {
+	if (!incoming) return current;
+	if (!preservePosition) return incoming;
+	return { ...incoming, occurred_at: current.occurred_at };
+}
+
+function applyPollResponse(
+	state: DiagnosticsDrawerState,
+	response: DiagnosticEventsResponse,
+	readingOlder: boolean,
+): DiagnosticsDrawerState {
+	const incomingById = new Map(response.items.map((event) => [event.id, event]));
+	const currentById = new Map(state.rows.map((event) => [event.id, event]));
+	const newRows = response.items.filter((event) => !currentById.has(event.id));
+	if (!state.rows.length) {
+		return {
+			...state,
+			rows: response.items.slice(0, MAX_ROWS),
+			queuedNextCursor: undefined,
+			nextCursor: response.next_cursor,
+		};
+	}
+	if (!readingOlder) {
+		const rows = mergeUnique([...response.items, ...state.rows]);
+		return {
+			...state,
+			rows,
+			queuedRows: [],
+			queuedNextCursor: undefined,
+			nextCursor: response.next_cursor,
+		};
+	}
+	const relocatedRows = response.items.filter((event) => {
+		const current = currentById.get(event.id);
+		return current !== undefined && current.occurred_at !== event.occurred_at;
+	});
+	const queuedUpdates = mergeUnique([...newRows, ...relocatedRows]);
+	const queuedIds = new Set(queuedUpdates.map((event) => event.id));
+	const rows = state.rows.map((event) =>
+		reconcilePolledRow(event, incomingById.get(event.id), queuedIds.has(event.id)),
+	);
+	const queuedRows = mergeUnique([...queuedUpdates, ...state.queuedRows]);
+	return {
+		...state,
+		rows,
+		queuedRows,
+		queuedNextCursor: response.next_cursor,
+		announcement: `${queuedRows.length} new diagnostic events are waiting.`,
+	};
+}
+
+function applyResponse(
+	state: DiagnosticsDrawerState,
+	action: Extract<DiagnosticsDrawerAction, { type: "request_succeeded" }>,
+): DiagnosticsDrawerState {
+	const base = {
+		...state,
+		generatedAt: action.response.generated_at,
+		loading: false,
+		error: false,
+		announcement: "",
+	};
+	if (action.mode === "replace") {
+		return {
+			...base,
+			rows: action.response.items.slice(0, MAX_ROWS),
+			queuedRows: [],
+			queuedNextCursor: undefined,
+			nextCursor: action.response.next_cursor,
+		};
+	}
+	if (action.mode === "older") {
+		return {
+			...base,
+			rows: mergeUnique([...state.rows, ...action.response.items]),
+			queuedNextCursor: state.queuedRows.length ? state.queuedNextCursor : undefined,
+			nextCursor: action.response.next_cursor,
+		};
+	}
+	if (action.mode === "technical") {
+		const incomingById = new Map(action.response.items.map((event) => [event.id, event]));
+		return {
+			...base,
+			rows: state.rows.map((event) => reconcilePolledRow(event, incomingById.get(event.id), true)),
+			queuedRows: state.queuedRows.map((event) =>
+				reconcilePolledRow(event, incomingById.get(event.id), true),
+			),
+			nextCursor: state.nextCursor,
+		};
+	}
+	return applyPollResponse(base, action.response, action.readingOlder);
+}
+
+export function diagnosticsDrawerReducer(
+	state: DiagnosticsDrawerState,
+	action: DiagnosticsDrawerAction,
+): DiagnosticsDrawerState {
+	if (action.type === "open") {
+		return {
+			...initialDiagnosticsDrawerState(),
+			open: true,
+			severity: action.severity,
+			subsystem: action.subsystem,
+			queryRevision: state.queryRevision + 1,
+		};
+	}
+	if (action.type === "close") return initialDiagnosticsDrawerState();
+	if (action.type === "set_severity") {
+		return replaceQueryState(state, { severity: action.severity });
+	}
+	if (action.type === "set_subsystem") {
+		return replaceQueryState(state, { subsystem: action.subsystem });
+	}
+	if (action.type === "reset_filters") {
+		return replaceQueryState(state, { severity: "", subsystem: "" });
+	}
+	if (action.type === "set_paused") {
+		return {
+			...state,
+			loading: action.paused ? false : state.loading,
+			paused: action.paused,
+			pollRevision: action.paused ? state.pollRevision : state.pollRevision + 1,
+		};
+	}
+	if (action.type === "reveal_technical") {
+		return {
+			...state,
+			includeTechnical: true,
+		};
+	}
+	if (action.type === "request_started") {
+		return { ...state, loading: action.mode !== "poll" };
+	}
+	if (action.type === "request_succeeded") return applyResponse(state, action);
+	if (action.type === "request_failed") {
+		return applyRequestFailure(state, action.mode, action.restartQuery);
+	}
+	const mergedRows = mergeUnique([...state.queuedRows, ...state.rows], MAX_ROWS + 1);
+	const rowsWereTrimmed = mergedRows.length > MAX_ROWS;
+	const useQueuedCursor = rowsWereTrimmed && state.queuedNextCursor !== undefined;
+	return {
+		...state,
+		rows: mergedRows.slice(0, MAX_ROWS),
+		queuedRows: [],
+		queuedNextCursor: undefined,
+		nextCursor: useQueuedCursor ? state.queuedNextCursor : state.nextCursor,
+		announcement: "",
+	};
+}

--- a/packages/ui/src/components/diagnostics/technical-history.test.ts
+++ b/packages/ui/src/components/diagnostics/technical-history.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DiagnosticEvent, DiagnosticEventsResponse } from "../../lib/api/diagnostics";
+import { loadTechnicalHistory } from "./technical-history";
+
+function event(id: string, detail?: string): DiagnosticEvent {
+	return {
+		id,
+		occurred_at: "2026-09-07T12:00:00.000Z",
+		severity: "warning",
+		subsystem: "capture",
+		code: "capture_backlog_growing",
+		message: "The capture queue is growing.",
+		...(detail ? { technical_detail: { available: true, text: detail } } : {}),
+	};
+}
+
+function response(items: DiagnosticEvent[], cursor: string | null): DiagnosticEventsResponse {
+	return {
+		contract_version: 1,
+		items,
+		next_cursor: cursor,
+		redacted: false,
+		generated_at: "2026-09-07T12:01:00.000Z",
+	};
+}
+
+describe("technical diagnostic history", () => {
+	it("pages past newly inserted events until every loaded row has a technical version", async () => {
+		const loadEvents = vi
+			.fn()
+			.mockResolvedValueOnce(response([event("new"), event("loaded-new", "new detail")], "next"))
+			.mockResolvedValueOnce(response([event("loaded-old", "old detail")], "unused"));
+
+		const result = await loadTechnicalHistory({
+			loadEvents,
+			request: { includeTechnical: true, limit: 50 },
+			existingRows: [event("loaded-new"), event("loaded-old")],
+		});
+
+		expect(result.items.map((item) => item.id)).toEqual(["new", "loaded-new", "loaded-old"]);
+		expect(loadEvents).toHaveBeenLastCalledWith(
+			expect.objectContaining({ cursor: "next", includeTechnical: true }),
+		);
+	});
+
+	it("rejects an incomplete bounded refresh instead of reporting partial history as current", async () => {
+		const pages = Array.from({ length: 4 }, (_, page) =>
+			response(
+				Array.from({ length: 50 }, (_, index) => event(`new-${page}-${index}`)),
+				`cursor-${page}`,
+			),
+		);
+		const loadEvents = vi.fn();
+		for (const page of pages) loadEvents.mockResolvedValueOnce(page);
+
+		await expect(
+			loadTechnicalHistory({
+				loadEvents,
+				request: { includeTechnical: true, limit: 50 },
+				existingRows: [event("loaded-target")],
+			}),
+		).rejects.toThrow("could not be refreshed completely");
+		expect(loadEvents).toHaveBeenCalledTimes(4);
+	});
+
+	it("fails when retained visible plus queued rows exceed the bounded refresh window", async () => {
+		const retained = Array.from({ length: 201 }, (_, index) => event(`retained-${index}`));
+		const loadEvents = vi.fn();
+		for (let page = 0; page < 4; page += 1) {
+			loadEvents.mockResolvedValueOnce(
+				response(
+					retained.slice(page * 50, page * 50 + 50).map((row) => event(row.id, "detail")),
+					`cursor-${page}`,
+				),
+			);
+		}
+
+		await expect(
+			loadTechnicalHistory({
+				loadEvents,
+				request: { includeTechnical: true, limit: 50 },
+				existingRows: retained,
+			}),
+		).rejects.toThrow("could not be refreshed completely");
+	});
+});

--- a/packages/ui/src/components/diagnostics/technical-history.ts
+++ b/packages/ui/src/components/diagnostics/technical-history.ts
@@ -1,0 +1,41 @@
+import type {
+	DiagnosticEvent,
+	DiagnosticEventsResponse,
+	LoadDiagnosticEventsOptions,
+	loadDiagnosticEvents,
+} from "../../lib/api/diagnostics";
+import { MAX_ROWS, mergeUnique, PAGE_SIZE } from "./state";
+
+type EventLoader = typeof loadDiagnosticEvents;
+
+type TechnicalHistoryOptions = {
+	loadEvents: EventLoader;
+	request: LoadDiagnosticEventsOptions;
+	existingRows: DiagnosticEvent[];
+};
+
+export async function loadTechnicalHistory(
+	options: TechnicalHistoryOptions,
+): Promise<DiagnosticEventsResponse> {
+	const targetIds = new Set(options.existingRows.map((event) => event.id));
+	let request = options.request;
+	let combined: DiagnosticEventsResponse | null = null;
+	let pageCount = 0;
+
+	while (true) {
+		const response = await options.loadEvents(request);
+		pageCount += 1;
+		const items = mergeUnique([...(combined?.items ?? []), ...response.items]);
+		combined = { ...response, items };
+		const loadedIds = new Set(items.map((event) => event.id));
+		if ([...targetIds].every((id) => loadedIds.has(id))) return combined;
+		if (!response.next_cursor || items.length >= MAX_ROWS || pageCount * PAGE_SIZE >= MAX_ROWS) {
+			throw new Error("Technical diagnostic history could not be refreshed completely.");
+		}
+		request = {
+			...options.request,
+			cursor: response.next_cursor,
+			limit: Math.min(PAGE_SIZE, MAX_ROWS - items.length),
+		};
+	}
+}

--- a/packages/ui/src/components/diagnostics/use-diagnostics-drawer.ts
+++ b/packages/ui/src/components/diagnostics/use-diagnostics-drawer.ts
@@ -1,0 +1,311 @@
+import { useEffect, useReducer, useRef } from "preact/hooks";
+import {
+	type DiagnosticEventSeverity,
+	type DiagnosticEventSubsystem,
+	DiagnosticEventsRequestError,
+	type DiagnosticEventsResponse,
+	type DiagnosticRecoveryHref,
+	type LoadDiagnosticEventsOptions,
+	type loadDiagnosticEvents,
+} from "../../lib/api/diagnostics";
+import { loadPollCatchup } from "./poll-catchup";
+import {
+	type DiagnosticsDrawerAction,
+	type DiagnosticsDrawerState,
+	diagnosticsDrawerReducer,
+	initialDiagnosticsDrawerState,
+	MAX_ROWS,
+	mergeUnique,
+	PAGE_SIZE,
+	type RequestMode,
+} from "./state";
+import { loadTechnicalHistory } from "./technical-history";
+
+type EventLoader = typeof loadDiagnosticEvents;
+type RequestReason = "routine" | "retry";
+type RequestRunner = (mode: RequestMode, reason?: RequestReason) => Promise<void>;
+
+export type OpenDiagnosticsDrawerOptions = {
+	severity?: DiagnosticEventSeverity;
+	subsystem?: DiagnosticEventSubsystem;
+	trigger?: HTMLElement | null;
+};
+
+export type DiagnosticsDrawerDependencies = {
+	loadEvents?: EventLoader;
+};
+
+function requestOptions(
+	mode: RequestMode,
+	state: ReturnType<typeof initialDiagnosticsDrawerState>,
+	signal: AbortSignal,
+): LoadDiagnosticEventsOptions {
+	const remaining = MAX_ROWS - state.rows.length;
+	return {
+		limit: mode === "older" ? Math.max(1, Math.min(PAGE_SIZE, remaining)) : PAGE_SIZE,
+		cursor: mode === "older" ? (state.nextCursor ?? undefined) : undefined,
+		severity: state.severity ? [state.severity] : undefined,
+		subsystem: state.subsystem ? [state.subsystem] : undefined,
+		includeTechnical: state.includeTechnical,
+		signal,
+	};
+}
+
+async function loadForMode(
+	loadEvents: EventLoader,
+	mode: RequestMode,
+	state: DiagnosticsDrawerState,
+	signal: AbortSignal,
+): Promise<DiagnosticEventsResponse> {
+	const request = requestOptions(mode, state, signal);
+	if (mode === "technical") {
+		return loadTechnicalHistory({
+			loadEvents,
+			request,
+			// Every retained row must be covered; the bounded loader fails
+			// (re-enabling reveal) rather than silently skipping the oldest rows.
+			existingRows: mergeUnique(
+				[...state.queuedRows, ...state.rows],
+				state.queuedRows.length + state.rows.length,
+			),
+		});
+	}
+	if (mode !== "poll") return loadEvents(request);
+	return loadPollCatchup({
+		loadEvents,
+		request,
+		existingRows: state.rows,
+		existingNextCursor: state.nextCursor,
+	});
+}
+
+function shouldRestartQuery(mode: RequestMode, error: unknown): boolean {
+	return mode === "older" && error instanceof DiagnosticEventsRequestError && error.status === 400;
+}
+
+function isReadingOlder(listRef: { current: HTMLDivElement | null }): boolean {
+	return listRef.current !== null && listRef.current.scrollTop > 24;
+}
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof DOMException && error.name === "AbortError";
+}
+
+const FOCUSABLE_SELECTOR = [
+	"a[href]",
+	"button:not([disabled])",
+	"input:not([disabled])",
+	"select:not([disabled])",
+	"textarea:not([disabled])",
+	'[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+function isUsableFocusTarget(element: HTMLElement | null): element is HTMLElement {
+	if (!element?.isConnected || !element.matches(FOCUSABLE_SELECTOR)) return false;
+	if (element.matches(':disabled, [aria-disabled="true"]')) return false;
+	let current: HTMLElement | null = element;
+	while (current) {
+		if (current.hidden || current.inert || current.hasAttribute("inert")) return false;
+		if (current.getAttribute("aria-hidden") === "true") return false;
+		const style = getComputedStyle(current);
+		if (
+			style.display === "none" ||
+			style.visibility === "hidden" ||
+			style.visibility === "collapse" ||
+			style.opacity === "0"
+		) {
+			return false;
+		}
+		current = current.parentElement;
+	}
+	return true;
+}
+
+function currentTabFocusTarget(): HTMLElement | null {
+	const currentTab = document.querySelector<HTMLElement>('.tab-btn[aria-current="page"]');
+	return isUsableFocusTarget(currentTab) ? currentTab : null;
+}
+
+function recoveryTabFocusTarget(href: DiagnosticRecoveryHref): HTMLElement | null {
+	const tabId = href === "#health" ? "health" : "advanced";
+	return document.getElementById(`tabBtn-${tabId}`);
+}
+
+function restoreDrawerFocus(
+	event: { preventDefault: () => void },
+	openerRef: { current: HTMLElement | null },
+	recoveryNavigationRef: { current: boolean },
+): void {
+	event.preventDefault();
+	if (recoveryNavigationRef.current) {
+		recoveryNavigationRef.current = false;
+		openerRef.current = null;
+		return;
+	}
+	const target = openerRef.current;
+	if (isUsableFocusTarget(target)) target.focus();
+	else currentTabFocusTarget()?.focus();
+	openerRef.current = null;
+}
+
+type DrawerActionContext = {
+	state: DiagnosticsDrawerState;
+	dispatch: (action: DiagnosticsDrawerAction) => void;
+	abortRequest: () => void;
+	runRequest: RequestRunner;
+	openerRef: { current: HTMLElement | null };
+	recoveryNavigationRef: { current: boolean };
+	listRef: { current: HTMLDivElement | null };
+};
+
+function createDrawerActions(context: DrawerActionContext) {
+	const { state, dispatch, abortRequest, runRequest, openerRef, recoveryNavigationRef, listRef } =
+		context;
+	return {
+		open(options: OpenDiagnosticsDrawerOptions = {}) {
+			abortRequest();
+			recoveryNavigationRef.current = false;
+			openerRef.current = options.trigger ?? (document.activeElement as HTMLElement | null);
+			dispatch({
+				type: "open",
+				severity: options.severity ?? "",
+				subsystem: options.subsystem ?? "",
+			});
+		},
+		close() {
+			abortRequest();
+			dispatch({ type: "close" });
+		},
+		navigateToRecovery(href: DiagnosticRecoveryHref) {
+			abortRequest();
+			recoveryNavigationRef.current = true;
+			dispatch({ type: "close" });
+			queueMicrotask(() => {
+				window.location.hash = href;
+				setTimeout(() => recoveryTabFocusTarget(href)?.focus(), 0);
+			});
+		},
+		refresh: () => runRequest("poll"),
+		retry: () => runRequest(state.rows.length > 0 ? "poll" : "replace", "retry"),
+		loadOlder: () => runRequest("older"),
+		setSeverity(severity: DiagnosticEventSeverity | "") {
+			abortRequest();
+			dispatch({ type: "set_severity", severity });
+		},
+		setSubsystem(subsystem: DiagnosticEventSubsystem | "") {
+			abortRequest();
+			dispatch({ type: "set_subsystem", subsystem });
+		},
+		resetFilters() {
+			abortRequest();
+			dispatch({ type: "reset_filters" });
+		},
+		togglePaused() {
+			if (!state.paused) abortRequest();
+			dispatch({ type: "set_paused", paused: !state.paused });
+		},
+		revealTechnical() {
+			abortRequest();
+			dispatch({ type: "reveal_technical" });
+		},
+		showQueued() {
+			dispatch({ type: "show_queued" });
+			if (listRef.current) listRef.current.scrollTop = 0;
+		},
+		restoreFocus(event: { preventDefault: () => void }) {
+			restoreDrawerFocus(event, openerRef, recoveryNavigationRef);
+		},
+	};
+}
+
+function useRequestRefs(state: DiagnosticsDrawerState) {
+	const stateRef = useRef(state);
+	const requestRef = useRef<{
+		controller: AbortController;
+		generation: number;
+	} | null>(null);
+	const generationRef = useRef(0);
+	stateRef.current = state;
+	return { stateRef, requestRef, generationRef };
+}
+
+function useQueryRequests(state: DiagnosticsDrawerState, runRequest: RequestRunner) {
+	const runnerRef = useRef(runRequest);
+	runnerRef.current = runRequest;
+	useEffect(() => {
+		if (!state.open) return;
+		void runnerRef.current("replace");
+	}, [state.open, state.queryRevision]);
+	useEffect(() => {
+		if (!state.open || state.pollRevision === 0) return;
+		void runnerRef.current("poll");
+	}, [state.open, state.pollRevision]);
+	useEffect(() => {
+		if (!state.open || !state.includeTechnical) return;
+		void runnerRef.current("technical");
+	}, [state.includeTechnical, state.open]);
+}
+
+export function useDiagnosticsDrawer(loadEvents: EventLoader) {
+	const [state, dispatch] = useReducer(diagnosticsDrawerReducer, initialDiagnosticsDrawerState());
+	const { stateRef, requestRef, generationRef } = useRequestRefs(state);
+	const openerRef = useRef<HTMLElement | null>(null);
+	const recoveryNavigationRef = useRef(false);
+	const listRef = useRef<HTMLDivElement | null>(null);
+
+	function abortRequest() {
+		generationRef.current += 1;
+		requestRef.current?.controller.abort();
+		requestRef.current = null;
+	}
+
+	function shouldSkipRequest(mode: RequestMode, reason: RequestReason): boolean {
+		const current = stateRef.current;
+		if (!current.open) return true;
+		if (mode !== "poll") return false;
+		if (requestRef.current !== null) return true;
+		if (reason === "retry") return false;
+		return current.paused || document.visibilityState === "hidden";
+	}
+
+	async function runRequest(mode: RequestMode, reason: RequestReason = "routine"): Promise<void> {
+		if (shouldSkipRequest(mode, reason)) return;
+		const controller = new AbortController();
+		requestRef.current?.controller.abort();
+		const generation = ++generationRef.current;
+		requestRef.current = { controller, generation };
+		dispatch({ type: "request_started", mode });
+		try {
+			const current = stateRef.current;
+			const response = await loadForMode(loadEvents, mode, current, controller.signal);
+			if (generation !== generationRef.current) return;
+			dispatch({
+				type: "request_succeeded",
+				mode,
+				response,
+				readingOlder: isReadingOlder(listRef),
+			});
+		} catch (error) {
+			if (generation !== generationRef.current || isAbortError(error)) return;
+			dispatch({
+				type: "request_failed",
+				mode,
+				restartQuery: shouldRestartQuery(mode, error),
+			});
+		} finally {
+			if (generation === generationRef.current) requestRef.current = null;
+		}
+	}
+
+	useQueryRequests(state, runRequest);
+	const actions = createDrawerActions({
+		state,
+		dispatch,
+		abortRequest,
+		runRequest,
+		openerRef,
+		recoveryNavigationRef,
+		listRef,
+	});
+	return { state, listRef, ...actions };
+}

--- a/packages/ui/src/components/diagnostics/view.tsx
+++ b/packages/ui/src/components/diagnostics/view.tsx
@@ -1,0 +1,281 @@
+import {
+	DIAGNOSTIC_SEVERITIES,
+	DIAGNOSTIC_SUBSYSTEMS,
+	type DiagnosticEvent,
+	type DiagnosticEventSeverity,
+	type DiagnosticEventSubsystem,
+	type DiagnosticRecoveryHref,
+	isDiagnosticRecoveryHref,
+} from "../../lib/api/diagnostics";
+import { DialogCloseButton } from "../primitives/dialog-close-button";
+import { RadixDialog, RadixDialogTitle } from "../primitives/radix-dialog";
+import { MAX_ROWS } from "./state";
+import type { useDiagnosticsDrawer } from "./use-diagnostics-drawer";
+
+type DrawerController = ReturnType<typeof useDiagnosticsDrawer>;
+
+function severityPresentation(severity: DiagnosticEventSeverity) {
+	if (severity === "error") return { icon: "×", label: "Error" };
+	if (severity === "warning") return { icon: "!", label: "Warning" };
+	return { icon: "i", label: "Info" };
+}
+
+function DiagnosticsEventRow({
+	event,
+	includeTechnical,
+	onRecoveryNavigation,
+}: {
+	event: DiagnosticEvent;
+	includeTechnical: boolean;
+	onRecoveryNavigation: (href: DiagnosticRecoveryHref) => void;
+}) {
+	const severity = severityPresentation(event.severity);
+	const recoveryHref = event.recovery?.href;
+	return (
+		<li className={`diagnostics-event diagnostics-event--${event.severity}`}>
+			<div className="diagnostics-event-heading">
+				<span className="diagnostics-severity">
+					<span aria-hidden="true" className="diagnostics-severity-icon">
+						{severity.icon}
+					</span>
+					{severity.label}
+				</span>
+				<time dateTime={event.occurred_at}>{new Date(event.occurred_at).toLocaleString()}</time>
+			</div>
+			<div className="diagnostics-event-context">
+				<span>{event.subsystem}</span>
+				<code>{event.code}</code>
+			</div>
+			<p>{event.message}</p>
+			{event.correlation ? (
+				<div className="diagnostics-event-meta">
+					{event.correlation.kind}: {event.correlation.label}
+				</div>
+			) : null}
+			{includeTechnical && event.technical_detail?.text ? (
+				<details className="diagnostics-technical-detail">
+					<summary>Technical detail</summary>
+					<pre>{event.technical_detail.text}</pre>
+				</details>
+			) : null}
+			{isDiagnosticRecoveryHref(recoveryHref) ? (
+				<a
+					className="diagnostics-recovery"
+					href={recoveryHref}
+					onClick={(event) => {
+						event.preventDefault();
+						onRecoveryNavigation(recoveryHref);
+					}}
+				>
+					{event.recovery?.label}
+				</a>
+			) : null}
+			{event.recovery?.command ? (
+				<div className="diagnostics-recovery-command">
+					<span>{event.recovery.label}</span>
+					<code>{event.recovery.command}</code>
+				</div>
+			) : null}
+		</li>
+	);
+}
+
+function LoadingRows() {
+	return (
+		<div
+			aria-busy="true"
+			aria-label="Loading diagnostics"
+			className="diagnostics-loading"
+			role="status"
+		>
+			{["first", "second", "third"].map((row) => (
+				<div className="diagnostics-loading-row" key={row}>
+					<span />
+					<span />
+					<span />
+				</div>
+			))}
+		</div>
+	);
+}
+
+function DrawerControls({ controller }: { controller: DrawerController }) {
+	const { state } = controller;
+	return (
+		<>
+			<div className="diagnostics-controls">
+				<label>
+					<span>Severity</span>
+					<select
+						aria-label="Diagnostic severity"
+						onChange={(event) =>
+							controller.setSeverity(event.currentTarget.value as DiagnosticEventSeverity | "")
+						}
+						value={state.severity}
+					>
+						<option value="">All severities</option>
+						{DIAGNOSTIC_SEVERITIES.map((value) => (
+							<option key={value} value={value}>
+								{severityPresentation(value).label}
+							</option>
+						))}
+					</select>
+				</label>
+				<label>
+					<span>Subsystem</span>
+					<select
+						aria-label="Diagnostic subsystem"
+						onChange={(event) =>
+							controller.setSubsystem(event.currentTarget.value as DiagnosticEventSubsystem | "")
+						}
+						value={state.subsystem}
+					>
+						<option value="">All subsystems</option>
+						{DIAGNOSTIC_SUBSYSTEMS.map((value) => (
+							<option key={value} value={value}>
+								{value}
+							</option>
+						))}
+					</select>
+				</label>
+				<button className="settings-button" onClick={controller.togglePaused} type="button">
+					{state.paused ? "Resume updates" : "Pause updates"}
+				</button>
+			</div>
+			<div className="diagnostics-secondary-controls">
+				<button
+					className="settings-button"
+					disabled={state.includeTechnical || state.loading}
+					onClick={controller.revealTechnical}
+					type="button"
+				>
+					{state.includeTechnical ? "Technical details shown" : "Reveal technical details"}
+				</button>
+				<span className="diagnostics-generated-at">
+					{state.generatedAt
+						? `Generated ${new Date(state.generatedAt).toLocaleTimeString()}`
+						: "Not loaded yet"}
+				</span>
+			</div>
+		</>
+	);
+}
+
+function DrawerNotices({ controller }: { controller: DrawerController }) {
+	const { state } = controller;
+	const staleLabel = state.error && state.rows.length ? "Showing stale events." : "";
+	return (
+		<>
+			<div aria-atomic="true" aria-live="polite" className="sr-only">
+				{state.announcement}
+			</div>
+			{state.subsystem || state.severity ? (
+				<div className="diagnostics-filter-context">
+					Showing{" "}
+					{state.severity ? `${severityPresentation(state.severity).label.toLowerCase()} ` : ""}
+					{state.subsystem ? `${state.subsystem} ` : ""}events from the recent retained window.
+				</div>
+			) : null}
+			{state.paused ? (
+				<div className="diagnostics-notice" role="status">
+					Updates are paused. Resume when you are ready to fetch newer events.
+				</div>
+			) : null}
+			{state.error ? (
+				<div className="diagnostics-notice diagnostics-notice--error" role="alert">
+					<span>Diagnostics could not be refreshed. {staleLabel}</span>
+					<button className="settings-button" onClick={() => void controller.retry()} type="button">
+						Retry
+					</button>
+				</div>
+			) : null}
+			{state.queuedRows.length ? (
+				<button className="diagnostics-new-events" onClick={controller.showQueued} type="button">
+					Show {state.queuedRows.length} new {state.queuedRows.length === 1 ? "event" : "events"}
+				</button>
+			) : null}
+		</>
+	);
+}
+
+function DrawerEventList({ controller }: { controller: DrawerController }) {
+	const { state } = controller;
+	const hasFilters = Boolean(state.severity || state.subsystem);
+	const canLoadOlder = Boolean(state.nextCursor) && state.rows.length < MAX_ROWS && !state.loading;
+	return (
+		<div className="diagnostics-event-list" ref={controller.listRef}>
+			{state.loading && !state.rows.length ? <LoadingRows /> : null}
+			{!state.loading && !state.error && !state.rows.length ? (
+				<div className="diagnostics-empty">
+					<p>No events match the recent retained window.</p>
+					{hasFilters ? (
+						<button className="settings-button" onClick={controller.resetFilters} type="button">
+							Reset filters
+						</button>
+					) : null}
+				</div>
+			) : null}
+			{state.rows.length ? (
+				<ul aria-label="Diagnostic events">
+					{state.rows.map((event) => (
+						<DiagnosticsEventRow
+							event={event}
+							includeTechnical={state.includeTechnical}
+							key={event.id}
+							onRecoveryNavigation={controller.navigateToRecovery}
+						/>
+					))}
+				</ul>
+			) : null}
+			{canLoadOlder ? (
+				<button
+					className="settings-button diagnostics-load-older"
+					onClick={() => void controller.loadOlder()}
+					type="button"
+				>
+					Load older
+				</button>
+			) : null}
+			{state.rows.length >= MAX_ROWS ? (
+				<div className="diagnostics-limit-note">Showing the newest {MAX_ROWS} events.</div>
+			) : null}
+		</div>
+	);
+}
+
+export function DiagnosticsDrawerView({ controller }: { controller: DrawerController }) {
+	return (
+		<RadixDialog
+			ariaDescribedby="diagnosticsDrawerDescription"
+			ariaLabelledby="diagnosticsDrawerTitle"
+			contentClassName="diagnostics-drawer"
+			contentId="diagnosticsDrawer"
+			onCloseAutoFocus={controller.restoreFocus}
+			onOpenAutoFocus={(event) => {
+				event.preventDefault();
+				document.getElementById("diagnosticsDrawerTitle")?.focus();
+			}}
+			onOpenChange={(open) => {
+				if (!open) controller.close();
+			}}
+			open={controller.state.open}
+			overlayClassName="diagnostics-drawer-overlay"
+			overlayId="diagnosticsDrawerOverlay"
+		>
+			<header className="diagnostics-drawer-header">
+				<div>
+					<RadixDialogTitle id="diagnosticsDrawerTitle" tabIndex={-1}>
+						Diagnostics
+					</RadixDialogTitle>
+					<p id="diagnosticsDrawerDescription">
+						Recent redacted operational events. Filters apply only to this drawer.
+					</p>
+				</div>
+				<DialogCloseButton ariaLabel="Close diagnostics" onClick={controller.close} />
+			</header>
+			<DrawerControls controller={controller} />
+			<DrawerNotices controller={controller} />
+			<DrawerEventList controller={controller} />
+		</RadixDialog>
+	);
+}

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -29,6 +29,14 @@ export {
 	unarchiveCoordinatorAdminGroup,
 	updateCoordinatorAdminScope,
 } from "./api/coordinator-admin";
+export type {
+	DiagnosticEvent,
+	DiagnosticEventSeverity,
+	DiagnosticEventSubsystem,
+	DiagnosticEventsResponse,
+	DiagnosticRecoveryHref,
+	LoadDiagnosticEventsOptions,
+} from "./api/diagnostics";
 export {
 	forgetMemory,
 	loadMemories,

--- a/packages/ui/src/lib/api/diagnostics.test.ts
+++ b/packages/ui/src/lib/api/diagnostics.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DiagnosticEventsRequestError, loadDiagnosticEvents } from "./diagnostics";
+
+const originalFetch = globalThis.fetch;
+
+function validResponse(overrides: Record<string, unknown> = {}) {
+	return {
+		contract_version: 1,
+		items: [],
+		next_cursor: null,
+		redacted: true,
+		generated_at: "2026-09-07T12:00:00.000Z",
+		...overrides,
+	};
+}
+
+function validEvent(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "event-id",
+		occurred_at: "2026-09-07T12:00:00.000Z",
+		severity: "warning",
+		subsystem: "capture",
+		code: "capture_backlog_growing",
+		message: "The capture queue is growing.",
+		...overrides,
+	};
+}
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+describe("diagnostics API", () => {
+	it("encodes filters and sends an abortable no-store GET", async () => {
+		const fetchMock = vi.fn(
+			async () => new Response(JSON.stringify(validResponse()), { status: 200 }),
+		);
+		globalThis.fetch = fetchMock as typeof fetch;
+		const controller = new AbortController();
+
+		await loadDiagnosticEvents({
+			limit: 50,
+			cursor: "opaque cursor/+",
+			severity: ["warning", "error"],
+			subsystem: ["observer", "capture"],
+			includeTechnical: true,
+			signal: controller.signal,
+		});
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/diagnostics/events?limit=50&cursor=opaque+cursor%2F%2B&severity=warning%2Cerror&subsystem=observer%2Ccapture&includeTechnical=1",
+			{ cache: "no-store", method: "GET", signal: controller.signal },
+		);
+	});
+
+	it("uses redacted defaults and accepts contract version 1", async () => {
+		globalThis.fetch = vi.fn(
+			async () => new Response(JSON.stringify(validResponse()), { status: 200 }),
+		) as typeof fetch;
+
+		const response = await loadDiagnosticEvents();
+
+		expect(response.contract_version).toBe(1);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"/api/diagnostics/events?includeTechnical=0",
+			expect.objectContaining({ cache: "no-store", method: "GET" }),
+		);
+	});
+
+	it("preserves the HTTP status for cursor recovery decisions", async () => {
+		globalThis.fetch = vi.fn(async () => new Response(null, { status: 400 })) as typeof fetch;
+
+		const request = loadDiagnosticEvents({ cursor: "stale" });
+
+		await expect(request).rejects.toMatchObject({
+			name: DiagnosticEventsRequestError.name,
+			status: 400,
+		});
+	});
+
+	it.each([
+		validResponse({ contract_version: 2 }),
+		validResponse({ items: null }),
+		validResponse({ next_cursor: 3 }),
+		validResponse({ redacted: "yes" }),
+		validResponse({ generated_at: null }),
+	])("rejects an unsupported top-level response shape", async (payload) => {
+		globalThis.fetch = vi.fn(
+			async () => new Response(JSON.stringify(payload), { status: 200 }),
+		) as typeof fetch;
+
+		await expect(loadDiagnosticEvents()).rejects.toThrow("Unsupported diagnostics response");
+	});
+});
+
+describe("diagnostics API event validation", () => {
+	it("accepts exact safe optional shapes and allowlisted recovery routes", async () => {
+		const payload = validResponse({
+			items: [
+				validEvent({
+					correlation: { kind: "operation", label: "Sync attempt" },
+					recovery: {
+						command: "codemem status",
+						href: "#advanced/sync/diagnostics",
+						label: "Open sync diagnostics",
+					},
+					technical_detail: { available: true, text: "Bounded detail" },
+				}),
+			],
+		});
+		globalThis.fetch = vi.fn(
+			async () => new Response(JSON.stringify(payload), { status: 200 }),
+		) as typeof fetch;
+
+		await expect(loadDiagnosticEvents()).resolves.toMatchObject(payload);
+	});
+
+	it.each([
+		validEvent({ id: "" }),
+		validEvent({ id: "x".repeat(129) }),
+		validEvent({ occurred_at: "not-a-date" }),
+		validEvent({ severity: "critical" }),
+		validEvent({ subsystem: "network" }),
+		validEvent({ code: "" }),
+		validEvent({ message: "x".repeat(2_001) }),
+		validEvent({ raw_error: "private path" }),
+	])("drops malformed required event fields", async (malformedEvent) => {
+		globalThis.fetch = vi.fn(
+			async () =>
+				new Response(JSON.stringify(validResponse({ items: [malformedEvent] })), {
+					status: 200,
+				}),
+		) as typeof fetch;
+
+		await expect(loadDiagnosticEvents()).resolves.toMatchObject({ items: [] });
+	});
+
+	it.each([
+		validEvent({ recovery: { label: "Unsafe", href: "javascript:alert(1)" } }),
+		validEvent({ recovery: { label: "External", href: "https://example.com" } }),
+		validEvent({ recovery: { label: "Unknown", href: "#settings" } }),
+		validEvent({ recovery: { label: "Health", href: "#health", extra: true } }),
+		validEvent({ correlation: { kind: "peer", label: "Peer" } }),
+		validEvent({ correlation: { kind: "session", label: "", secret: "value" } }),
+		validEvent({ technical_detail: { available: false, text: "unexpected" } }),
+		validEvent({ technical_detail: { available: true, text: "x".repeat(2_001) } }),
+	])("drops unsafe optional event fields", async (malformedEvent) => {
+		globalThis.fetch = vi.fn(
+			async () =>
+				new Response(JSON.stringify(validResponse({ items: [malformedEvent] })), {
+					status: 200,
+				}),
+		) as typeof fetch;
+
+		await expect(loadDiagnosticEvents()).resolves.toMatchObject({ items: [] });
+	});
+
+	it("keeps valid server failure rows when another item fails validation", async () => {
+		const observerFailure = validEvent({
+			id: "observer-failure",
+			severity: "error",
+			subsystem: "observer",
+			code: "observer_flush_failed",
+			message: "Processing failed and queued events are waiting for retry.",
+			recovery: { label: "Open Health", href: "#health" },
+		});
+		const payload = validResponse({
+			items: [observerFailure, validEvent({ recovery: { label: "Unsafe", href: "#settings" } })],
+		});
+		globalThis.fetch = vi.fn(
+			async () => new Response(JSON.stringify(payload), { status: 200 }),
+		) as typeof fetch;
+
+		await expect(loadDiagnosticEvents()).resolves.toMatchObject({ items: [observerFailure] });
+	});
+});

--- a/packages/ui/src/lib/api/diagnostics.ts
+++ b/packages/ui/src/lib/api/diagnostics.ts
@@ -1,0 +1,180 @@
+export const DIAGNOSTIC_SEVERITIES = ["info", "warning", "error"] as const;
+export const DIAGNOSTIC_SUBSYSTEMS = [
+	"viewer",
+	"observer",
+	"capture",
+	"sync",
+	"storage",
+	"maintenance",
+] as const;
+
+export const DIAGNOSTIC_RECOVERY_HREFS = ["#health", "#advanced/sync/diagnostics"] as const;
+
+const MAX_EVENT_COUNT = 100;
+const MAX_ID_LENGTH = 128;
+const MAX_TIMESTAMP_LENGTH = 64;
+const MAX_CODE_LENGTH = 128;
+const MAX_MESSAGE_LENGTH = 2_000;
+const MAX_LABEL_LENGTH = 256;
+const MAX_COMMAND_LENGTH = 2_000;
+const MAX_TECHNICAL_DETAIL_LENGTH = 2_000;
+const MAX_CURSOR_LENGTH = 2_048;
+
+export type DiagnosticEventSeverity = (typeof DIAGNOSTIC_SEVERITIES)[number];
+export type DiagnosticEventSubsystem = (typeof DIAGNOSTIC_SUBSYSTEMS)[number];
+export type DiagnosticRecoveryHref = (typeof DIAGNOSTIC_RECOVERY_HREFS)[number];
+
+export type DiagnosticEvent = {
+	id: string;
+	occurred_at: string;
+	severity: DiagnosticEventSeverity;
+	subsystem: DiagnosticEventSubsystem;
+	code: string;
+	message: string;
+	recovery?: { label: string; href?: DiagnosticRecoveryHref; command?: string };
+	correlation?: { kind: "session" | "device" | "operation"; label: string };
+	technical_detail?: { available: boolean; text?: string };
+};
+
+export type DiagnosticEventsResponse = {
+	contract_version: 1;
+	items: DiagnosticEvent[];
+	next_cursor: string | null;
+	redacted: boolean;
+	generated_at: string;
+};
+
+export type LoadDiagnosticEventsOptions = {
+	limit?: number;
+	cursor?: string;
+	severity?: DiagnosticEventSeverity[];
+	subsystem?: DiagnosticEventSubsystem[];
+	includeTechnical?: boolean;
+	signal?: AbortSignal;
+};
+
+export class DiagnosticEventsRequestError extends Error {
+	constructor(
+		readonly status: number,
+		statusText: string,
+	) {
+		super(`Diagnostics request failed: ${status} ${statusText}`);
+		this.name = "DiagnosticEventsRequestError";
+	}
+}
+
+function buildDiagnosticParams(options: LoadDiagnosticEventsOptions): string {
+	const params = new URLSearchParams();
+	if (typeof options.limit === "number") params.set("limit", String(options.limit));
+	if (options.cursor) params.set("cursor", options.cursor);
+	if (options.severity?.length) params.set("severity", options.severity.join(","));
+	if (options.subsystem?.length) params.set("subsystem", options.subsystem.join(","));
+	params.set("includeTechnical", options.includeTechnical ? "1" : "0");
+	return params.toString();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+	return Object.keys(value).every((key) => allowed.includes(key));
+}
+
+function isBoundedString(value: unknown, maximum: number): value is string {
+	return typeof value === "string" && value.trim().length > 0 && value.length <= maximum;
+}
+
+function isTimestamp(value: unknown): value is string {
+	return isBoundedString(value, MAX_TIMESTAMP_LENGTH) && Number.isFinite(Date.parse(value));
+}
+
+export function isDiagnosticRecoveryHref(value: unknown): value is DiagnosticRecoveryHref {
+	return (
+		typeof value === "string" && DIAGNOSTIC_RECOVERY_HREFS.includes(value as DiagnosticRecoveryHref)
+	);
+}
+
+function isRecovery(value: unknown): value is NonNullable<DiagnosticEvent["recovery"]> {
+	if (!isRecord(value) || !hasOnlyKeys(value, ["label", "href", "command"])) return false;
+	if (!isBoundedString(value.label, MAX_LABEL_LENGTH)) return false;
+	if (value.href !== undefined && !isDiagnosticRecoveryHref(value.href)) return false;
+	return value.command === undefined || isBoundedString(value.command, MAX_COMMAND_LENGTH);
+}
+
+function isCorrelation(value: unknown): value is NonNullable<DiagnosticEvent["correlation"]> {
+	if (!isRecord(value) || !hasOnlyKeys(value, ["kind", "label"])) return false;
+	if (!isBoundedString(value.label, MAX_LABEL_LENGTH)) return false;
+	return value.kind === "session" || value.kind === "device" || value.kind === "operation";
+}
+
+function isTechnicalDetail(
+	value: unknown,
+): value is NonNullable<DiagnosticEvent["technical_detail"]> {
+	if (!isRecord(value) || !hasOnlyKeys(value, ["available", "text"])) return false;
+	if (typeof value.available !== "boolean") return false;
+	if (value.text === undefined) return true;
+	return value.available && isBoundedString(value.text, MAX_TECHNICAL_DETAIL_LENGTH);
+}
+
+function isDiagnosticEvent(value: unknown): value is DiagnosticEvent {
+	if (!isRecord(value)) return false;
+	if (
+		!hasOnlyKeys(value, [
+			"id",
+			"occurred_at",
+			"severity",
+			"subsystem",
+			"code",
+			"message",
+			"recovery",
+			"correlation",
+			"technical_detail",
+		])
+	) {
+		return false;
+	}
+	if (!isBoundedString(value.id, MAX_ID_LENGTH) || !isTimestamp(value.occurred_at)) return false;
+	if (!DIAGNOSTIC_SEVERITIES.includes(value.severity as DiagnosticEventSeverity)) return false;
+	if (!DIAGNOSTIC_SUBSYSTEMS.includes(value.subsystem as DiagnosticEventSubsystem)) return false;
+	if (!isBoundedString(value.code, MAX_CODE_LENGTH)) return false;
+	if (!isBoundedString(value.message, MAX_MESSAGE_LENGTH)) return false;
+	if (value.recovery !== undefined && !isRecovery(value.recovery)) return false;
+	if (value.correlation !== undefined && !isCorrelation(value.correlation)) return false;
+	return value.technical_detail === undefined || isTechnicalDetail(value.technical_detail);
+}
+
+function parseDiagnosticEventsResponse(value: unknown): DiagnosticEventsResponse | null {
+	if (!isRecord(value) || value.contract_version !== 1) return null;
+	if (!Array.isArray(value.items) || value.items.length > MAX_EVENT_COUNT) return null;
+	let nextCursor: string | null = null;
+	if (value.next_cursor !== null) {
+		if (!isBoundedString(value.next_cursor, MAX_CURSOR_LENGTH)) return null;
+		nextCursor = value.next_cursor;
+	}
+	if (typeof value.redacted !== "boolean" || !isTimestamp(value.generated_at)) return null;
+	return {
+		contract_version: 1,
+		items: value.items.filter(isDiagnosticEvent),
+		next_cursor: nextCursor,
+		redacted: value.redacted,
+		generated_at: value.generated_at,
+	};
+}
+
+export async function loadDiagnosticEvents(
+	options: LoadDiagnosticEventsOptions = {},
+): Promise<DiagnosticEventsResponse> {
+	const query = buildDiagnosticParams(options);
+	const response = await fetch(`/api/diagnostics/events?${query}`, {
+		cache: "no-store",
+		method: "GET",
+		signal: options.signal,
+	});
+	if (!response.ok) {
+		throw new DiagnosticEventsRequestError(response.status, response.statusText);
+	}
+	const parsed = parseDiagnosticEventsResponse(await response.json());
+	if (!parsed) throw new Error("Unsupported diagnostics response");
+	return parsed;
+}

--- a/packages/ui/src/lib/api/internal.ts
+++ b/packages/ui/src/lib/api/internal.ts
@@ -10,8 +10,11 @@ export function payloadError(payload: unknown): string | undefined {
 	return typeof maybeError === "string" ? maybeError : undefined;
 }
 
-export async function fetchJson<T = Record<string, unknown>>(url: string): Promise<T> {
-	const resp = await fetch(url);
+export async function fetchJson<T = Record<string, unknown>>(
+	url: string,
+	init?: RequestInit,
+): Promise<T> {
+	const resp = init ? await fetch(url, init) : await fetch(url);
 	if (!resp.ok) throw new Error(`${url}: ${resp.status} ${resp.statusText}`);
 	return resp.json() as Promise<T>;
 }

--- a/packages/ui/src/tabs/projects.test.ts
+++ b/packages/ui/src/tabs/projects.test.ts
@@ -247,86 +247,87 @@ async function flushAsyncWork() {
 	}
 }
 
-describe("Projects tab", () => {
-	beforeEach(() => {
-		mountProjectsDom();
-		state.lastProjectCoordinatorAdminGroups = [
-			{ archived_at: null, display_name: "ExampleCo Team", group_id: "exampleco" },
-		];
-		vi.mocked(api.loadCoordinatorAdminStatus).mockResolvedValue({
-			has_admin_secret: true,
-			readiness: "ready",
-		});
-		vi.mocked(api.loadCoordinatorAdminGroupsFiltered).mockResolvedValue({
-			items: [{ archived_at: null, display_name: "ExampleCo Team", group_id: "exampleco" }],
-		});
-		vi.mocked(api.loadSharingDomainSettings).mockResolvedValue({
-			local_default_scope_id: "local-default",
-			mappings: [],
-			projects: [],
-			scopes: [
-				{
-					authority_type: "local",
-					kind: "system",
-					label: "Local only",
-					scope_id: "local-default",
-					status: "active",
-				},
-				{
-					authority_type: "local",
-					kind: "system",
-					label: "Legacy shared review",
-					scope_id: "legacy-shared-review",
-					status: "active",
-				},
-				{
-					authority_type: "coordinator",
-					group_id: "exampleco",
-					kind: "team_default",
-					label: "ExampleCo Work",
-					scope_id: "exampleco-work",
-					status: "active",
-				},
-			],
-		});
-		vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue({
-			blockedItems: [],
-			categoryCounts: {
-				actionableReview: 0,
-				preservedContinuity: 0,
-				blockedRepair: 0,
-			},
-			continuity: null,
-			reviewItems: [],
-			version: 1,
-		});
-		vi.mocked(api.loadRecipientPolicyIntent).mockResolvedValue(recipientIntent());
-		vi.mocked(api.loadLegacyTeamSetupSummary).mockResolvedValue({ version: 1, candidates: [] });
-		vi.mocked(api.resolveRecipientPolicyReview).mockResolvedValue({
-			errorCode: null,
-			idempotent: false,
-			reviewItemId: "review-1",
-			sourceFingerprint: "fingerprint-1",
-			status: "applied",
-		});
-		vi.mocked(api.loadProjects).mockResolvedValue(["api", "codemem"]);
-		vi.mocked(api.reassignProjectInventoryProject).mockResolvedValue({
-			moved_memory_count: 1,
-			moved_session_count: 1,
-			previous_projects: ["api"],
-			project: "codemem",
-			workspace_identity: "https://git.example.invalid/exampleco/api.git",
-		});
-		vi.mocked(api.forgetProjectInventoryMemories).mockResolvedValue({
-			confirmation_token: "token",
-			confirmed: true,
-			forgotten_memory_count: 1,
-			local_owned_memory_count: 1,
-			peer_owned_memory_count: 0,
-			workspace_identity: "https://git.example.invalid/exampleco/api.git",
-		});
+function setupProjectsTest() {
+	mountProjectsDom();
+	state.lastProjectCoordinatorAdminGroups = [
+		{ archived_at: null, display_name: "ExampleCo Team", group_id: "exampleco" },
+	];
+	vi.mocked(api.loadCoordinatorAdminStatus).mockResolvedValue({
+		has_admin_secret: true,
+		readiness: "ready",
 	});
+	vi.mocked(api.loadCoordinatorAdminGroupsFiltered).mockResolvedValue({
+		items: [{ archived_at: null, display_name: "ExampleCo Team", group_id: "exampleco" }],
+	});
+	vi.mocked(api.loadSharingDomainSettings).mockResolvedValue({
+		local_default_scope_id: "local-default",
+		mappings: [],
+		projects: [],
+		scopes: [
+			{
+				authority_type: "local",
+				kind: "system",
+				label: "Local only",
+				scope_id: "local-default",
+				status: "active",
+			},
+			{
+				authority_type: "local",
+				kind: "system",
+				label: "Legacy shared review",
+				scope_id: "legacy-shared-review",
+				status: "active",
+			},
+			{
+				authority_type: "coordinator",
+				group_id: "exampleco",
+				kind: "team_default",
+				label: "ExampleCo Work",
+				scope_id: "exampleco-work",
+				status: "active",
+			},
+		],
+	});
+	vi.mocked(api.loadRecipientPolicyReview).mockResolvedValue({
+		blockedItems: [],
+		categoryCounts: {
+			actionableReview: 0,
+			preservedContinuity: 0,
+			blockedRepair: 0,
+		},
+		continuity: null,
+		reviewItems: [],
+		version: 1,
+	});
+	vi.mocked(api.loadRecipientPolicyIntent).mockResolvedValue(recipientIntent());
+	vi.mocked(api.loadLegacyTeamSetupSummary).mockResolvedValue({ version: 1, candidates: [] });
+	vi.mocked(api.resolveRecipientPolicyReview).mockResolvedValue({
+		errorCode: null,
+		idempotent: false,
+		reviewItemId: "review-1",
+		sourceFingerprint: "fingerprint-1",
+		status: "applied",
+	});
+	vi.mocked(api.loadProjects).mockResolvedValue(["api", "codemem"]);
+	vi.mocked(api.reassignProjectInventoryProject).mockResolvedValue({
+		moved_memory_count: 1,
+		moved_session_count: 1,
+		previous_projects: ["api"],
+		project: "codemem",
+		workspace_identity: "https://git.example.invalid/exampleco/api.git",
+	});
+	vi.mocked(api.forgetProjectInventoryMemories).mockResolvedValue({
+		confirmation_token: "token",
+		confirmed: true,
+		forgotten_memory_count: 1,
+		local_owned_memory_count: 1,
+		peer_owned_memory_count: 0,
+		workspace_identity: "https://git.example.invalid/exampleco/api.git",
+	});
+}
 
+describe("Projects tab", () => {
+	beforeEach(setupProjectsTest);
 	afterEach(() => {
 		vi.clearAllMocks();
 		state.lastProjectCoordinatorAdminGroups = [];
@@ -1954,6 +1955,56 @@ describe("Projects tab", () => {
 			[],
 			{ inventoryError: true },
 		);
+	});
+
+	it("reports the newer successful result when an older overlapping load fails", async () => {
+		let rejectOlder!: (reason?: unknown) => void;
+		const inventory = {
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [project()],
+			total: 1,
+		};
+		vi.mocked(api.loadProjectScopeInventory)
+			.mockImplementationOnce(
+				() => new Promise<ProjectScopeInventoryResult>((_, reject) => (rejectOlder = reject)),
+			)
+			.mockResolvedValue(inventory);
+
+		const olderLoad = loadProjectsData();
+		await vi.waitFor(() => expect(api.loadProjectScopeInventory).toHaveBeenCalledTimes(2));
+		const newerLoad = loadProjectsData();
+
+		await expect(newerLoad).resolves.toBe(true);
+		rejectOlder(new Error("older load failed"));
+		await expect(olderLoad).resolves.toBe(true);
+	});
+
+	it("reports the newer failed result when an older overlapping load succeeds", async () => {
+		let resolveOlder!: (value: ProjectScopeInventoryResult) => void;
+		const inventory = {
+			has_more: false,
+			limit: 250,
+			offset: 0,
+			projects: [project()],
+			total: 1,
+		};
+		vi.mocked(api.loadProjectScopeInventory)
+			.mockImplementationOnce(
+				() => new Promise<ProjectScopeInventoryResult>((resolve) => (resolveOlder = resolve)),
+			)
+			.mockResolvedValueOnce(inventory)
+			.mockRejectedValueOnce(new Error("newer load failed"))
+			.mockResolvedValue(inventory);
+
+		const olderLoad = loadProjectsData();
+		await vi.waitFor(() => expect(api.loadProjectScopeInventory).toHaveBeenCalledTimes(2));
+		const newerLoad = loadProjectsData();
+
+		await expect(newerLoad).resolves.toBe(false);
+		resolveOlder(inventory);
+		await expect(olderLoad).resolves.toBe(false);
 	});
 
 	it("does not reuse cached repair targets after an inventory load fails", async () => {

--- a/packages/ui/src/tabs/projects.ts
+++ b/packages/ui/src/tabs/projects.ts
@@ -59,6 +59,7 @@ const projectInventoryByIdentity = new Map<string, ProjectScopeInventoryProject>
 let coordinatorGroupNamesCurrent = false;
 let projectShareInventoryReady = false;
 let projectsLoadGeneration = 0;
+let latestProjectsLoad: Promise<boolean> | null = null;
 let projectsUserNavigationGeneration = 0;
 let teamSetupEntryLoadGeneration = 0;
 let recipientPolicyRepairInFlight: Promise<void> | null = null;
@@ -1557,7 +1558,22 @@ export interface ProjectsDataLoadOptions {
 	requireTeamSetupSummary?: boolean;
 }
 
-export async function loadProjectsData(options: ProjectsDataLoadOptions = {}) {
+export function loadProjectsData(options: ProjectsDataLoadOptions = {}): Promise<boolean> {
+	const operation = loadProjectsDataOperation(options);
+	latestProjectsLoad = operation;
+	return operation;
+}
+
+async function supersededProjectsLoad(
+	options: ProjectsDataLoadOptions,
+	teamSetupSummaryPromise: Promise<TeamSetupSummaryResult> | null,
+): Promise<boolean> {
+	if (!options.requireTeamSetupSummary) return latestProjectsLoad ?? false;
+	await teamSetupSummaryPromise;
+	return false;
+}
+
+async function loadProjectsDataOperation(options: ProjectsDataLoadOptions): Promise<boolean> {
 	const meta = el<HTMLDivElement>("projectsInventoryMeta");
 	const list = el<HTMLDivElement>("projectsInventoryList");
 	if (!meta || !list) {
@@ -1586,11 +1602,10 @@ export async function loadProjectsData(options: ProjectsDataLoadOptions = {}) {
 	recipientPolicyIntentReady = false;
 	updateSelectionControls();
 	meta.textContent = "Loading project inventory…";
+	let teamSetupSummaryPromise: Promise<TeamSetupSummaryResult> | null = null;
 	try {
 		const entryLoadGeneration = ++teamSetupEntryLoadGeneration;
-		const teamSetupSummaryPromise = loadTeamSetupSummaryOnce(
-			options.requireTeamSetupSummary === true,
-		);
+		teamSetupSummaryPromise = loadTeamSetupSummaryOnce(options.requireTeamSetupSummary === true);
 		const [result, settings, shareInventory, recipientPolicyReview, intentResult] =
 			await Promise.all([
 				api.loadProjectScopeInventory({
@@ -1613,8 +1628,7 @@ export async function loadProjectsData(options: ProjectsDataLoadOptions = {}) {
 					.catch((error: unknown) => ({ ok: false as const, error })),
 			]);
 		if (loadGeneration !== projectsLoadGeneration) {
-			if (options.requireTeamSetupSummary) await teamSetupSummaryPromise;
-			return false;
+			return supersededProjectsLoad(options, teamSetupSummaryPromise);
 		}
 		scopes = settings.scopes;
 		projectShareInventoryReady = shareInventory.ok;
@@ -1685,7 +1699,9 @@ export async function loadProjectsData(options: ProjectsDataLoadOptions = {}) {
 			return false;
 		return requiredLoadSucceeded && teamSetupSummary.ok;
 	} catch (error) {
-		if (loadGeneration !== projectsLoadGeneration) return false;
+		if (loadGeneration !== projectsLoadGeneration) {
+			return supersededProjectsLoad(options, teamSetupSummaryPromise);
+		}
 		projectInventoryByIdentity.clear();
 		projectShareInventoryReady = false;
 		recipientPolicyIntentReady = false;

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -3248,6 +3248,144 @@
       @media (max-height: 720px) { .modal { align-items: flex-start; } }
       .modal-backdrop[hidden], .modal[hidden] { display: none; }
 
+      /* ── Contextual diagnostics drawer ─────────────────────── */
+      .diagnostics-drawer-overlay {
+        position: fixed;
+        inset: 0;
+        z-index: 45;
+        background: rgba(25, 24, 23, 0.42);
+        backdrop-filter: blur(4px);
+        animation: diagnosticsOverlayIn var(--duration-fast) var(--ease-standard);
+      }
+      .diagnostics-drawer {
+        position: fixed;
+        inset: 0 0 0 auto;
+        z-index: 46;
+        width: clamp(420px, 42vw, 640px);
+        display: flex;
+        flex-direction: column;
+        gap: var(--sp-3);
+        padding: var(--sp-5);
+        border-left: 1px solid var(--border);
+        background: var(--surface-1);
+        box-shadow: var(--shadow-lg);
+        color: var(--text-primary);
+        animation: diagnosticsDrawerIn var(--duration-fast) var(--ease-standard);
+      }
+      .diagnostics-drawer-header,
+      .diagnostics-secondary-controls,
+      .diagnostics-notice,
+      .diagnostics-event-heading,
+      .diagnostics-event-context {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--sp-3);
+      }
+      .diagnostics-drawer-header { flex-shrink: 0; align-items: flex-start; }
+      .diagnostics-drawer-header h2 { margin: 0; font-size: var(--font-size-2xl); }
+      .diagnostics-drawer-header p { margin-top: var(--sp-1); color: var(--text-secondary); }
+      .diagnostics-controls {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+        gap: var(--sp-2);
+        align-items: end;
+        flex-shrink: 0;
+      }
+      .diagnostics-controls label { display: grid; gap: 5px; color: var(--text-secondary); font-size: var(--font-size-sm); }
+      .diagnostics-controls select {
+        width: 100%;
+        min-height: 36px;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: 6px 10px;
+        background: var(--input-bg);
+        color: var(--text-primary);
+      }
+      .diagnostics-controls select:focus-visible,
+      .diagnostics-new-events:focus-visible,
+      .diagnostics-recovery:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+        box-shadow: 0 0 0 4px var(--focus-ring);
+      }
+      .diagnostics-secondary-controls { flex-shrink: 0; }
+      .diagnostics-generated-at,
+      .diagnostics-limit-note,
+      .diagnostics-filter-context { color: var(--text-tertiary); font-size: var(--font-size-sm); }
+      .diagnostics-notice {
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: var(--sp-2) var(--sp-3);
+        background: var(--surface-2);
+        color: var(--text-secondary);
+        flex-shrink: 0;
+      }
+      .diagnostics-notice--error { border-color: color-mix(in srgb, var(--status-attention) 42%, var(--border)); }
+      .diagnostics-new-events {
+        align-self: center;
+        border: 1px solid var(--accent);
+        border-radius: var(--radius-pill);
+        padding: 7px 14px;
+        background: var(--accent-subtle);
+        color: var(--text-primary);
+        cursor: pointer;
+        font: inherit;
+        font-weight: var(--font-weight-semibold);
+      }
+      .diagnostics-event-list { min-height: 0; overflow-y: auto; overscroll-behavior: contain; }
+      .diagnostics-event-list ul { display: grid; gap: var(--sp-2); margin: 0; padding: 0; list-style: none; }
+      .diagnostics-event {
+        display: grid;
+        gap: var(--sp-2);
+        border: 1px solid var(--border);
+        border-left-width: 3px;
+        border-radius: var(--radius-md);
+        padding: var(--sp-3);
+        background: var(--surface-0);
+      }
+      .diagnostics-event--info { border-left-color: var(--accent); }
+      .diagnostics-event--warning { border-left-color: var(--status-degraded); }
+      .diagnostics-event--error { border-left-color: var(--status-attention); }
+      .diagnostics-event-heading time,
+      .diagnostics-event-context,
+      .diagnostics-event-meta { color: var(--text-tertiary); font-size: var(--font-size-sm); }
+      .diagnostics-event-context { justify-content: flex-start; flex-wrap: wrap; }
+      .diagnostics-event-context span { text-transform: capitalize; }
+      .diagnostics-event p { margin: 0; line-height: 1.5; }
+      .diagnostics-severity { display: inline-flex; align-items: center; gap: 6px; font-weight: var(--font-weight-semibold); }
+      .diagnostics-severity-icon {
+        display: inline-grid;
+        place-items: center;
+        width: 20px;
+        height: 20px;
+        border: 1px solid currentColor;
+        border-radius: 50%;
+        font-weight: var(--font-weight-semibold);
+      }
+      .diagnostics-technical-detail pre,
+      .diagnostics-recovery-command code { white-space: pre-wrap; overflow-wrap: anywhere; }
+      .diagnostics-technical-detail pre { margin: var(--sp-2) 0 0; color: var(--text-secondary); }
+      .diagnostics-recovery { color: var(--accent); font-weight: var(--font-weight-semibold); width: fit-content; }
+      .diagnostics-recovery-command { display: grid; gap: 4px; color: var(--text-secondary); }
+      .diagnostics-empty { display: grid; place-items: center; gap: var(--sp-3); min-height: 220px; text-align: center; color: var(--text-secondary); }
+      .diagnostics-loading { display: grid; gap: var(--sp-2); }
+      .diagnostics-loading-row { display: grid; gap: var(--sp-2); padding: var(--sp-3); border: 1px solid var(--border); border-radius: var(--radius-md); }
+      .diagnostics-loading-row span { height: 10px; border-radius: var(--radius-pill); background: var(--surface-2); animation: pulse var(--duration-pulse) var(--ease-standard) infinite; }
+      .diagnostics-loading-row span:nth-child(2) { width: 64%; }
+      .diagnostics-loading-row span:nth-child(3) { width: 82%; }
+      .diagnostics-load-older { display: block; margin: var(--sp-3) auto 0; }
+      .diagnostics-limit-note { padding: var(--sp-3); text-align: center; }
+      @keyframes diagnosticsOverlayIn { from { opacity: 0; } to { opacity: 1; } }
+      @keyframes diagnosticsDrawerIn { from { transform: translateX(24px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+
+      @media (max-width: 699px) {
+        .diagnostics-drawer { inset: 0; width: 100vw; padding: var(--sp-4); border-left: 0; }
+        .diagnostics-controls { grid-template-columns: 1fr 1fr; }
+        .diagnostics-controls > button { grid-column: 1 / -1; }
+        .diagnostics-secondary-controls { align-items: flex-start; flex-direction: column; }
+      }
+
       .legacy-upgrade-modal .modal-card { width: min(620px, 100%); }
       .legacy-upgrade-summary {
         padding: var(--sp-3);
@@ -4101,6 +4239,7 @@
     <div id="toastRoot"></div>
     <div id="recipientPolicyManagementMount"></div>
     <div id="legacyTeamSetupMount"></div>
+    <div id="diagnosticsDrawerMount"></div>
     <div class="viewer-reconnect-overlay" id="viewerReconnectOverlay" hidden>
       <div class="viewer-reconnect-card" role="status" aria-live="assertive">
         <div class="viewer-reconnect-eyebrow">Viewer connection</div>
@@ -4374,6 +4513,7 @@
       <div class="card" style="animation-delay: 0s">
         <div class="section-header">
           <h2>System health</h2>
+          <button class="settings-button" id="healthOpenDiagnostics" type="button">View diagnostics</button>
         </div>
         <div class="section-meta" id="healthMeta">Assessing health signals…</div>
         <div class="health-actions" id="healthActions"></div>
@@ -4590,6 +4730,7 @@
             <h2>Sync diagnostics</h2>
           </div>
           <div class="section-actions">
+            <button class="settings-button" id="syncOpenDiagnostics" type="button">Recent sync events</button>
             <label class="small sync-redact-control">
               <span id="syncRedactMount"></span>
               <span id="syncRedactLabel">Redact</span>

--- a/packages/viewer-server/src/routes/diagnostics.test.ts
+++ b/packages/viewer-server/src/routes/diagnostics.test.ts
@@ -250,6 +250,10 @@ describe("GET /api/diagnostics/events", () => {
 			"maintenance_job_failed",
 		]);
 		expect(body.items.every((event) => event.technical_detail?.text == null)).toBe(true);
+		expect(body.items.find((event) => event.code === "observer_flush_failed")?.recovery).toEqual({
+			label: "Open Health",
+			href: "#health",
+		});
 	});
 
 	it("never returns stored sensitive text, identifiers, or paths", async () => {

--- a/packages/viewer-server/src/routes/diagnostics.ts
+++ b/packages/viewer-server/src/routes/diagnostics.ts
@@ -346,7 +346,7 @@ function failureEvent(row: DiagnosticSourceRow, includeTechnical: boolean): Orde
 		message: gaveUp
 			? "Processing stopped after all retry attempts were exhausted."
 			: "Processing failed and queued events are waiting for retry.",
-		recovery: { label: "Open observer settings", href: "#settings" },
+		recovery: { label: "Open Health", href: "#health" },
 		technical_detail: technicalDetail(
 			true,
 			`Failure category: ${row.category ?? "unspecified"}. Attempts: ${attempts}.`,


### PR DESCRIPTION
## Description
Adds the typed diagnostics API client and accessible right-side drawer with filters, technical-detail reveal, pause/resume, stale and retry states, queued updates, bounded pagination, and Health/Advanced entry points. Refreshes reuse the viewer app coordination and stop while hidden, paused, or closed.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced