### PR TITLE
feat(viewer): add contextual diagnostics actions

### DIFF
--- a/packages/ui/src/app-devices.test.tsx
+++ b/packages/ui/src/app-devices.test.tsx
@@ -8,12 +8,17 @@ const mocks = vi.hoisted(() => ({
 	loadProjectScopeInventory: vi.fn(),
 	loadDeviceIdentityInventory: vi.fn(),
 	loadLegacyTeamSetupDetail: vi.fn(),
+	loadHealthData: vi.fn(),
 	loadProjectsData: vi.fn(),
 	loadRecipientPolicyIntent: vi.fn(),
 	loadRecipientPolicyReconciliationStatus: vi.fn(),
 	loadRecipientPolicySharingData: vi.fn(),
 	loadSyncData: vi.fn(),
+	loadPairingData: vi.fn(),
+	loadCoordinatorAdminData: vi.fn(),
 	mountLegacyTeamSetupDialog: vi.fn(),
+	loadSyncStatus: vi.fn(),
+	pingViewerReady: vi.fn(),
 }));
 
 vi.mock("./app-sharing", () => ({
@@ -32,8 +37,8 @@ vi.mock("./lib/api", () => ({
 	loadRecipientPolicyIntent: mocks.loadRecipientPolicyIntent,
 	loadRecipientPolicyReconciliationStatus: mocks.loadRecipientPolicyReconciliationStatus,
 	loadRuntimeInfo: vi.fn(async () => ({ version: "test" })),
-	loadSyncStatus: vi.fn(async () => ({})),
-	pingViewerReady: vi.fn(async () => true),
+	loadSyncStatus: mocks.loadSyncStatus,
+	pingViewerReady: mocks.pingViewerReady,
 	refreshLegacyTeamSetupCandidate: vi.fn(),
 	saveLegacyTeamSetupAssignment: vi.fn(),
 	saveLegacyTeamSetupDecision: vi.fn(),
@@ -41,7 +46,7 @@ vi.mock("./lib/api", () => ({
 }));
 vi.mock("./tabs/coordinator-admin", () => ({
 	initCoordinatorAdminTab: vi.fn(),
-	loadCoordinatorAdminData: vi.fn(async () => undefined),
+	loadCoordinatorAdminData: mocks.loadCoordinatorAdminData,
 }));
 vi.mock("./tabs/feed", () => ({
 	initFeedTab: vi.fn(),
@@ -50,7 +55,7 @@ vi.mock("./tabs/feed", () => ({
 }));
 vi.mock("./tabs/health", () => ({
 	initHealthTab: vi.fn(),
-	loadHealthData: vi.fn(async () => undefined),
+	loadHealthData: mocks.loadHealthData,
 }));
 vi.mock("./tabs/legacy-team-setup-dialog", () => ({
 	mountLegacyTeamSetupDialog: mocks.mountLegacyTeamSetupDialog,
@@ -74,7 +79,7 @@ vi.mock("./tabs/settings", () => ({
 vi.mock("./tabs/sync", () => ({
 	initSyncTab: vi.fn(),
 	invalidateSyncPeerScopeCache: vi.fn(),
-	loadPairingData: vi.fn(async () => undefined),
+	loadPairingData: mocks.loadPairingData,
 	loadSyncData: mocks.loadSyncData,
 }));
 vi.mock("./tabs/sync/sync-view-controller", () => ({ applySyncSubView: vi.fn() }));
@@ -148,108 +153,306 @@ function bodyMarkup(): string {
 	return html.match(/<body[^>]*>([\s\S]*?)<\/body>/)?.[1] ?? "";
 }
 
-describe("Devices app integration", () => {
-	beforeEach(async () => {
-		vi.useFakeTimers();
-		vi.clearAllMocks();
-		vi.resetModules();
-		localStorage.clear();
-		localStorage.setItem("codemem-theme", "light");
-		document.body.innerHTML = bodyMarkup();
-		window.location.hash = "devices";
-		mocks.loadProjectScopeInventory.mockResolvedValue({
-			projects: [
-				{
-					workspace_identity: "project-private",
-					identity_source: "git_remote",
-					display_project: "Codemem",
-					memory_count: 10,
-					read_only: false,
-				},
-			],
-			has_more: false,
-			limit: 250,
-			offset: 0,
-		});
-		mocks.loadRecipientPolicyIntent.mockResolvedValue(intent);
-		mocks.loadProjectsData.mockResolvedValue(true);
-		mocks.loadRecipientPolicySharingData.mockResolvedValue(true);
-		mocks.loadLegacyTeamSetupDetail.mockResolvedValue({
-			version: 1,
-			candidate: {
-				candidateRef: "opaque-candidate-ref",
-				displayName: "Example Team",
-				status: "in_progress",
-				deviceCount: 0,
-				projectCount: 0,
-				unresolvedDeviceCount: 0,
-				unresolvedProjectCount: 0,
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, reject, resolve };
+}
+
+async function verifyRestorationWaitsForQueuedActiveTabRefresh(): Promise<void> {
+	const { state } = await import("./lib/state");
+	const connectionEvents = await import("./components/diagnostics/viewer-connection-events");
+	connectionEvents.resetViewerConnectionEventsForTests();
+	mocks.loadHealthData.mockRejectedValueOnce(new Error("viewer unavailable"));
+	mocks.pingViewerReady.mockRejectedValueOnce(new Error("viewer unavailable"));
+
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(5_100);
+	});
+	expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).toContain(
+		"viewer_connection_lost",
+	);
+
+	const devicesRefresh = deferred<typeof intent>();
+	const intentCalls = mocks.loadRecipientPolicyIntent.mock.calls.length;
+	const projectCalls = mocks.loadProjectsData.mock.calls.length;
+	mocks.loadRecipientPolicyIntent.mockReturnValueOnce(devicesRefresh.promise);
+	mocks.loadProjectsData.mockResolvedValueOnce(false);
+	await act(async () => {
+		vi.advanceTimersByTime(1_600);
+		await Promise.resolve();
+		await Promise.resolve();
+	});
+	expect(mocks.loadRecipientPolicyIntent).toHaveBeenCalledTimes(intentCalls + 1);
+
+	state.activeTab = "projects";
+	state.refreshQueued = true;
+
+	await act(async () => {
+		devicesRefresh.resolve(intent);
+		await devicesRefresh.promise;
+		await vi.advanceTimersByTimeAsync(0);
+	});
+	expect(mocks.loadProjectsData).toHaveBeenCalledTimes(projectCalls + 1);
+	expect(document.getElementById("refreshStatus")?.dataset.refreshState).toBe("error");
+	expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).not.toContain(
+		"viewer_connection_restored",
+	);
+
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(5_100);
+	});
+	expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).toContain(
+		"viewer_connection_restored",
+	);
+}
+
+async function verifyHealthRestorationWaitsForSyncRefresh(): Promise<void> {
+	const { state } = await import("./lib/state");
+	const connectionEvents = await import("./components/diagnostics/viewer-connection-events");
+	connectionEvents.resetViewerConnectionEventsForTests();
+	state.activeTab = "health";
+	mocks.loadHealthData.mockRejectedValueOnce(new Error("viewer unavailable"));
+	mocks.pingViewerReady.mockRejectedValueOnce(new Error("viewer unavailable"));
+
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(5_100);
+	});
+	expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).toContain(
+		"viewer_connection_lost",
+	);
+
+	mocks.loadSyncData.mockResolvedValueOnce(false);
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(1_600);
+	});
+	expect(mocks.loadSyncData).toHaveBeenLastCalledWith({
+		requiredSurface: "health",
+		requireFreshSyncStatus: true,
+	});
+	expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).not.toContain(
+		"viewer_connection_restored",
+	);
+
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(5_100);
+	});
+	expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).toContain(
+		"viewer_connection_restored",
+	);
+}
+
+async function verifyDevicesRestorationWaitsForSyncRefresh(): Promise<void> {
+	const connectionEvents = await import("./components/diagnostics/viewer-connection-events");
+	connectionEvents.resetViewerConnectionEventsForTests();
+	mocks.loadHealthData.mockRejectedValueOnce(new Error("viewer unavailable"));
+	mocks.pingViewerReady.mockRejectedValueOnce(new Error("viewer unavailable"));
+
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(5_100);
+	});
+	expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).toContain(
+		"viewer_connection_lost",
+	);
+
+	mocks.loadSyncData.mockResolvedValueOnce(false);
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(1_600);
+	});
+	expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).not.toContain(
+		"viewer_connection_restored",
+	);
+
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(5_100);
+	});
+	expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).toContain(
+		"viewer_connection_restored",
+	);
+}
+
+async function verifyPairingRestorationWaitsForRefresh(): Promise<void> {
+	const { state } = await import("./lib/state");
+	const connectionEvents = await import("./components/diagnostics/viewer-connection-events");
+	connectionEvents.resetViewerConnectionEventsForTests();
+	state.activeTab = "advanced";
+	state.advancedSection = "sync";
+	state.syncPairingOpen = true;
+	mocks.loadHealthData.mockRejectedValueOnce(new Error("viewer unavailable"));
+	mocks.pingViewerReady.mockRejectedValueOnce(new Error("viewer unavailable"));
+
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(5_100);
+	});
+	mocks.loadPairingData.mockResolvedValueOnce(false);
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(1_600);
+	});
+	expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).not.toContain(
+		"viewer_connection_restored",
+	);
+
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(5_100);
+	});
+	expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).toContain(
+		"viewer_connection_restored",
+	);
+}
+
+async function verifyHiddenPairingFailureDoesNotBlockRestoration(): Promise<void> {
+	const { state } = await import("./lib/state");
+	const connectionEvents = await import("./components/diagnostics/viewer-connection-events");
+	connectionEvents.resetViewerConnectionEventsForTests();
+	state.syncPairingOpen = true;
+	mocks.loadHealthData.mockRejectedValueOnce(new Error("viewer unavailable"));
+	mocks.pingViewerReady.mockRejectedValueOnce(new Error("viewer unavailable"));
+
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(5_100);
+	});
+	mocks.loadPairingData.mockResolvedValue(false);
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(1_600);
+	});
+	expect(state.activeTab).toBe("devices");
+	expect(document.getElementById("refreshStatus")?.textContent).not.toBe("refresh failed");
+	expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).toContain(
+		"viewer_connection_restored",
+	);
+}
+
+async function verifyDevicesRestorationIgnoresAuxiliarySyncFailures(): Promise<void> {
+	const connectionEvents = await import("./components/diagnostics/viewer-connection-events");
+	connectionEvents.resetViewerConnectionEventsForTests();
+	mocks.loadHealthData.mockRejectedValueOnce(new Error("viewer unavailable"));
+	mocks.pingViewerReady.mockRejectedValueOnce(new Error("viewer unavailable"));
+
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(5_100);
+	});
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(1_600);
+	});
+	expect(mocks.loadSyncData).toHaveBeenLastCalledWith({ requiredSurface: "devices" });
+	expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).toContain(
+		"viewer_connection_restored",
+	);
+}
+
+async function setupDevicesAppTest() {
+	vi.useFakeTimers();
+	vi.clearAllMocks();
+	vi.resetModules();
+	localStorage.clear();
+	localStorage.setItem("codemem-theme", "light");
+	document.body.innerHTML = bodyMarkup();
+	window.location.hash = "devices";
+	mocks.loadProjectScopeInventory.mockResolvedValue({
+		projects: [
+			{
+				workspace_identity: "project-private",
+				identity_source: "git_remote",
+				display_project: "Codemem",
+				memory_count: 10,
+				read_only: false,
 			},
-			attemptId: "opaque-attempt",
-			state: "reviewing",
+		],
+		has_more: false,
+		limit: 250,
+		offset: 0,
+	});
+	mocks.loadRecipientPolicyIntent.mockResolvedValue(intent);
+	mocks.loadProjectsData.mockResolvedValue(true);
+	mocks.loadRecipientPolicySharingData.mockResolvedValue(true);
+	mocks.loadCoordinatorAdminData.mockResolvedValue(true);
+	mocks.loadPairingData.mockResolvedValue(true);
+	mocks.loadHealthData.mockResolvedValue(undefined);
+	mocks.loadSyncStatus.mockResolvedValue({});
+	mocks.pingViewerReady.mockResolvedValue(true);
+	mocks.loadLegacyTeamSetupDetail.mockResolvedValue({
+		version: 1,
+		candidate: {
+			candidateRef: "opaque-candidate-ref",
+			displayName: "Example Team",
+			status: "in_progress",
+			deviceCount: 0,
+			projectCount: 0,
 			unresolvedDeviceCount: 0,
 			unresolvedProjectCount: 0,
-			devices: [],
-			projects: [],
-			identityChoices: [],
-			actions: {
-				refresh: { enabled: true, blockedReason: null },
-				finish: { enabled: false, blockedReason: "setup_incomplete" },
+		},
+		attemptId: "opaque-attempt",
+		state: "reviewing",
+		unresolvedDeviceCount: 0,
+		unresolvedProjectCount: 0,
+		devices: [],
+		projects: [],
+		identityChoices: [],
+		actions: {
+			refresh: { enabled: true, blockedReason: null },
+			finish: { enabled: false, blockedReason: "setup_incomplete" },
+		},
+	});
+	if (expect.getState().currentTestName?.includes("first Devices load")) {
+		mocks.loadDeviceIdentityInventory.mockRejectedValue(new Error("inventory unavailable"));
+	} else {
+		mocks.loadDeviceIdentityInventory.mockResolvedValue(configuredDeviceInventory());
+	}
+	mocks.loadRecipientPolicyReconciliationStatus.mockResolvedValue({
+		version: 1,
+		items: [
+			{
+				canonicalProjectIdentity: "project-private",
+				state: "needs_attention",
+				label: "Needs attention",
+				explanation: "Current access remains in place until it is safe to retry.",
+				deliveredCopiesMayRemain: true,
+				revocationWarning: "internal warning",
 			},
-		});
-		if (expect.getState().currentTestName?.includes("first Devices load")) {
-			mocks.loadDeviceIdentityInventory.mockRejectedValue(new Error("inventory unavailable"));
-		} else {
-			mocks.loadDeviceIdentityInventory.mockResolvedValue(configuredDeviceInventory());
-		}
-		mocks.loadRecipientPolicyReconciliationStatus.mockResolvedValue({
-			version: 1,
-			items: [
+		],
+	});
+	mocks.loadSyncData.mockImplementation(async () => {
+		const { state } = await import("./lib/state");
+		state.lastSyncStatus = {
+			coordinator_enrollment_reconciliation_issues: { counts: { open: 2, resolved: 1 } },
+		};
+		state.lastSyncPeers = [
+			{
+				peer_device_id: "device-private",
+				runtime_version: "0.42.0",
+				runtime_version_observed_at: "2026-08-11T12:00:00.000Z",
+				status: { peer_state: "online", fresh: true },
+			},
+			{
+				peer_device_id: "unmatched-paired-device",
+				runtime_version: "9.9.9",
+				runtime_version_observed_at: "2026-08-11T12:00:00.000Z",
+				status: { peer_state: "online", fresh: true },
+			},
+		];
+		state.lastSyncCoordinator = {
+			discovered_devices: [
 				{
-					canonicalProjectIdentity: "project-private",
-					state: "needs_attention",
-					label: "Needs attention",
-					explanation: "Current access remains in place until it is safe to retry.",
-					deliveredCopiesMayRemain: true,
-					revocationWarning: "internal warning",
+					device_id: "coordinator-only-device",
+					display_name: "Coordinator Tablet",
+					stale: false,
 				},
 			],
-		});
-		mocks.loadSyncData.mockImplementation(async () => {
-			const { state } = await import("./lib/state");
-			state.lastSyncStatus = {
-				coordinator_enrollment_reconciliation_issues: { counts: { open: 2, resolved: 1 } },
-			};
-			state.lastSyncPeers = [
-				{
-					peer_device_id: "device-private",
-					runtime_version: "0.42.0",
-					runtime_version_observed_at: "2026-08-11T12:00:00.000Z",
-					status: { peer_state: "online", fresh: true },
-				},
-				{
-					peer_device_id: "unmatched-paired-device",
-					runtime_version: "9.9.9",
-					runtime_version_observed_at: "2026-08-11T12:00:00.000Z",
-					status: { peer_state: "online", fresh: true },
-				},
-			];
-			state.lastSyncCoordinator = {
-				discovered_devices: [
-					{
-						device_id: "coordinator-only-device",
-						display_name: "Coordinator Tablet",
-						stale: false,
-					},
-				],
-			};
-		});
-		await import("./app");
-		await act(async () => {
-			await vi.advanceTimersByTimeAsync(100);
-		});
+		};
+		return true;
 	});
+	await import("./app");
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(100);
+	});
+}
 
+describe("Devices app integration", () => {
+	beforeEach(setupDevicesAppTest);
 	afterEach(() => {
 		vi.clearAllTimers();
 		vi.useRealTimers();
@@ -567,6 +770,97 @@ describe("Devices app integration", () => {
 		expect(document.getElementById("refreshStatus")?.dataset.refreshState).toBe("idle");
 	});
 
+	it("records restoration only after the active Devices refresh succeeds", async () => {
+		const connectionEvents = await import("./components/diagnostics/viewer-connection-events");
+		connectionEvents.resetViewerConnectionEventsForTests();
+		mocks.loadHealthData.mockRejectedValueOnce(new Error("viewer unavailable"));
+		mocks.pingViewerReady.mockRejectedValueOnce(new Error("viewer unavailable"));
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(5_100);
+		});
+		expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).toContain(
+			"viewer_connection_lost",
+		);
+
+		mocks.loadRecipientPolicyIntent.mockRejectedValueOnce(new Error("refresh failed"));
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(1_600);
+		});
+		expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).not.toContain(
+			"viewer_connection_restored",
+		);
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(5_100);
+		});
+		expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).toContain(
+			"viewer_connection_restored",
+		);
+	});
+
+	it(
+		"waits for a queued new-tab refresh before recording restoration",
+		verifyRestorationWaitsForQueuedActiveTabRefresh,
+	);
+
+	it(
+		"records restoration only after the active Health sync refresh succeeds",
+		verifyHealthRestorationWaitsForSyncRefresh,
+	);
+	it(
+		"records restoration only after the active Devices sync refresh succeeds",
+		verifyDevicesRestorationWaitsForSyncRefresh,
+	);
+
+	it.each(["sync", "teams"] as const)(
+		"records restoration only after the active Advanced %s refresh succeeds",
+		async (advancedSection) => {
+			const { state } = await import("./lib/state");
+			const connectionEvents = await import("./components/diagnostics/viewer-connection-events");
+			connectionEvents.resetViewerConnectionEventsForTests();
+			state.activeTab = "advanced";
+			state.advancedSection = advancedSection;
+			mocks.loadHealthData.mockRejectedValueOnce(new Error("viewer unavailable"));
+			mocks.pingViewerReady.mockRejectedValueOnce(new Error("viewer unavailable"));
+
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(5_100);
+			});
+			if (advancedSection === "sync") mocks.loadSyncData.mockResolvedValueOnce(false);
+			if (advancedSection === "teams") mocks.loadCoordinatorAdminData.mockResolvedValueOnce(false);
+
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(1_600);
+			});
+			expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).not.toContain(
+				"viewer_connection_restored",
+			);
+
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(5_100);
+			});
+			expect(connectionEvents.getViewerConnectionEvents().map((event) => event.code)).toContain(
+				"viewer_connection_restored",
+			);
+		},
+	);
+
+	it(
+		"records restoration only after an open pairing panel refresh succeeds",
+		verifyPairingRestorationWaitsForRefresh,
+	);
+
+	it(
+		"ignores a hidden pairing panel failure when recording restoration",
+		verifyHiddenPairingFailureDoesNotBlockRestoration,
+	);
+
+	it(
+		"scopes the Devices sync refresh to the Devices surface",
+		verifyDevicesRestorationIgnoresAuxiliarySyncFailures,
+	);
+
 	it("uses a fresh Devices inventory instead of accepting cached Sync ownership", async () => {
 		const { state } = await import("./lib/state");
 		state.lastDeviceIdentityInventory = {
@@ -590,6 +884,7 @@ describe("Devices app integration", () => {
 		mocks.loadDeviceIdentityInventory.mockClear();
 		mocks.loadSyncData.mockImplementationOnce(async () => {
 			state.deviceIdentityInventoryLoadError = true;
+			return true;
 		});
 
 		await act(async () => {

--- a/packages/ui/src/app.ts
+++ b/packages/ui/src/app.ts
@@ -15,6 +15,7 @@ import {
 	coordinatedRefreshDiagnosticsDrawer,
 	initDiagnosticsEntryPoints,
 	mountDiagnosticsDrawer,
+	recordViewerConnectionEvent,
 } from "./components/diagnostics";
 import { mountToastHost } from "./components/primitives/toast";
 import * as api from "./lib/api";
@@ -92,6 +93,7 @@ const LEGACY_UPGRADE_NOTICE_DISMISSED_KEY = "codemem-legacy-upgrade-notice-dismi
 
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let reconnecting = false;
+let viewerIncidentAwaitingRefresh = false;
 let legacyUpgradeNoticeShown = false;
 let legacyUpgradeNoticePreviousFocus: HTMLElement | null = null;
 
@@ -259,9 +261,25 @@ function canResumeRefresh() {
 	return document.visibilityState !== "hidden" && !isSettingsOpen();
 }
 
+function activeRefreshSurface(): string {
+	return `${state.activeTab}:${state.advancedSection}:${state.syncPairingOpen}`;
+}
+
+function recordViewerRestoredAfterSuccessfulRefresh(options: {
+	refreshSucceeded: boolean;
+	surface: string;
+}): void {
+	if (state.refreshQueued || options.surface !== activeRefreshSurface()) return;
+	if (!options.refreshSucceeded || !viewerIncidentAwaitingRefresh || reconnecting) return;
+	viewerIncidentAwaitingRefresh = false;
+	recordViewerConnectionEvent("connection_restored");
+}
+
 function scheduleReconnectLoop() {
 	if (reconnecting) return;
 	reconnecting = true;
+	viewerIncidentAwaitingRefresh = true;
+	recordViewerConnectionEvent("connection_lost");
 	stopPolling();
 	closeDiagnosticsDrawer();
 	setRefreshStatus("error", "(reconnecting)");
@@ -621,7 +639,7 @@ async function runLoadDevicesData(mount: HTMLElement, revision: number): Promise
 		});
 	}
 	try {
-		const [projects, intent, reconciliation, inventoryResult] = await Promise.all([
+		const [projects, intent, reconciliation, inventoryResult, syncRefreshed] = await Promise.all([
 			loadRecipientPolicyProjects(),
 			api.loadRecipientPolicyIntent(),
 			api.loadRecipientPolicyReconciliationStatus(),
@@ -629,7 +647,7 @@ async function runLoadDevicesData(mount: HTMLElement, revision: number): Promise
 				.loadDeviceIdentityInventory()
 				.then((inventory) => ({ inventory, unavailable: false }))
 				.catch(() => ({ inventory: lastDevicesData?.inventory, unavailable: true })),
-			loadSyncData(),
+			loadSyncData({ requiredSurface: "devices" }),
 		]);
 		if (revision !== devicesLoadRevision) return latestDevicesLoad ?? false;
 		const availability = deriveDeviceAvailability();
@@ -665,7 +683,7 @@ async function runLoadDevicesData(mount: HTMLElement, revision: number): Promise
 			inventoryUnavailable: inventoryResult.unavailable,
 			coordinatorEnrollmentIssueCount,
 		};
-		return true;
+		return syncRefreshed;
 	} catch {
 		if (revision !== devicesLoadRevision) return latestDevicesLoad ?? false;
 		if (lastDevicesData) {
@@ -739,13 +757,24 @@ function appendTabRefreshTasks(
 	if (refreshTab === "devices") {
 		promises.push(loadDevicesData().then(recordBooleanResult));
 	}
-	if ((refreshTab === "advanced" && state.advancedSection === "sync") || refreshTab === "health") {
-		promises.push(loadSyncData());
+	if (refreshTab === "health") {
+		promises.push(
+			loadSyncData({
+				requiredSurface: "health",
+				requireFreshSyncStatus: viewerIncidentAwaitingRefresh,
+			}).then(recordBooleanResult),
+		);
+	}
+	if (refreshTab === "advanced" && state.advancedSection === "sync") {
+		promises.push(loadSyncData().then(recordBooleanResult));
 	}
 	if (refreshTab === "advanced" && state.advancedSection === "teams") {
-		promises.push(loadCoordinatorAdminData());
+		promises.push(loadCoordinatorAdminData().then(recordBooleanResult));
 	}
-	if (state.syncPairingOpen) promises.push(loadPairingData());
+	if (!state.syncPairingOpen) return;
+	const pairingVisible = refreshTab === "advanced" && state.advancedSection === "sync";
+	const pairingRefresh = loadPairingData();
+	promises.push(pairingVisible ? pairingRefresh.then(recordBooleanResult) : pairingRefresh);
 }
 
 async function refresh() {
@@ -755,7 +784,7 @@ async function refresh() {
 	refreshDebounceTimer = setTimeout(() => doRefresh(), 80);
 }
 
-async function doRefresh() {
+async function doRefresh(): Promise<void> {
 	if (reconnecting) return;
 	if (state.refreshInFlight) {
 		state.refreshQueued = true;
@@ -766,6 +795,7 @@ async function doRefresh() {
 	try {
 		setRefreshStatus("refreshing");
 		const refreshTab = state.activeTab;
+		const surface = activeRefreshSurface();
 		const promises: Promise<unknown>[] = [loadGlobalRefreshData()];
 		let activeTabRefreshSucceeded = true;
 		appendTabRefreshTasks(promises, refreshTab, (succeeded) => {
@@ -779,6 +809,10 @@ async function doRefresh() {
 		}
 		renderTabs(state.activeTab);
 		setRefreshStatus(activeTabRefreshSucceeded ? "idle" : "error");
+		recordViewerRestoredAfterSuccessfulRefresh({
+			refreshSucceeded: activeTabRefreshSucceeded,
+			surface,
+		});
 	} catch {
 		const ready = await isViewerReady();
 		if (!ready) {
@@ -843,6 +877,7 @@ initSettings(stopPolling, startPolling, () => refresh());
 loadProjects();
 
 $("viewerReconnectRetry")?.addEventListener("click", async () => {
+	recordViewerConnectionEvent("reconnect_requested");
 	setReconnectOverlay(true, "Checking whether the viewer server is back…");
 	const ready = await isViewerReady();
 	if (!ready) {

--- a/packages/ui/src/components/diagnostics/index.test.tsx
+++ b/packages/ui/src/components/diagnostics/index.test.tsx
@@ -1,6 +1,7 @@
 import { type ComponentChildren, render } from "preact";
 import { act } from "preact/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import staticHtml from "../../../static/index.html?raw";
 import type { DiagnosticEvent, DiagnosticEventsResponse } from "../../lib/api";
 import { DiagnosticEventsRequestError } from "../../lib/api/diagnostics";
 
@@ -39,7 +40,9 @@ import {
 	initDiagnosticsEntryPoints,
 	mountDiagnosticsDrawer,
 	openDiagnosticsDrawer,
+	recordViewerConnectionEvent,
 } from ".";
+import { resetViewerConnectionEventsForTests } from "./viewer-connection-events";
 
 function event(id: string, overrides: Partial<DiagnosticEvent> = {}): DiagnosticEvent {
 	return {
@@ -56,13 +59,14 @@ function event(id: string, overrides: Partial<DiagnosticEvent> = {}): Diagnostic
 function response(
 	items: DiagnosticEvent[] = [],
 	nextCursor: string | null = null,
+	generatedAt = "2026-09-07T12:00:01.000Z",
 ): DiagnosticEventsResponse {
 	return {
 		contract_version: 1,
 		items,
 		next_cursor: nextCursor,
 		redacted: true,
-		generated_at: "2026-09-07T12:00:01.000Z",
+		generated_at: generatedAt,
 	};
 }
 
@@ -72,6 +76,7 @@ function setup(loadEvents = vi.fn().mockResolvedValue(response())) {
 		<button class="tab-btn" id="tabBtn-advanced">Advanced</button>
 		<button id="healthOpenDiagnostics">View diagnostics</button>
 		<button id="syncOpenDiagnostics">Recent sync events</button>
+		<button id="viewerReconnectDiagnostics">View connection diagnostics</button>
 		<div id="diagnosticsDrawerMount"></div>
 	`;
 	const mount = document.getElementById("diagnosticsDrawerMount");
@@ -95,6 +100,7 @@ afterEach(() => {
 	dialogControls.onCloseAutoFocus = undefined;
 	dialogControls.onOpenAutoFocus = undefined;
 	dialogControls.onOpenChange = undefined;
+	resetViewerConnectionEventsForTests();
 	vi.restoreAllMocks();
 });
 
@@ -123,6 +129,20 @@ describe("diagnostics drawer", () => {
 		act(() => button("Reset filters").click());
 		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(3));
 		expect(loadEvents).toHaveBeenLastCalledWith(expect.objectContaining({ subsystem: undefined }));
+	});
+
+	it("ships a reconnect action that opens seeded viewer-session evidence", async () => {
+		expect(staticHtml).toContain('id="viewerReconnectDiagnostics"');
+		setup();
+		recordViewerConnectionEvent("connection_lost");
+		initDiagnosticsEntryPoints();
+
+		act(() => button("View connection diagnostics").click());
+
+		await vi.waitFor(() => expect(document.body.textContent).toContain("viewer_connection_lost"));
+		expect(
+			document.querySelector<HTMLSelectElement>('[aria-label="Diagnostic subsystem"]')?.value,
+		).toBe("viewer");
 	});
 
 	it("focuses the title, aborts on close, and restores trigger focus", async () => {
@@ -255,6 +275,39 @@ describe("diagnostics drawer automatic refresh", () => {
 });
 
 describe("diagnostics drawer paused actions", () => {
+	it("holds viewer-session events until updates resume", async () => {
+		setup(vi.fn().mockResolvedValue(response()));
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(button("Pause updates").disabled).toBe(false));
+		act(() => button("Pause updates").click());
+
+		act(() => recordViewerConnectionEvent("connection_lost"));
+
+		expect(document.body.textContent).not.toContain("viewer_connection_lost");
+		act(() => button("Resume updates").click());
+		await vi.waitFor(() => expect(document.body.textContent).toContain("viewer_connection_lost"));
+	});
+
+	it("keeps held viewer-session events hidden during paused retry", async () => {
+		const loadEvents = vi
+			.fn()
+			.mockResolvedValueOnce(response())
+			.mockRejectedValueOnce(new Error("refresh failed"))
+			.mockResolvedValue(response());
+		setup(loadEvents);
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(button("Pause updates").disabled).toBe(false));
+		await act(async () => coordinatedRefreshDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).not.toBeNull());
+		act(() => button("Pause updates").click());
+		act(() => recordViewerConnectionEvent("connection_lost"));
+
+		act(() => button("Retry").click());
+		await vi.waitFor(() => expect(loadEvents).toHaveBeenCalledTimes(3));
+
+		expect(document.body.textContent).not.toContain("viewer_connection_lost");
+	});
+
 	it("allows retry and filter requests while paused", async () => {
 		const loadEvents = vi
 			.fn()
@@ -305,22 +358,32 @@ describe("diagnostics drawer paused actions", () => {
 describe("diagnostics drawer updates and pagination", () => {
 	it("replaces mutable fields for a known event id during polling", async () => {
 		const refreshedEvent = event("one", {
+			occurred_at: "2026-09-07T12:00:04.000Z",
 			severity: "error",
+			code: "capture_backlog_blocked",
 			message: "The capture queue is blocked.",
 		});
+		const generatedAt = "2026-09-07T12:00:05.000Z";
 		const loadEvents = vi
 			.fn()
 			.mockResolvedValueOnce(response([event("one")], "older"))
-			.mockResolvedValueOnce(response([refreshedEvent]));
+			.mockResolvedValueOnce(response([refreshedEvent], null, generatedAt));
 		setup(loadEvents);
 		act(() => openDiagnosticsDrawer());
-		await vi.waitFor(() => expect(document.body.textContent).toContain("queue is growing"));
+		await vi.waitFor(() => expect(document.body.textContent).toContain("capture_backlog_growing"));
+		const list = document.querySelector<HTMLElement>(".diagnostics-event-list");
+		if (!list) throw new Error("event list missing");
+		list.scrollTop = 100;
 
 		await act(async () => coordinatedRefreshDiagnosticsDrawer());
 
 		expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(1);
-		expect(document.body.textContent).toContain("queue is blocked");
-		expect(document.body.textContent).not.toContain("queue is growing");
+		expect(document.body.textContent).toContain("capture_backlog_blocked");
+		expect(document.body.textContent).toContain("The capture queue is blocked.");
+		expect(document.body.textContent).not.toContain("capture_backlog_growing");
+		expect(document.querySelector(".diagnostics-generated-at")?.textContent).toContain(
+			new Date(generatedAt).toLocaleTimeString(),
+		);
 	});
 
 	it("queues polled events while reading older rows and shows them on request", async () => {
@@ -341,6 +404,22 @@ describe("diagnostics drawer updates and pagination", () => {
 
 		act(() => button("Show 1 new event").click());
 		expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(2);
+	});
+});
+
+describe("diagnostics drawer queued row details", () => {
+	it("does not offer filtered-out queued session events", async () => {
+		setup(vi.fn().mockResolvedValue(response([event("sync", { subsystem: "sync" })])));
+		act(() => openDiagnosticsDrawer({ subsystem: "sync" }));
+		await vi.waitFor(() => expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(1));
+		const list = document.querySelector<HTMLElement>(".diagnostics-event-list");
+		if (!list) throw new Error("event list missing");
+		list.scrollTop = 100;
+
+		act(() => recordViewerConnectionEvent("connection_lost"));
+
+		expect(document.body.textContent).not.toContain("Show 1 new event");
+		expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(1);
 	});
 
 	it("loads and reconciles technical details for queued server events", async () => {
@@ -377,7 +456,9 @@ describe("diagnostics drawer updates and pagination", () => {
 
 		expect(document.body.textContent).toContain("queued detail");
 	});
+});
 
+describe("diagnostics drawer queued promotion", () => {
 	it("removes queued events when a top-of-list poll promotes them", async () => {
 		const loadEvents = vi
 			.fn()
@@ -474,10 +555,133 @@ describe("diagnostics drawer retry history", () => {
 	});
 });
 
+describe("diagnostics drawer local evidence controls", () => {
+	it("keeps viewer events buffered before a paused clear hidden after resume", async () => {
+		setup(vi.fn().mockResolvedValue(response()));
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(button("Pause updates").disabled).toBe(false));
+		act(() => button("Pause updates").click());
+		act(() => recordViewerConnectionEvent("connection_lost"));
+
+		act(() => button("Clear view").click());
+		act(() => button("Resume updates").click());
+
+		await vi.waitFor(() => expect(button("Pause updates").disabled).toBe(false));
+		expect(document.body.textContent).not.toContain("viewer_connection_lost");
+		act(() => recordViewerConnectionEvent("reconnect_requested"));
+		expect(document.body.textContent).toContain("viewer_reconnect_requested");
+	});
+
+	it("keeps cleared session rows hidden until reopen while allowing later evidence", async () => {
+		recordViewerConnectionEvent("connection_lost");
+		const { loadEvents } = setup(vi.fn().mockResolvedValue(response([event("one")], "cursor")));
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(2));
+
+		act(() => button("Clear view").click());
+
+		expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(0);
+		expect(document.body.textContent).toContain("Not loaded yet");
+		await act(async () => coordinatedRefreshDiagnosticsDrawer());
+		expect(document.body.textContent).not.toContain("viewer_connection_lost");
+		expect(document.body.textContent).toContain("capture_backlog_growing");
+		for (const [options] of loadEvents.mock.calls) {
+			expect(options).not.toHaveProperty("method");
+		}
+		act(() => recordViewerConnectionEvent("reconnect_requested"));
+		expect(document.body.textContent).toContain("viewer_reconnect_requested");
+		act(() => button("Close").click());
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.body.textContent).toContain("viewer_connection_lost"));
+
+		expect(loadEvents).toHaveBeenCalledTimes(3);
+		act(() => button("Close").click());
+		await Promise.resolve();
+	});
+
+	it("warns and copies only visible redacted presentation fields", async () => {
+		const sensitiveEvent = event("opaque-id", {
+			recovery: { label: "Open Health", href: "#health", command: "private command" },
+			correlation: { kind: "session", label: "Safe session label" },
+			technical_detail: { available: true, text: "private technical detail" },
+		});
+		const hiddenEvent = event("hidden-id", {
+			subsystem: "sync",
+			message: "hidden sync message",
+		});
+		const queuedEvent = event("queued-id", { message: "queued capture message" });
+		setup(
+			vi
+				.fn()
+				.mockResolvedValueOnce(
+					response([{ ...sensitiveEvent, technical_detail: { available: false } }, hiddenEvent]),
+				)
+				.mockResolvedValueOnce(response([sensitiveEvent, hiddenEvent]))
+				.mockResolvedValueOnce(response([queuedEvent, sensitiveEvent, hiddenEvent]))
+				.mockResolvedValue(response([sensitiveEvent, hiddenEvent])),
+		);
+		const confirm = vi.spyOn(globalThis, "confirm").mockReturnValue(true);
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+		act(() => openDiagnosticsDrawer({ subsystem: "capture" }));
+		await vi.waitFor(() => expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(1));
+		act(() => button("Reveal technical details").click());
+		await vi.waitFor(() => expect(document.body.textContent).toContain("private technical detail"));
+		const list = document.querySelector<HTMLElement>(".diagnostics-event-list");
+		if (!list) throw new Error("event list missing");
+		list.scrollTop = 100;
+		await act(async () => coordinatedRefreshDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.body.textContent).toContain("Show 1 new event"));
+
+		await act(async () => button("Copy visible redacted events").click());
+
+		expect(confirm).toHaveBeenCalledWith(expect.stringContaining("sensitive operational context"));
+		const copied = String(writeText.mock.calls[0]?.[0]);
+		expect(copied).toContain('"recovery_label": "Open Health"');
+		expect(copied).toContain('"correlation_label": "Safe session label"');
+		expect(copied).not.toContain("opaque-id");
+		expect(copied).not.toContain("private command");
+		expect(copied).not.toContain("private technical detail");
+		expect(copied).not.toContain("hidden sync message");
+		expect(copied).not.toContain("queued capture message");
+		expect(document.body.textContent).toContain("Visible redacted events copied.");
+
+		const severity = document.querySelector<HTMLSelectElement>(
+			'[aria-label="Diagnostic severity"]',
+		);
+		if (!severity) throw new Error("severity filter missing");
+		severity.value = "warning";
+		act(() => {
+			severity.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		expect(document.body.textContent).not.toContain("Visible redacted events copied.");
+	});
+
+	it("reports clipboard failure without exposing copied content", async () => {
+		setup(vi.fn().mockResolvedValue(response([event("one")])));
+		vi.spyOn(globalThis, "confirm").mockReturnValue(true);
+		Object.defineProperty(navigator, "clipboard", {
+			configurable: true,
+			value: { writeText: vi.fn().mockRejectedValue(new Error("clipboard denied")) },
+		});
+		act(() => openDiagnosticsDrawer());
+		await vi.waitFor(() => expect(document.querySelectorAll(".diagnostics-event")).toHaveLength(1));
+
+		await act(async () => button("Copy visible redacted events").click());
+
+		expect(document.body.textContent).toContain(
+			"Visible events could not be copied. Check clipboard permission and try again.",
+		);
+		expect(document.body.textContent).not.toContain("clipboard denied");
+	});
+});
+
 describe("diagnostics drawer filters and pagination", () => {
 	it("refetches for filters and technical reveal, then bounds older pagination", async () => {
 		const firstPage = Array.from({ length: 50 }, (_, index) => event(`first-${index}`));
-		const olderPage = Array.from({ length: 250 }, (_, index) => event(`older-${index}`));
+		const olderPage = Array.from({ length: 250 }, (_, index) =>
+			event(`older-${index}`, { severity: "error" }),
+		);
 		const loadEvents = vi
 			.fn()
 			.mockResolvedValueOnce(response(firstPage, "cursor-one"))
@@ -532,6 +736,7 @@ describe("diagnostics drawer recovery navigation", () => {
 	it("closes and resets before following an allowlisted recovery hash", async () => {
 		window.location.hash = "";
 		const recoveryEvent = event("recovery", {
+			subsystem: "sync",
 			recovery: { href: "#health", label: "Open Health" },
 		});
 		const { loadEvents } = setup(vi.fn().mockResolvedValue(response([recoveryEvent])));

--- a/packages/ui/src/components/diagnostics/index.tsx
+++ b/packages/ui/src/components/diagnostics/index.tsx
@@ -8,6 +8,11 @@ import {
 } from "./use-diagnostics-drawer";
 import { DiagnosticsDrawerView } from "./view";
 
+export {
+	getViewerConnectionEvents,
+	recordViewerConnectionEvent,
+} from "./viewer-connection-events";
+
 type DrawerCommands = {
 	open: (options?: OpenDiagnosticsDrawerOptions) => void;
 	refresh: () => Promise<void>;
@@ -59,6 +64,12 @@ export function initDiagnosticsEntryPoints(): void {
 	document.getElementById("syncOpenDiagnostics")?.addEventListener("click", (event) => {
 		openDiagnosticsDrawer({
 			subsystem: "sync",
+			trigger: event.currentTarget as HTMLElement,
+		});
+	});
+	document.getElementById("viewerReconnectDiagnostics")?.addEventListener("click", (event) => {
+		openDiagnosticsDrawer({
+			subsystem: "viewer",
 			trigger: event.currentTarget as HTMLElement,
 		});
 	});

--- a/packages/ui/src/components/diagnostics/session-queue.test.ts
+++ b/packages/ui/src/components/diagnostics/session-queue.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import type { DiagnosticEvent } from "../../lib/api/diagnostics";
+import { diagnosticsDrawerReducer, initialDiagnosticsDrawerState } from "./state";
+
+function event(id: string, occurredAt: string): DiagnosticEvent {
+	return {
+		id,
+		occurred_at: occurredAt,
+		severity: "warning",
+		subsystem: "viewer",
+		code: "viewer_connection_lost",
+		message: "The viewer connection was interrupted. Automatic recovery started.",
+	};
+}
+
+describe("diagnostics drawer session queue", () => {
+	it("queues a recorded session event while older rows are being read", () => {
+		// Arrange: the visible session row must keep its current position.
+		const visible = event("visible", "2026-09-08T12:00:00.000Z");
+		const incoming = event("incoming", "2026-09-08T12:01:00.000Z");
+		const state = {
+			...initialDiagnosticsDrawerState(),
+			open: true,
+			sessionRows: [visible],
+		};
+
+		// Act
+		const queued = diagnosticsDrawerReducer(state, {
+			type: "session_event_recorded",
+			event: incoming,
+			readingOlder: true,
+		});
+
+		// Assert
+		expect(queued.sessionRows).toEqual([visible]);
+		expect(queued.queuedSessionRows).toEqual([incoming]);
+	});
+
+	it("queues refreshed session rows without shifting visible rows", () => {
+		// Arrange: refresh includes both an already-visible event and a new event.
+		const visible = event("visible", "2026-09-08T12:00:00.000Z");
+		const incoming = event("incoming", "2026-09-08T12:01:00.000Z");
+		const state = {
+			...initialDiagnosticsDrawerState(),
+			open: true,
+			sessionRows: [visible],
+		};
+
+		// Act
+		const queued = diagnosticsDrawerReducer(state, {
+			type: "refresh_session_rows",
+			events: [incoming, visible],
+			readingOlder: true,
+		});
+
+		// Assert
+		expect(queued.sessionRows).toEqual([visible]);
+		expect(queued.queuedSessionRows).toEqual([incoming]);
+	});
+
+	it("promotes queued session rows when the reader shows queued events", () => {
+		// Arrange
+		const visible = event("visible", "2026-09-08T12:00:00.000Z");
+		const incoming = event("incoming", "2026-09-08T12:01:00.000Z");
+		const state = {
+			...initialDiagnosticsDrawerState(),
+			open: true,
+			sessionRows: [visible],
+			queuedSessionRows: [incoming],
+		};
+
+		// Act
+		const shown = diagnosticsDrawerReducer(state, { type: "show_queued" });
+
+		// Assert
+		expect(shown.sessionRows).toEqual([incoming, visible]);
+		expect(shown.queuedSessionRows).toEqual([]);
+	});
+
+	it("does not queue session events while updates are paused", () => {
+		// Arrange
+		const state = {
+			...initialDiagnosticsDrawerState(),
+			open: true,
+			paused: true,
+		};
+
+		// Act
+		const unchanged = diagnosticsDrawerReducer(state, {
+			type: "session_event_recorded",
+			event: event("incoming", "2026-09-08T12:01:00.000Z"),
+			readingOlder: true,
+		});
+
+		// Assert
+		expect(unchanged).toBe(state);
+	});
+
+	it("keeps cleared session events hidden when a later refresh repeats them", () => {
+		// Arrange: clear both visible and queued session events from the view.
+		const visible = event("visible", "2026-09-08T12:00:00.000Z");
+		const queued = event("queued", "2026-09-08T12:01:00.000Z");
+		const cleared = diagnosticsDrawerReducer(
+			{
+				...initialDiagnosticsDrawerState(),
+				open: true,
+				sessionRows: [visible],
+				queuedSessionRows: [queued],
+			},
+			{ type: "clear_view", sessionEvents: [visible, queued] },
+		);
+
+		// Act
+		const refreshed = diagnosticsDrawerReducer(cleared, {
+			type: "refresh_session_rows",
+			events: [queued, visible],
+			readingOlder: true,
+		});
+
+		// Assert
+		expect(refreshed.sessionRows).toEqual([]);
+		expect(refreshed.queuedSessionRows).toEqual([]);
+		expect(refreshed.hiddenSessionIds).toEqual(["visible", "queued"]);
+	});
+});

--- a/packages/ui/src/components/diagnostics/state.ts
+++ b/packages/ui/src/components/diagnostics/state.ts
@@ -4,6 +4,7 @@ import type {
 	DiagnosticEventSubsystem,
 	DiagnosticEventsResponse,
 } from "../../lib/api/diagnostics";
+import { MAX_VIEWER_CONNECTION_EVENTS } from "./viewer-connection-events";
 
 export const PAGE_SIZE = 50;
 export const MAX_ROWS = 200;
@@ -17,6 +18,8 @@ export type DiagnosticsDrawerState = {
 	includeTechnical: boolean;
 	paused: boolean;
 	rows: DiagnosticEvent[];
+	sessionRows: DiagnosticEvent[];
+	queuedSessionRows: DiagnosticEvent[];
 	queuedRows: DiagnosticEvent[];
 	queuedNextCursor: string | null | undefined;
 	nextCursor: string | null;
@@ -24,6 +27,8 @@ export type DiagnosticsDrawerState = {
 	loading: boolean;
 	error: boolean;
 	announcement: string;
+	copyStatus: string;
+	hiddenSessionIds: string[];
 	queryRevision: number;
 	pollRevision: number;
 };
@@ -33,6 +38,7 @@ export type DiagnosticsDrawerAction =
 			type: "open";
 			severity: DiagnosticEventSeverity | "";
 			subsystem: DiagnosticEventSubsystem | "";
+			sessionRows: DiagnosticEvent[];
 	  }
 	| { type: "close" }
 	| { type: "set_severity"; severity: DiagnosticEventSeverity | "" }
@@ -48,7 +54,11 @@ export type DiagnosticsDrawerAction =
 			readingOlder: boolean;
 	  }
 	| { type: "request_failed"; mode: RequestMode; restartQuery: boolean }
-	| { type: "show_queued" };
+	| { type: "show_queued" }
+	| { type: "session_event_recorded"; event: DiagnosticEvent; readingOlder?: boolean }
+	| { type: "refresh_session_rows"; events: DiagnosticEvent[]; readingOlder?: boolean }
+	| { type: "clear_view"; sessionEvents: DiagnosticEvent[] }
+	| { type: "set_copy_status"; status: string };
 
 export function initialDiagnosticsDrawerState(): DiagnosticsDrawerState {
 	return {
@@ -58,6 +68,8 @@ export function initialDiagnosticsDrawerState(): DiagnosticsDrawerState {
 		includeTechnical: false,
 		paused: false,
 		rows: [],
+		sessionRows: [],
+		queuedSessionRows: [],
 		queuedRows: [],
 		queuedNextCursor: undefined,
 		nextCursor: null,
@@ -65,9 +77,33 @@ export function initialDiagnosticsDrawerState(): DiagnosticsDrawerState {
 		loading: false,
 		error: false,
 		announcement: "",
+		copyStatus: "",
+		hiddenSessionIds: [],
 		queryRevision: 0,
 		pollRevision: 0,
 	};
+}
+
+export function visibleDiagnosticRows(state: DiagnosticsDrawerState): DiagnosticEvent[] {
+	const matchingRows = [...state.sessionRows, ...state.rows]
+		.filter((event) => matchesDiagnosticFilters(state, event))
+		.sort((left, right) => Date.parse(right.occurred_at) - Date.parse(left.occurred_at));
+	return mergeUnique(matchingRows);
+}
+
+function matchesDiagnosticFilters(
+	state: Pick<DiagnosticsDrawerState, "severity" | "subsystem">,
+	event: DiagnosticEvent,
+): boolean {
+	if (state.severity && event.severity !== state.severity) return false;
+	return !state.subsystem || event.subsystem === state.subsystem;
+}
+
+export function queuedDiagnosticRowCount(state: DiagnosticsDrawerState): number {
+	const matchingSessionRows = state.queuedSessionRows.filter((event) =>
+		matchesDiagnosticFilters(state, event),
+	);
+	return state.queuedRows.length + matchingSessionRows.length;
 }
 
 export function mergeUnique(events: DiagnosticEvent[], maximum = MAX_ROWS): DiagnosticEvent[] {
@@ -111,6 +147,7 @@ function replaceQueryState(
 		loading: false,
 		error: false,
 		announcement: "",
+		copyStatus: "",
 		queryRevision: state.queryRevision + 1,
 	};
 }
@@ -166,7 +203,8 @@ function applyPollResponse(
 		rows,
 		queuedRows,
 		queuedNextCursor: response.next_cursor,
-		announcement: `${queuedRows.length} new diagnostic events are waiting.`,
+		announcement:
+			queuedRows.length > 0 ? `${queuedRows.length} new diagnostic events are waiting.` : "",
 	};
 }
 
@@ -212,16 +250,17 @@ function applyResponse(
 	return applyPollResponse(base, action.response, action.readingOlder);
 }
 
-export function diagnosticsDrawerReducer(
+function reduceDrawerQueryAction(
 	state: DiagnosticsDrawerState,
 	action: DiagnosticsDrawerAction,
-): DiagnosticsDrawerState {
+): DiagnosticsDrawerState | null {
 	if (action.type === "open") {
 		return {
 			...initialDiagnosticsDrawerState(),
 			open: true,
 			severity: action.severity,
 			subsystem: action.subsystem,
+			sessionRows: action.sessionRows,
 			queryRevision: state.queryRevision + 1,
 		};
 	}
@@ -249,6 +288,13 @@ export function diagnosticsDrawerReducer(
 			includeTechnical: true,
 		};
 	}
+	return null;
+}
+
+function reduceDrawerRequestAction(
+	state: DiagnosticsDrawerState,
+	action: DiagnosticsDrawerAction,
+): DiagnosticsDrawerState | null {
 	if (action.type === "request_started") {
 		return { ...state, loading: action.mode !== "poll" };
 	}
@@ -256,15 +302,102 @@ export function diagnosticsDrawerReducer(
 	if (action.type === "request_failed") {
 		return applyRequestFailure(state, action.mode, action.restartQuery);
 	}
+	return null;
+}
+
+function receiveSessionRows(
+	state: DiagnosticsDrawerState,
+	events: DiagnosticEvent[],
+	readingOlder = false,
+): DiagnosticsDrawerState {
+	if (state.paused || !state.open) return state;
+	const allowed = events.filter((event) => !state.hiddenSessionIds.includes(event.id));
+	if (!readingOlder) {
+		return {
+			...state,
+			sessionRows: mergeUnique(
+				[...allowed, ...state.queuedSessionRows, ...state.sessionRows],
+				MAX_VIEWER_CONNECTION_EVENTS,
+			),
+			queuedSessionRows: [],
+		};
+	}
+	const known = new Set(state.sessionRows.map((event) => event.id));
+	const queuedSessionRows = mergeUnique(
+		[...allowed.filter((event) => !known.has(event.id)), ...state.queuedSessionRows],
+		MAX_VIEWER_CONNECTION_EVENTS,
+	);
+	return { ...state, queuedSessionRows };
+}
+
+function reduceDrawerLocalAction(
+	state: DiagnosticsDrawerState,
+	action: DiagnosticsDrawerAction,
+): DiagnosticsDrawerState | null {
+	if (action.type === "session_event_recorded") {
+		return receiveSessionRows(state, [action.event], action.readingOlder);
+	}
+	if (action.type === "refresh_session_rows") {
+		return receiveSessionRows(state, action.events, action.readingOlder);
+	}
+	if (action.type === "clear_view") {
+		const hiddenSessionIds = [
+			...new Set([
+				...action.sessionEvents.map((event) => event.id),
+				...state.queuedSessionRows.map((event) => event.id),
+				...state.sessionRows.map((event) => event.id),
+				...state.hiddenSessionIds,
+			]),
+		].slice(0, MAX_VIEWER_CONNECTION_EVENTS);
+		return {
+			...state,
+			rows: [],
+			sessionRows: [],
+			queuedSessionRows: [],
+			queuedRows: [],
+			queuedNextCursor: undefined,
+			nextCursor: null,
+			generatedAt: null,
+			loading: false,
+			error: false,
+			announcement: "Diagnostics view cleared.",
+			copyStatus: "",
+			hiddenSessionIds,
+		};
+	}
+	if (action.type === "set_copy_status") {
+		return { ...state, copyStatus: action.status };
+	}
+	if (action.type !== "show_queued") return null;
+	return showQueuedRows(state);
+}
+
+function showQueuedRows(state: DiagnosticsDrawerState): DiagnosticsDrawerState {
 	const mergedRows = mergeUnique([...state.queuedRows, ...state.rows], MAX_ROWS + 1);
 	const rowsWereTrimmed = mergedRows.length > MAX_ROWS;
 	const useQueuedCursor = rowsWereTrimmed && state.queuedNextCursor !== undefined;
 	return {
 		...state,
 		rows: mergedRows.slice(0, MAX_ROWS),
+		sessionRows: mergeUnique(
+			[...state.queuedSessionRows, ...state.sessionRows],
+			MAX_VIEWER_CONNECTION_EVENTS,
+		),
+		queuedSessionRows: [],
 		queuedRows: [],
 		queuedNextCursor: undefined,
 		nextCursor: useQueuedCursor ? state.queuedNextCursor : state.nextCursor,
 		announcement: "",
 	};
+}
+
+export function diagnosticsDrawerReducer(
+	state: DiagnosticsDrawerState,
+	action: DiagnosticsDrawerAction,
+): DiagnosticsDrawerState {
+	const queryState = reduceDrawerQueryAction(state, action);
+	if (queryState) return queryState;
+	const requestState = reduceDrawerRequestAction(state, action);
+	if (requestState) return requestState;
+	return reduceDrawerLocalAction(state, action) ?? state;
 }

--- a/packages/ui/src/components/diagnostics/use-diagnostics-drawer.ts
+++ b/packages/ui/src/components/diagnostics/use-diagnostics-drawer.ts
@@ -5,6 +5,7 @@ import {
 	DiagnosticEventsRequestError,
 	type DiagnosticEventsResponse,
 	type DiagnosticRecoveryHref,
+	isDiagnosticRecoveryHref,
 	type LoadDiagnosticEventsOptions,
 	type loadDiagnosticEvents,
 } from "../../lib/api/diagnostics";
@@ -18,8 +19,13 @@ import {
 	mergeUnique,
 	PAGE_SIZE,
 	type RequestMode,
+	visibleDiagnosticRows,
 } from "./state";
 import { loadTechnicalHistory } from "./technical-history";
+import {
+	getViewerConnectionEvents,
+	subscribeToViewerConnectionEvents,
+} from "./viewer-connection-events";
 
 type EventLoader = typeof loadDiagnosticEvents;
 type RequestReason = "routine" | "retry";
@@ -40,7 +46,7 @@ function requestOptions(
 	state: ReturnType<typeof initialDiagnosticsDrawerState>,
 	signal: AbortSignal,
 ): LoadDiagnosticEventsOptions {
-	const remaining = MAX_ROWS - state.rows.length;
+	const remaining = MAX_ROWS - visibleDiagnosticRows(state).length;
 	return {
 		limit: mode === "older" ? Math.max(1, Math.min(PAGE_SIZE, remaining)) : PAGE_SIZE,
 		cursor: mode === "older" ? (state.nextCursor ?? undefined) : undefined,
@@ -51,7 +57,7 @@ function requestOptions(
 	};
 }
 
-async function loadForMode(
+function loadForMode(
 	loadEvents: EventLoader,
 	mode: RequestMode,
 	state: DiagnosticsDrawerState,
@@ -158,9 +164,8 @@ type DrawerActionContext = {
 	listRef: { current: HTMLDivElement | null };
 };
 
-function createDrawerActions(context: DrawerActionContext) {
-	const { state, dispatch, abortRequest, runRequest, openerRef, recoveryNavigationRef, listRef } =
-		context;
+function createLifecycleActions(context: DrawerActionContext) {
+	const { dispatch, abortRequest, openerRef, recoveryNavigationRef } = context;
 	return {
 		open(options: OpenDiagnosticsDrawerOptions = {}) {
 			abortRequest();
@@ -170,6 +175,7 @@ function createDrawerActions(context: DrawerActionContext) {
 				type: "open",
 				severity: options.severity ?? "",
 				subsystem: options.subsystem ?? "",
+				sessionRows: getViewerConnectionEvents(),
 			});
 		},
 		close() {
@@ -185,9 +191,15 @@ function createDrawerActions(context: DrawerActionContext) {
 				setTimeout(() => recoveryTabFocusTarget(href)?.focus(), 0);
 			});
 		},
-		refresh: () => runRequest("poll"),
-		retry: () => runRequest(state.rows.length > 0 ? "poll" : "replace", "retry"),
-		loadOlder: () => runRequest("older"),
+		restoreFocus(event: { preventDefault: () => void }) {
+			restoreDrawerFocus(event, openerRef, recoveryNavigationRef);
+		},
+	};
+}
+
+function createQueryActions(context: DrawerActionContext) {
+	const { state, dispatch, abortRequest } = context;
+	return {
 		setSeverity(severity: DiagnosticEventSeverity | "") {
 			abortRequest();
 			dispatch({ type: "set_severity", severity });
@@ -208,14 +220,76 @@ function createDrawerActions(context: DrawerActionContext) {
 			abortRequest();
 			dispatch({ type: "reveal_technical" });
 		},
+	};
+}
+
+async function copyVisibleEvents(
+	state: DiagnosticsDrawerState,
+	dispatch: DrawerActionContext["dispatch"],
+): Promise<void> {
+	if (
+		!globalThis.confirm(
+			"Copied diagnostics may contain sensitive operational context. Copy the visible redacted events?",
+		)
+	) {
+		return;
+	}
+	const payload = serializeVisibleEvents(visibleDiagnosticRows(state));
+	try {
+		await navigator.clipboard.writeText(payload);
+		dispatch({ type: "set_copy_status", status: "Visible redacted events copied." });
+	} catch {
+		dispatch({
+			type: "set_copy_status",
+			status: "Visible events could not be copied. Check clipboard permission and try again.",
+		});
+	}
+}
+
+function createEvidenceActions(context: DrawerActionContext) {
+	const { state, dispatch, abortRequest, listRef } = context;
+	return {
 		showQueued() {
 			dispatch({ type: "show_queued" });
 			if (listRef.current) listRef.current.scrollTop = 0;
 		},
-		restoreFocus(event: { preventDefault: () => void }) {
-			restoreDrawerFocus(event, openerRef, recoveryNavigationRef);
+		clearView() {
+			abortRequest();
+			dispatch({ type: "clear_view", sessionEvents: getViewerConnectionEvents() });
 		},
+		copyVisibleEvents: () => copyVisibleEvents(state, dispatch),
 	};
+}
+
+function createDrawerActions(context: DrawerActionContext) {
+	return {
+		...createLifecycleActions(context),
+		refresh: () => context.runRequest("poll"),
+		retry: () => context.runRequest(context.state.rows.length > 0 ? "poll" : "replace", "retry"),
+		loadOlder: () => context.runRequest("older"),
+		...createQueryActions(context),
+		...createEvidenceActions(context),
+	};
+}
+
+export function serializeVisibleEvents(events: ReturnType<typeof visibleDiagnosticRows>): string {
+	return JSON.stringify(
+		events.map((event) => {
+			const recoveryIsDisplayed =
+				isDiagnosticRecoveryHref(event.recovery?.href) || Boolean(event.recovery?.command);
+			return {
+				occurred_at: event.occurred_at,
+				severity: event.severity,
+				subsystem: event.subsystem,
+				code: event.code,
+				message: event.message,
+				...(recoveryIsDisplayed ? { recovery_label: event.recovery?.label } : {}),
+				...(event.correlation?.label ? { correlation_label: event.correlation.label } : {}),
+			};
+		}),
+		null,
+		2,
+	);
 }
 
 function useRequestRefs(state: DiagnosticsDrawerState) {
@@ -246,12 +320,16 @@ function useQueryRequests(state: DiagnosticsDrawerState, runRequest: RequestRunn
 	}, [state.includeTechnical, state.open]);
 }
 
-export function useDiagnosticsDrawer(loadEvents: EventLoader) {
-	const [state, dispatch] = useReducer(diagnosticsDrawerReducer, initialDiagnosticsDrawerState());
+type RequestRunnerOptions = {
+	state: DiagnosticsDrawerState;
+	dispatch: DrawerActionContext["dispatch"];
+	loadEvents: EventLoader;
+	listRef: DrawerActionContext["listRef"];
+};
+
+function useDiagnosticsRequestRunner(options: RequestRunnerOptions) {
+	const { state, dispatch, loadEvents, listRef } = options;
 	const { stateRef, requestRef, generationRef } = useRequestRefs(state);
-	const openerRef = useRef<HTMLElement | null>(null);
-	const recoveryNavigationRef = useRef(false);
-	const listRef = useRef<HTMLDivElement | null>(null);
 
 	function abortRequest() {
 		generationRef.current += 1;
@@ -270,6 +348,11 @@ export function useDiagnosticsDrawer(loadEvents: EventLoader) {
 
 	async function runRequest(mode: RequestMode, reason: RequestReason = "routine"): Promise<void> {
 		if (shouldSkipRequest(mode, reason)) return;
+		dispatch({
+			type: "refresh_session_rows",
+			events: getViewerConnectionEvents(),
+			readingOlder: isReadingOlder(listRef),
+		});
 		const controller = new AbortController();
 		requestRef.current?.controller.abort();
 		const generation = ++generationRef.current;
@@ -298,6 +381,28 @@ export function useDiagnosticsDrawer(loadEvents: EventLoader) {
 	}
 
 	useQueryRequests(state, runRequest);
+	return { abortRequest, runRequest };
+}
+
+export function useDiagnosticsDrawer(loadEvents: EventLoader) {
+	const [state, dispatch] = useReducer(diagnosticsDrawerReducer, initialDiagnosticsDrawerState());
+	const openerRef = useRef<HTMLElement | null>(null);
+	const recoveryNavigationRef = useRef(false);
+	const listRef = useRef<HTMLDivElement | null>(null);
+	const { abortRequest, runRequest } = useDiagnosticsRequestRunner({
+		state,
+		dispatch,
+		loadEvents,
+		listRef,
+	});
+	useEffect(
+		() =>
+			subscribeToViewerConnectionEvents((event) => {
+				dispatch({ type: "session_event_recorded", event, readingOlder: isReadingOlder(listRef) });
+			}),
+		[],
+	);
+
 	const actions = createDrawerActions({
 		state,
 		dispatch,
@@ -307,5 +412,5 @@ export function useDiagnosticsDrawer(loadEvents: EventLoader) {
 		recoveryNavigationRef,
 		listRef,
 	});
-	return { state, listRef, ...actions };
+	return { state, visibleRows: visibleDiagnosticRows(state), listRef, ...actions };
 }

--- a/packages/ui/src/components/diagnostics/view.tsx
+++ b/packages/ui/src/components/diagnostics/view.tsx
@@ -9,7 +9,7 @@ import {
 } from "../../lib/api/diagnostics";
 import { DialogCloseButton } from "../primitives/dialog-close-button";
 import { RadixDialog, RadixDialogTitle } from "../primitives/radix-dialog";
-import { MAX_ROWS } from "./state";
+import { MAX_ROWS, queuedDiagnosticRowCount } from "./state";
 import type { useDiagnosticsDrawer } from "./use-diagnostics-drawer";
 
 type DrawerController = ReturnType<typeof useDiagnosticsDrawer>;
@@ -143,14 +143,27 @@ function DrawerControls({ controller }: { controller: DrawerController }) {
 				</button>
 			</div>
 			<div className="diagnostics-secondary-controls">
-				<button
-					className="settings-button"
-					disabled={state.includeTechnical || state.loading}
-					onClick={controller.revealTechnical}
-					type="button"
-				>
-					{state.includeTechnical ? "Technical details shown" : "Reveal technical details"}
-				</button>
+				<div className="diagnostics-secondary-actions">
+					<button
+						className="settings-button"
+						disabled={state.includeTechnical || state.loading}
+						onClick={controller.revealTechnical}
+						type="button"
+					>
+						{state.includeTechnical ? "Technical details shown" : "Reveal technical details"}
+					</button>
+					<button className="settings-button" onClick={controller.clearView} type="button">
+						Clear view
+					</button>
+					<button
+						className="settings-button"
+						disabled={!controller.visibleRows.length}
+						onClick={() => void controller.copyVisibleEvents()}
+						type="button"
+					>
+						Copy visible redacted events
+					</button>
+				</div>
 				<span className="diagnostics-generated-at">
 					{state.generatedAt
 						? `Generated ${new Date(state.generatedAt).toLocaleTimeString()}`
@@ -163,11 +176,15 @@ function DrawerControls({ controller }: { controller: DrawerController }) {
 
 function DrawerNotices({ controller }: { controller: DrawerController }) {
 	const { state } = controller;
+	const queuedCount = queuedDiagnosticRowCount(state);
 	const staleLabel = state.error && state.rows.length ? "Showing stale events." : "";
 	return (
 		<>
 			<div aria-atomic="true" aria-live="polite" className="sr-only">
 				{state.announcement}
+			</div>
+			<div aria-atomic="true" aria-live="polite" className="diagnostics-copy-status">
+				{state.copyStatus}
 			</div>
 			{state.subsystem || state.severity ? (
 				<div className="diagnostics-filter-context">
@@ -189,9 +206,9 @@ function DrawerNotices({ controller }: { controller: DrawerController }) {
 					</button>
 				</div>
 			) : null}
-			{state.queuedRows.length ? (
+			{queuedCount ? (
 				<button className="diagnostics-new-events" onClick={controller.showQueued} type="button">
-					Show {state.queuedRows.length} new {state.queuedRows.length === 1 ? "event" : "events"}
+					Show {queuedCount} new {queuedCount === 1 ? "event" : "events"}
 				</button>
 			) : null}
 		</>
@@ -200,12 +217,13 @@ function DrawerNotices({ controller }: { controller: DrawerController }) {
 
 function DrawerEventList({ controller }: { controller: DrawerController }) {
 	const { state } = controller;
+	const rows = controller.visibleRows;
 	const hasFilters = Boolean(state.severity || state.subsystem);
-	const canLoadOlder = Boolean(state.nextCursor) && state.rows.length < MAX_ROWS && !state.loading;
+	const canLoadOlder = Boolean(state.nextCursor) && rows.length < MAX_ROWS && !state.loading;
 	return (
 		<div className="diagnostics-event-list" ref={controller.listRef}>
-			{state.loading && !state.rows.length ? <LoadingRows /> : null}
-			{!state.loading && !state.error && !state.rows.length ? (
+			{state.loading && !rows.length ? <LoadingRows /> : null}
+			{!state.loading && !state.error && !rows.length ? (
 				<div className="diagnostics-empty">
 					<p>No events match the recent retained window.</p>
 					{hasFilters ? (
@@ -215,9 +233,9 @@ function DrawerEventList({ controller }: { controller: DrawerController }) {
 					) : null}
 				</div>
 			) : null}
-			{state.rows.length ? (
+			{rows.length ? (
 				<ul aria-label="Diagnostic events">
-					{state.rows.map((event) => (
+					{rows.map((event) => (
 						<DiagnosticsEventRow
 							event={event}
 							includeTechnical={state.includeTechnical}
@@ -236,7 +254,7 @@ function DrawerEventList({ controller }: { controller: DrawerController }) {
 					Load older
 				</button>
 			) : null}
-			{state.rows.length >= MAX_ROWS ? (
+			{rows.length >= MAX_ROWS ? (
 				<div className="diagnostics-limit-note">Showing the newest {MAX_ROWS} events.</div>
 			) : null}
 		</div>

--- a/packages/ui/src/components/diagnostics/viewer-connection-events.test.ts
+++ b/packages/ui/src/components/diagnostics/viewer-connection-events.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	diagnosticsDrawerReducer,
+	initialDiagnosticsDrawerState,
+	visibleDiagnosticRows,
+} from "./state";
+import {
+	getViewerConnectionEvents,
+	MAX_VIEWER_CONNECTION_EVENTS,
+	recordViewerConnectionEvent,
+	resetViewerConnectionEventsForTests,
+} from "./viewer-connection-events";
+
+afterEach(() => resetViewerConnectionEventsForTests());
+
+describe("viewer connection diagnostic events", () => {
+	it("constructs fixed safe fields and deduplicates loss during one incident", () => {
+		recordViewerConnectionEvent("caller supplied text" as never);
+		recordViewerConnectionEvent("constructor" as never);
+		recordViewerConnectionEvent("toString" as never);
+		recordViewerConnectionEvent("connection_lost");
+		recordViewerConnectionEvent("connection_lost");
+
+		expect(getViewerConnectionEvents()).toEqual([
+			expect.objectContaining({
+				severity: "warning",
+				subsystem: "viewer",
+				code: "viewer_connection_lost",
+				message: "The viewer connection was interrupted. Automatic recovery started.",
+			}),
+		]);
+		expect(Object.keys(getViewerConnectionEvents()[0] ?? {}).sort()).toEqual([
+			"code",
+			"id",
+			"message",
+			"occurred_at",
+			"severity",
+			"subsystem",
+		]);
+	});
+
+	it("deduplicates consecutive reconnect requests", () => {
+		recordViewerConnectionEvent("reconnect_requested");
+		recordViewerConnectionEvent("reconnect_requested");
+
+		expect(getViewerConnectionEvents()).toHaveLength(1);
+		recordViewerConnectionEvent("connection_lost");
+		recordViewerConnectionEvent("reconnect_requested");
+		expect(getViewerConnectionEvents()).toHaveLength(3);
+	});
+
+	it("keeps the newest twenty events and starts a new incident after restoration", () => {
+		for (let index = 0; index < 12; index += 1) {
+			recordViewerConnectionEvent("connection_lost");
+			recordViewerConnectionEvent("connection_restored");
+		}
+
+		const events = getViewerConnectionEvents();
+		expect(events).toHaveLength(MAX_VIEWER_CONNECTION_EVENTS);
+		expect(events[0]?.code).toBe("viewer_connection_restored");
+		expect(events[1]?.code).toBe("viewer_connection_lost");
+	});
+
+	it("applies active severity and subsystem filters to session rows locally", () => {
+		recordViewerConnectionEvent("connection_lost");
+		const openState = diagnosticsDrawerReducer(initialDiagnosticsDrawerState(), {
+			type: "open",
+			severity: "error",
+			subsystem: "viewer",
+			sessionRows: getViewerConnectionEvents(),
+		});
+
+		expect(visibleDiagnosticRows(openState)).toEqual([]);
+		expect(
+			visibleDiagnosticRows({ ...openState, severity: "warning", subsystem: "capture" }),
+		).toEqual([]);
+		expect(visibleDiagnosticRows({ ...openState, severity: "warning" })).toHaveLength(1);
+	});
+});

--- a/packages/ui/src/components/diagnostics/viewer-connection-events.ts
+++ b/packages/ui/src/components/diagnostics/viewer-connection-events.ts
@@ -1,0 +1,73 @@
+import type { DiagnosticEvent } from "../../lib/api/diagnostics";
+
+export type ViewerConnectionEventKind =
+	| "connection_lost"
+	| "reconnect_requested"
+	| "connection_restored";
+
+export const MAX_VIEWER_CONNECTION_EVENTS = 20;
+
+const EVENT_PRESENTATION: Record<
+	ViewerConnectionEventKind,
+	Pick<DiagnosticEvent, "code" | "message" | "severity" | "subsystem">
+> = {
+	connection_lost: {
+		code: "viewer_connection_lost",
+		message: "The viewer connection was interrupted. Automatic recovery started.",
+		severity: "warning",
+		subsystem: "viewer",
+	},
+	reconnect_requested: {
+		code: "viewer_reconnect_requested",
+		message: "A viewer reconnection check was requested.",
+		severity: "info",
+		subsystem: "viewer",
+	},
+	connection_restored: {
+		code: "viewer_connection_restored",
+		message: "The viewer connection and page data were restored.",
+		severity: "info",
+		subsystem: "viewer",
+	},
+};
+
+let activeIncident = false;
+let eventSequence = 0;
+let sessionEvents: DiagnosticEvent[] = [];
+const listeners = new Set<(event: DiagnosticEvent) => void>();
+
+export function getViewerConnectionEvents(): DiagnosticEvent[] {
+	return [...sessionEvents];
+}
+
+export function recordViewerConnectionEvent(kind: ViewerConnectionEventKind): void {
+	if (!Object.hasOwn(EVENT_PRESENTATION, kind)) return;
+	const presentation = EVENT_PRESENTATION[kind];
+	if (kind === "connection_lost" && activeIncident) return;
+	if (kind === "reconnect_requested" && sessionEvents[0]?.code === presentation.code) return;
+	if (kind === "connection_restored" && !activeIncident) return;
+
+	const occurredAt = new Date().toISOString();
+	const event: DiagnosticEvent = {
+		id: `viewer-session-${Date.now()}-${++eventSequence}`,
+		occurred_at: occurredAt,
+		...presentation,
+	};
+	sessionEvents = [event, ...sessionEvents].slice(0, MAX_VIEWER_CONNECTION_EVENTS);
+	if (kind === "connection_lost") activeIncident = true;
+	if (kind === "connection_restored") activeIncident = false;
+	for (const listener of listeners) listener(event);
+}
+
+export function subscribeToViewerConnectionEvents(
+	listener: (event: DiagnosticEvent) => void,
+): () => void {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}
+
+export function resetViewerConnectionEventsForTests(): void {
+	activeIncident = false;
+	eventSequence = 0;
+	sessionEvents = [];
+}

--- a/packages/ui/src/lib/api/diagnostics.test.ts
+++ b/packages/ui/src/lib/api/diagnostics.test.ts
@@ -83,6 +83,7 @@ describe("diagnostics API", () => {
 		validResponse({ contract_version: 2 }),
 		validResponse({ items: null }),
 		validResponse({ next_cursor: 3 }),
+		validResponse({ redacted: false }),
 		validResponse({ redacted: "yes" }),
 		validResponse({ generated_at: null }),
 	])("rejects an unsupported top-level response shape", async (payload) => {

--- a/packages/ui/src/lib/api/diagnostics.ts
+++ b/packages/ui/src/lib/api/diagnostics.ts
@@ -152,7 +152,7 @@ function parseDiagnosticEventsResponse(value: unknown): DiagnosticEventsResponse
 		if (!isBoundedString(value.next_cursor, MAX_CURSOR_LENGTH)) return null;
 		nextCursor = value.next_cursor;
 	}
-	if (typeof value.redacted !== "boolean" || !isTimestamp(value.generated_at)) return null;
+	if (value.redacted !== true || !isTimestamp(value.generated_at)) return null;
 	return {
 		contract_version: 1,
 		items: value.items.filter(isDiagnosticEvent),

--- a/packages/ui/src/tabs/coordinator-admin/lifecycle.test.tsx
+++ b/packages/ui/src/tabs/coordinator-admin/lifecycle.test.tsx
@@ -169,8 +169,9 @@ describe("coordinator administration recovery lifecycle", () => {
 			],
 		});
 
-		await loadCoordinatorAdminData();
+		const refreshed = await loadCoordinatorAdminData();
 
+		expect(refreshed).toBe(true);
 		expect(coordinatorAdminState.unnamedDeviceAliases.aliases.get("join-unnamed")).toBe(
 			"Unnamed device 2",
 		);
@@ -207,8 +208,9 @@ describe("coordinator administration recovery lifecycle", () => {
 	it("marks first-load failures unavailable instead of treating them as empty snapshots", async () => {
 		mocks.loadCoordinatorAdminStatus.mockRejectedValue(new Error("secret backend detail"));
 
-		await loadCoordinatorAdminData();
+		const refreshed = await loadCoordinatorAdminData();
 
+		expect(refreshed).toBe(false);
 		expect(coordinatorAdminState.recovery.status.availability).toBe("unavailable");
 		expect(coordinatorAdminState.recovery.groups.availability).toBe("unavailable");
 		expect(surfaceHasSnapshot(coordinatorAdminState.recovery, "devices")).toBe(false);
@@ -360,16 +362,39 @@ describe("coordinator administration recovery lifecycle", () => {
 			});
 
 		const olderLoad = loadCoordinatorAdminData();
-		await loadCoordinatorAdminData();
+		const newerLoad = loadCoordinatorAdminData();
+		await expect(newerLoad).resolves.toBe(true);
 		olderStatus.resolve({
 			active_group: "group-old",
 			coordinator_url: "https://old.example",
 			readiness: "ready",
 		});
-		await olderLoad;
+		await expect(olderLoad).resolves.toBe(true);
 
 		expect(state.lastCoordinatorAdminStatus?.active_group).toBe("group-new");
 		expect(coordinatorAdminState.recovery.status.availability).toBe("fresh");
+	});
+
+	it("forwards an older load to the newer failed result", async () => {
+		const olderStatus = deferred<{
+			active_group: string;
+			coordinator_url: string;
+			readiness: "ready";
+		}>();
+		mocks.loadCoordinatorAdminStatus
+			.mockImplementationOnce(() => olderStatus.promise)
+			.mockRejectedValueOnce(new Error("newer refresh failed"));
+
+		const olderLoad = loadCoordinatorAdminData();
+		const newerLoad = loadCoordinatorAdminData();
+
+		await expect(newerLoad).resolves.toBe(false);
+		olderStatus.resolve({
+			active_group: "group-old",
+			coordinator_url: "https://old.example",
+			readiness: "ready",
+		});
+		await expect(olderLoad).resolves.toBe(false);
 	});
 
 	it("shares generation authority with the feed status writer", async () => {

--- a/packages/ui/src/tabs/coordinator-admin/lifecycle.ts
+++ b/packages/ui/src/tabs/coordinator-admin/lifecycle.ts
@@ -51,7 +51,9 @@ const {
 	runDeviceAction,
 } = createCoordinatorAdminActions({
 	renderShell: () => renderShell(),
-	reloadData: () => loadCoordinatorAdminData(),
+	reloadData: async () => {
+		await loadCoordinatorAdminData();
+	},
 });
 
 function renderShell() {
@@ -306,8 +308,21 @@ export function initCoordinatorAdminTab() {
 	renderShell();
 }
 
-export async function loadCoordinatorAdminData() {
+let latestCoordinatorAdminLoad: { generation: number; operation: Promise<boolean> } | null = null;
+
+function latestCoordinatorAdminLoadResult(generation: number): boolean | Promise<boolean> {
+	if (latestCoordinatorAdminLoad?.generation === generation) return false;
+	return latestCoordinatorAdminLoad?.operation ?? false;
+}
+
+export function loadCoordinatorAdminData(): Promise<boolean> {
 	const generation = beginCoordinatorAdminLoadGeneration();
+	const operation = runCoordinatorAdminLoad(generation);
+	latestCoordinatorAdminLoad = { generation, operation };
+	return operation;
+}
+
+async function runCoordinatorAdminLoad(generation: number): Promise<boolean> {
 	const isCurrent = () => isCurrentCoordinatorAdminLoadGeneration(generation);
 	if (!coordinatorAdminState.recoveryRetryRequested) {
 		coordinatorAdminState.recoveryAnnouncement = "";
@@ -318,7 +333,7 @@ export async function loadCoordinatorAdminData() {
 	beginSurfaceRefresh(coordinatorAdminState.recovery, "devices");
 	renderShell();
 	const statusResult = await refreshCoordinatorAdminStatusForGeneration(generation);
-	if (statusResult === "superseded") return;
+	if (statusResult === "superseded") return latestCoordinatorAdminLoadResult(generation);
 	const activeGroup = String(state.lastCoordinatorAdminStatus?.active_group || "").trim();
 	resolveAdminTargetGroup();
 	if (
@@ -327,10 +342,10 @@ export async function loadCoordinatorAdminData() {
 	) {
 		try {
 			const payload = await api.loadShareOperations();
-			if (!isCurrent()) return;
+			if (!isCurrent()) return latestCoordinatorAdminLoadResult(generation);
 			state.lastShareOperations = Array.isArray(payload.items) ? payload.items : [];
 		} catch {
-			if (!isCurrent()) return;
+			if (!isCurrent()) return latestCoordinatorAdminLoadResult(generation);
 			// Keep the previous read-only reflection; Coordinator Administration remains usable.
 		}
 		try {
@@ -339,14 +354,14 @@ export async function loadCoordinatorAdminData() {
 			)) as {
 				items?: typeof state.lastCoordinatorAdminGroups;
 			};
-			if (!isCurrent()) return;
+			if (!isCurrent()) return latestCoordinatorAdminLoadResult(generation);
 			if (!Array.isArray(groupsPayload?.items)) throw new Error("Invalid groups payload");
 			state.lastCoordinatorAdminGroups = groupsPayload.items;
 			completeSurfaceRefresh(coordinatorAdminState.recovery, "groups");
 			reconcileGroupRenameDrafts();
 			resolveAdminTargetGroup();
 		} catch {
-			if (!isCurrent()) return;
+			if (!isCurrent()) return latestCoordinatorAdminLoadResult(generation);
 			failSurfaceRefresh(coordinatorAdminState.recovery, "groups");
 		}
 		const targetGroup = currentAdminTargetGroup();
@@ -356,13 +371,13 @@ export async function loadCoordinatorAdminData() {
 			const payload = (await api.loadCoordinatorAdminJoinRequests(targetGroup || activeGroup)) as {
 				items?: typeof state.lastCoordinatorAdminJoinRequests;
 			};
-			if (!isCurrent()) return;
+			if (!isCurrent()) return latestCoordinatorAdminLoadResult(generation);
 			if (!Array.isArray(payload?.items)) throw new Error("Invalid join requests payload");
 			state.lastCoordinatorAdminJoinRequests = payload.items;
 			coordinatorAdminState.joinRequestsSnapshotTarget = snapshotTarget;
 			completeSurfaceRefresh(coordinatorAdminState.recovery, "joinRequests");
 		} catch {
-			if (!isCurrent()) return;
+			if (!isCurrent()) return latestCoordinatorAdminLoadResult(generation);
 			failSurfaceRefresh(
 				coordinatorAdminState.recovery,
 				"joinRequests",
@@ -377,14 +392,14 @@ export async function loadCoordinatorAdminData() {
 			)) as {
 				items?: typeof state.lastCoordinatorAdminDevices;
 			};
-			if (!isCurrent()) return;
+			if (!isCurrent()) return latestCoordinatorAdminLoadResult(generation);
 			if (!Array.isArray(devicesPayload?.items)) throw new Error("Invalid devices payload");
 			state.lastCoordinatorAdminDevices = devicesPayload.items;
 			coordinatorAdminState.devicesSnapshotTarget = snapshotTarget;
 			completeSurfaceRefresh(coordinatorAdminState.recovery, "devices");
 			reconcileDeviceRenameDrafts();
 		} catch {
-			if (!isCurrent()) return;
+			if (!isCurrent()) return latestCoordinatorAdminLoadResult(generation);
 			failSurfaceRefresh(
 				coordinatorAdminState.recovery,
 				"devices",
@@ -393,10 +408,10 @@ export async function loadCoordinatorAdminData() {
 		}
 		try {
 			const projects = await api.loadProjects();
-			if (!isCurrent()) return;
+			if (!isCurrent()) return latestCoordinatorAdminLoadResult(generation);
 			coordinatorAdminState.availableProjects = projects;
 		} catch {
-			if (!isCurrent()) return;
+			if (!isCurrent()) return latestCoordinatorAdminLoadResult(generation);
 			// Non-fatal — picker falls back to free-text entry.
 		}
 	} else if (coordinatorAdminState.recovery.status.availability === "fresh") {
@@ -418,7 +433,7 @@ export async function loadCoordinatorAdminData() {
 			adminSnapshotTargetMatchesCurrent(coordinatorAdminState.devicesSnapshotTarget),
 		);
 	}
-	if (!isCurrent()) return;
+	if (!isCurrent()) return latestCoordinatorAdminLoadResult(generation);
 	stableUnnamedDeviceAliases(
 		[
 			...state.lastCoordinatorAdminDevices,
@@ -447,4 +462,5 @@ export async function loadCoordinatorAdminData() {
 	}
 	coordinatorAdminState.recoveryRetryRequested = false;
 	renderShell();
+	return coordinatorAdminRecoveryNotice(coordinatorAdminState.recovery) === null;
 }

--- a/packages/ui/src/tabs/health-diagnostics-actions.test.ts
+++ b/packages/ui/src/tabs/health-diagnostics-actions.test.ts
@@ -1,0 +1,79 @@
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { state } from "../lib/state";
+
+const openDiagnosticsDrawer = vi.hoisted(() => vi.fn());
+
+vi.mock("../components/diagnostics", () => ({ openDiagnosticsDrawer }));
+vi.mock("../components/primitives/tooltip", () => ({
+	Tooltip: ({ children }: { children?: unknown }) => children,
+	TooltipProvider: ({ children }: { children?: unknown }) => children,
+}));
+
+import { renderHealthOverview } from "./health";
+
+function renderOverview(): void {
+	act(() => renderHealthOverview());
+}
+
+function findDiagnosticsAction(): HTMLButtonElement {
+	const action = [...document.querySelectorAll<HTMLButtonElement>("button")].find(
+		(button) => button.textContent === "View diagnostics",
+	);
+	if (!action) throw new Error("diagnostics action missing");
+	return action;
+}
+
+beforeEach(() => {
+	document.body.innerHTML = `
+		<div id="healthGrid"></div>
+		<div id="healthMeta"></div>
+		<div id="healthActions"></div>
+		<div id="healthDot"></div>
+	`;
+	state.lastStatsPayload = {};
+	state.lastUsagePayload = {};
+	state.lastRawEventsPayload = {};
+	state.lastSyncStatus = { enabled: false, daemon_state: "disabled" };
+	state.lastSyncPeers = [];
+	openDiagnosticsDrawer.mockReset();
+});
+
+afterEach(() => {
+	for (const id of ["healthGrid", "healthActions"]) {
+		const element = document.getElementById(id);
+		if (element) act(() => render(null, element));
+	}
+	document.body.innerHTML = "";
+});
+
+describe("Health diagnostics actions", () => {
+	it("opens capture diagnostics from the existing backlog threshold", () => {
+		state.lastRawEventsPayload = { pending: 200 };
+		renderOverview();
+
+		const trigger = findDiagnosticsAction();
+		trigger.click();
+
+		expect(openDiagnosticsDrawer).toHaveBeenCalledWith({ subsystem: "capture", trigger });
+	});
+
+	it("opens error-filtered maintenance diagnostics for an existing failed job", () => {
+		state.lastStatsPayload = {
+			maintenance_jobs: [
+				{ kind: "cleanup", title: "Cleanup", status: "failed", error: "private path" },
+			],
+		};
+		renderOverview();
+
+		const trigger = findDiagnosticsAction();
+		trigger.click();
+
+		expect(openDiagnosticsDrawer).toHaveBeenCalledWith({
+			severity: "error",
+			subsystem: "maintenance",
+			trigger,
+		});
+	});
+});

--- a/packages/ui/src/tabs/health/components.ts
+++ b/packages/ui/src/tabs/health/components.ts
@@ -230,7 +230,7 @@ export function HealthActionRow({ item }: HealthActionRowProps) {
 		actionButton.disabled = true;
 		actionButton.textContent = "Running…";
 		try {
-			await item.action();
+			await item.action(actionButton);
 		} catch {}
 		actionButton.disabled = false;
 		actionButton.textContent = actionLabel;

--- a/packages/ui/src/tabs/health/render/health-overview.ts
+++ b/packages/ui/src/tabs/health/render/health-overview.ts
@@ -4,6 +4,7 @@
  * The risk scoring and recommendation rules are the single source of
  * truth for the Health tab's "Overall health" status. */
 
+import { openDiagnosticsDrawer } from "../../../components/diagnostics";
 import * as api from "../../../lib/api";
 import {
 	formatAgeShort,
@@ -23,6 +24,20 @@ import {
 import type { HealthAction, HealthCardInput } from "../types";
 
 const SCOPE_BACKFILL_JOB = "scope_id_backfill";
+
+function appendFailedMaintenanceDiagnosticsAction(
+	recommendations: HealthAction[],
+	hasFailedMaintenance: boolean,
+): void {
+	if (!hasFailedMaintenance || recommendations.length >= 3) return;
+	recommendations.push({
+		label: "Background maintenance failed. Review recent safe failure evidence.",
+		command: "codemem maintenance status",
+		action: (trigger) =>
+			openDiagnosticsDrawer({ severity: "error", subsystem: "maintenance", trigger }),
+		actionLabel: "View diagnostics",
+	});
+}
 
 export function renderHealthOverview() {
 	const healthGrid = document.getElementById("healthGrid");
@@ -48,6 +63,7 @@ export function renderHealthOverview() {
 		progress?: { current?: number; total?: number | null; unit?: string };
 	}> = Array.isArray(stats.maintenance_jobs) ? stats.maintenance_jobs : [];
 	const scopeBackfillJob = maintenanceJobs.find((job) => job.kind === SCOPE_BACKFILL_JOB);
+	const hasFailedMaintenance = maintenanceJobs.some((job) => job.status === "failed");
 	const reliability = stats.reliability || {};
 	const counts = reliability.counts || {};
 	const rates = reliability.rates || {};
@@ -288,6 +304,8 @@ export function renderHealthOverview() {
 		recommendations.push({
 			label: "Pipeline needs attention. Check queue health first.",
 			command: "codemem db raw-events-status",
+			action: (trigger) => openDiagnosticsDrawer({ subsystem: "capture", trigger }),
+			actionLabel: "View diagnostics",
 		});
 		recommendations.push({
 			label: "Then retry failed batches for impacted sessions.",
@@ -322,6 +340,7 @@ export function renderHealthOverview() {
 			actionLabel: "Sync now",
 		});
 	}
+	appendFailedMaintenanceDiagnosticsAction(recommendations, hasFailedMaintenance);
 	if (tagCoverage > 0 && tagCoverage < 0.7 && recommendations.length < 2) {
 		recommendations.push({
 			label: "Tag coverage is low. Preview backfill impact.",

--- a/packages/ui/src/tabs/health/types.ts
+++ b/packages/ui/src/tabs/health/types.ts
@@ -7,7 +7,7 @@ export type HealthAction = {
 	label: string;
 	command: string;
 	/** If set, show an actionable button that triggers this async function. */
-	action?: () => Promise<void>;
+	action?: (trigger: HTMLButtonElement) => Promise<void> | void;
 	actionLabel?: string;
 };
 

--- a/packages/ui/src/tabs/settings/components/ObserverStatusBanner.test.tsx
+++ b/packages/ui/src/tabs/settings/components/ObserverStatusBanner.test.tsx
@@ -1,0 +1,34 @@
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ObserverStatusBanner } from "./ObserverStatusBanner";
+
+afterEach(() => {
+	act(() => render(null, document.body));
+	document.body.innerHTML = "";
+});
+
+describe("ObserverStatusBanner diagnostics action", () => {
+	it("offers a contextual action for a processing failure without forwarding raw error text", () => {
+		const onOpenDiagnostics = vi.fn();
+		act(() =>
+			render(
+				<ObserverStatusBanner
+					onOpenDiagnostics={onOpenDiagnostics}
+					status={{ latest_failure: { error_message: "private provider response" } }}
+				/>,
+				document.body,
+			),
+		);
+		const action = document.querySelector<HTMLButtonElement>("button");
+		if (!action) throw new Error("observer diagnostics action missing");
+
+		act(() => action.click());
+
+		expect(onOpenDiagnostics).toHaveBeenCalledWith({
+			severity: "error",
+			subsystem: "observer",
+		});
+		expect(JSON.stringify(onOpenDiagnostics.mock.calls)).not.toContain("private provider response");
+	});
+});

--- a/packages/ui/src/tabs/settings/components/ObserverStatusBanner.tsx
+++ b/packages/ui/src/tabs/settings/components/ObserverStatusBanner.tsx
@@ -21,7 +21,28 @@ export type ObserverStatusShape = {
 	} | null;
 };
 
-export function ObserverStatusBanner({ status }: { status: ObserverStatusShape | null }) {
+type ObserverDiagnosticsActionProps = {
+	onOpenDiagnostics?: (options: { severity: "error"; subsystem: "observer" }) => void;
+};
+
+type ObserverStatusBannerProps = ObserverDiagnosticsActionProps & {
+	status: ObserverStatusShape | null;
+};
+
+function ObserverDiagnosticsAction({ onOpenDiagnostics }: ObserverDiagnosticsActionProps) {
+	if (!onOpenDiagnostics) return null;
+	return (
+		<button
+			className="settings-button"
+			onClick={() => onOpenDiagnostics({ severity: "error", subsystem: "observer" })}
+			type="button"
+		>
+			View observer diagnostics
+		</button>
+	);
+}
+
+export function ObserverStatusBanner({ status, onOpenDiagnostics }: ObserverStatusBannerProps) {
 	if (!status) {
 		return <div id="observerStatusBanner" className="observer-status-banner" hidden />;
 	}
@@ -122,6 +143,7 @@ export function ObserverStatusBanner({ status }: { status: ObserverStatusShape |
 						{typeof failure.impact === "string" && failure.impact.trim() ? (
 							<div className="status-issue-impact">{failure.impact.trim()}</div>
 						) : null}
+						<ObserverDiagnosticsAction onOpenDiagnostics={onOpenDiagnostics} />
 					</div>
 				</>
 			) : null}

--- a/packages/ui/src/tabs/settings/lifecycle.test.tsx
+++ b/packages/ui/src/tabs/settings/lifecycle.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { state } from "../../lib/state";
+import { settingsState } from "./data/state";
+
+const openDiagnosticsDrawer = vi.hoisted(() => vi.fn());
+
+vi.mock("../../components/diagnostics", () => ({ openDiagnosticsDrawer }));
+
+import { openObserverDiagnosticsFromSettings } from "./lifecycle";
+
+const observerDiagnosticsOptions = {
+	severity: "error" as const,
+	subsystem: "observer" as const,
+};
+
+beforeEach(() => {
+	document.body.innerHTML = '<button id="settingsButton">Settings</button>';
+	state.settingsDirty = false;
+	settingsState.open = true;
+	settingsState.previouslyFocused = null;
+	settingsState.startPolling = vi.fn();
+	settingsState.refresh = vi.fn();
+	settingsState.controller = null;
+	openDiagnosticsDrawer.mockReset();
+});
+
+afterEach(() => {
+	document.body.innerHTML = "";
+	settingsState.open = false;
+	settingsState.startPolling = null;
+	settingsState.refresh = null;
+	settingsState.controller = null;
+	state.settingsDirty = false;
+	vi.restoreAllMocks();
+});
+
+describe("Settings observer diagnostics handoff", () => {
+	it("closes Settings before opening diagnostics in a microtask", async () => {
+		const startPolling = settingsState.startPolling;
+		const refresh = settingsState.refresh;
+
+		openObserverDiagnosticsFromSettings(observerDiagnosticsOptions);
+
+		expect(settingsState.open).toBe(false);
+		expect(startPolling).toHaveBeenCalledOnce();
+		expect(refresh).toHaveBeenCalledOnce();
+		expect(openDiagnosticsDrawer).not.toHaveBeenCalled();
+
+		await Promise.resolve();
+
+		expect(openDiagnosticsDrawer).toHaveBeenCalledWith({
+			...observerDiagnosticsOptions,
+			trigger: document.getElementById("settingsButton"),
+		});
+	});
+
+	it("keeps Settings open when discarding dirty changes is declined", async () => {
+		state.settingsDirty = true;
+		vi.spyOn(globalThis, "confirm").mockReturnValue(false);
+
+		openObserverDiagnosticsFromSettings(observerDiagnosticsOptions);
+		await Promise.resolve();
+
+		expect(settingsState.open).toBe(true);
+		expect(settingsState.startPolling).not.toHaveBeenCalled();
+		expect(settingsState.refresh).not.toHaveBeenCalled();
+		expect(openDiagnosticsDrawer).not.toHaveBeenCalled();
+	});
+});

--- a/packages/ui/src/tabs/settings/lifecycle.tsx
+++ b/packages/ui/src/tabs/settings/lifecycle.tsx
@@ -3,6 +3,7 @@
  * to SettingsDialogContent + the settingsState-driven handlers. */
 
 import { render } from "preact";
+import { openDiagnosticsDrawer } from "../../components/diagnostics";
 import * as api from "../../lib/api";
 import { $, $button } from "../../lib/dom";
 import { showGlobalNotice } from "../../lib/notice";
@@ -56,7 +57,23 @@ const { onTextInput, onSelectValueChange, onSwitchInput } = createSettingsEventH
 
 function ObserverStatusBanner() {
 	const status = settingsState.renderState.observerStatus as ObserverStatusShape | null;
-	return <ObserverStatusBannerComponent status={status} />;
+	return (
+		<ObserverStatusBannerComponent
+			status={status}
+			onOpenDiagnostics={openObserverDiagnosticsFromSettings}
+		/>
+	);
+}
+
+export function openObserverDiagnosticsFromSettings(options: {
+	severity: "error";
+	subsystem: "observer";
+}): void {
+	if (!settingsState.startPolling || !settingsState.refresh) return;
+	closeSettings(settingsState.startPolling, settingsState.refresh);
+	if (settingsState.open) return;
+	const trigger = $button("settingsButton");
+	queueMicrotask(() => openDiagnosticsDrawer({ ...options, trigger }));
 }
 
 function SettingsDialogContent() {

--- a/packages/ui/src/tabs/sync/components/sync-diagnostics.tsx
+++ b/packages/ui/src/tabs/sync/components/sync-diagnostics.tsx
@@ -13,6 +13,7 @@ export type SyncAttemptItem = {
 	startedAt: string;
 	actionHref?: string;
 	actionLabel?: string;
+	action?: (trigger: HTMLElement) => void;
 };
 
 export type PairingView = {
@@ -55,6 +56,15 @@ function AttemptsList({ attempts, note }: { attempts: SyncAttemptItem[]; note?: 
 							<a class="small" href={attempt.actionHref}>
 								{attempt.actionLabel}
 							</a>
+						) : null}
+						{attempt.action ? (
+							<button
+								className="settings-button small"
+								onClick={(event) => attempt.action?.(event.currentTarget)}
+								type="button"
+							>
+								View sync diagnostics
+							</button>
 						) : null}
 					</div>
 					<div class="right">{attempt.startedAt}</div>

--- a/packages/ui/src/tabs/sync/diagnostics/render/sync-attempts.test.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/render/sync-attempts.test.ts
@@ -1,5 +1,10 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { state } from "../../../../lib/state";
+
+const openDiagnosticsDrawer = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../../components/diagnostics", () => ({ openDiagnosticsDrawer }));
+
 import { renderSyncAttempts, shouldShowSyncAttemptRedactionHint } from "./sync-attempts";
 
 afterEach(() => {
@@ -8,6 +13,7 @@ afterEach(() => {
 	state.lastSyncAttempts = [];
 	state.lastSyncPeers = [];
 	state.lastSyncStatus = null;
+	openDiagnosticsDrawer.mockReset();
 });
 
 describe("shouldShowSyncAttemptRedactionHint", () => {
@@ -62,5 +68,32 @@ describe("renderSyncAttempts", () => {
 			"Turn off Redact in Advanced diagnostics to reveal the full error.",
 		);
 		expect(link?.textContent).toBe("Open Advanced diagnostics Redact setting");
+	});
+
+	it("opens error-filtered sync diagnostics from a failed attempt without passing its error", () => {
+		document.body.innerHTML = `<div id="syncAttempts"></div>`;
+		state.lastSyncAttempts = [
+			{
+				status: "error",
+				error: "private peer address and raw failure",
+				started_at: "2026-06-11T17:00:00.000Z",
+			},
+		];
+		renderSyncAttempts();
+
+		const action = [...document.querySelectorAll<HTMLButtonElement>("button")].find(
+			(button) => button.textContent === "View sync diagnostics",
+		);
+		if (!action) throw new Error("sync diagnostics action missing");
+		action.click();
+
+		expect(openDiagnosticsDrawer).toHaveBeenCalledWith({
+			severity: "error",
+			subsystem: "sync",
+			trigger: action,
+		});
+		expect(JSON.stringify(openDiagnosticsDrawer.mock.calls)).not.toContain(
+			"private peer address and raw failure",
+		);
 	});
 });

--- a/packages/ui/src/tabs/sync/diagnostics/render/sync-attempts.ts
+++ b/packages/ui/src/tabs/sync/diagnostics/render/sync-attempts.ts
@@ -4,6 +4,7 @@
  * unavailable" fallback for when the whole /api/sync/status call
  * failed. */
 
+import { openDiagnosticsDrawer } from "../../../../components/diagnostics";
 import { formatTimestamp } from "../../../../lib/format";
 import { isSyncRedactionEnabled, state } from "../../../../lib/state";
 import {
@@ -25,6 +26,13 @@ export function shouldShowSyncAttemptRedactionHint(
 	redact: boolean,
 ): boolean {
 	return redact && attempt.error_redacted === true;
+}
+
+function failedAttemptDiagnosticsAction(isError: boolean): Partial<SyncAttemptItem> {
+	if (!isError) return {};
+	return {
+		action: (trigger) => openDiagnosticsDrawer({ severity: "error", subsystem: "sync", trigger }),
+	};
 }
 
 export function renderSyncAttempts() {
@@ -78,6 +86,7 @@ export function renderSyncAttempts() {
 			peerLabel,
 			detail: detailParts.join(" · "),
 			startedAt: time ? formatTimestamp(time) : "",
+			...failedAttemptDiagnosticsAction(isError),
 			...(shouldShowSyncAttemptRedactionHint(attempt, redact)
 				? {
 						actionHref: "#sync/diagnostics",

--- a/packages/ui/src/tabs/sync/index.test.ts
+++ b/packages/ui/src/tabs/sync/index.test.ts
@@ -6,6 +6,7 @@ vi.mock("../../lib/api", () => ({
 	loadShareOperations: vi.fn(),
 	loadCoordinatorAdminStatus: vi.fn(),
 	loadDeviceIdentityInventory: vi.fn(),
+	loadPairing: vi.fn(),
 }));
 
 vi.mock("../health", () => ({ renderHealthOverview: vi.fn() }));
@@ -25,6 +26,7 @@ vi.mock("./team-sync", () => ({
 }));
 vi.mock("./people", () => ({
 	renderSyncActors: vi.fn(),
+	renderSyncActorsUnavailable: vi.fn(),
 	renderSyncPeers: vi.fn(),
 	renderSyncPeopleUnavailable: vi.fn(),
 	renderLegacyDeviceClaims: vi.fn(),
@@ -55,27 +57,53 @@ function deferred<T>(): Deferred<T> {
 	return { promise, resolve, reject };
 }
 
+async function verifyRecoveryBypassesCachedHealthStatus(): Promise<void> {
+	const api = await import("../../lib/api");
+	const { state } = await import("../../lib/state");
+	const { loadSyncData } = await import("./index");
+	state.activeTab = "health";
+	vi.mocked(api.loadSyncStatus).mockResolvedValueOnce({ peers: [] } as never);
+	vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
+	vi.mocked(api.loadCoordinatorAdminStatus).mockResolvedValue({});
+	vi.mocked(api.loadShareOperations).mockResolvedValue({ items: [] });
+	await expect(loadSyncData()).resolves.toBe(true);
+
+	vi.mocked(api.loadSyncStatus).mockRejectedValueOnce(new Error("status unavailable"));
+	await expect(
+		loadSyncData({ requiredSurface: "health", requireFreshSyncStatus: true }),
+	).resolves.toBe(false);
+	expect(api.loadSyncStatus).toHaveBeenCalledTimes(2);
+
+	vi.mocked(api.loadSyncStatus).mockResolvedValueOnce({ peers: [] } as never);
+	await expect(
+		loadSyncData({ requiredSurface: "health", requireFreshSyncStatus: true }),
+	).resolves.toBe(true);
+	expect(api.loadSyncStatus).toHaveBeenCalledTimes(3);
+}
+
+async function resetSyncTestState(activeTab: "advanced" | "devices") {
+	vi.clearAllMocks();
+	const { state } = await import("../../lib/state");
+	const { resetSyncLoadStateForTests } = await import("./index");
+	resetSyncLoadStateForTests();
+	state.activeTab = activeTab;
+	state.currentProject = "";
+	state.lastSyncPeers = [];
+	state.pendingAcceptedSyncPeers = [];
+	state.lastSyncActors = [];
+	state.lastShareOperations = [];
+	state.shareOperationsLoadError = false;
+	state.lastSyncCoordinator = null;
+	state.lastSyncCoordinatorAdminStatus = null;
+	state.lastCoordinatorAdminStatus = null;
+	state.pendingCoordinatorApprovalsByDeviceId.clear();
+	state.lastSyncViewModel = null;
+	state.lastDeviceIdentityInventory = null;
+	state.deviceIdentityInventoryLoadError = false;
+}
+
 describe("loadSyncData", () => {
-	beforeEach(async () => {
-		vi.clearAllMocks();
-		const { state } = await import("../../lib/state");
-		const { resetSyncLoadStateForTests } = await import("./index");
-		resetSyncLoadStateForTests();
-		state.activeTab = "advanced";
-		state.currentProject = "";
-		state.lastSyncPeers = [];
-		state.pendingAcceptedSyncPeers = [];
-		state.lastSyncActors = [];
-		state.lastShareOperations = [];
-		state.shareOperationsLoadError = false;
-		state.lastSyncCoordinator = null;
-		state.lastSyncCoordinatorAdminStatus = null;
-		state.lastCoordinatorAdminStatus = null;
-		state.pendingCoordinatorApprovalsByDeviceId.clear();
-		state.lastSyncViewModel = null;
-		state.lastDeviceIdentityInventory = null;
-		state.deviceIdentityInventoryLoadError = false;
-	});
+	beforeEach(() => resetSyncTestState("advanced"));
 
 	it("retains pending approval when the matching device still needs local approval", async () => {
 		const api = await import("../../lib/api");
@@ -104,8 +132,9 @@ describe("loadSyncData", () => {
 		vi.mocked(api.loadSyncActors).mockResolvedValue({ items: [] });
 		vi.mocked(api.loadShareOperations).mockResolvedValue({ items: [] });
 
-		await loadSyncData();
+		const refreshed = await loadSyncData();
 
+		expect(refreshed).toBe(true);
 		expect(state.pendingCoordinatorApprovalsByDeviceId.get("device-a")).toEqual({
 			coordinatorUrl: "https://coord.example.test",
 			incomingRequestId: "request-a",
@@ -127,8 +156,9 @@ describe("loadSyncData", () => {
 			new Error("sync status refresh failed"),
 		);
 
-		await loadSyncData();
+		const refreshed = await loadSyncData();
 
+		expect(refreshed).toBe(false);
 		expect(state.lastCoordinatorAdminStatus?.active_group).toBe("retained-group");
 		expect(state.lastSyncCoordinatorAdminStatus).toBeNull();
 	});
@@ -398,7 +428,7 @@ describe("loadSyncData", () => {
 			attempts: [],
 			legacy_devices: [],
 		});
-		await secondLoad;
+		await expect(secondLoad).resolves.toBe(true);
 		expect(state.lastSyncPeers.map((peer) => peer.peer_device_id)).toEqual(["peer-new"]);
 		expect(api.loadSyncStatus).toHaveBeenNthCalledWith(1, false, "", {
 			includeJoinRequests: false,
@@ -413,8 +443,24 @@ describe("loadSyncData", () => {
 			attempts: [],
 			legacy_devices: [],
 		});
-		await firstLoad;
+		await expect(firstLoad).resolves.toBe(true);
 		expect(state.lastSyncPeers.map((peer) => peer.peer_device_id)).toEqual(["peer-new"]);
+	});
+
+	it("forwards an older overlapping load to the newer failed result", async () => {
+		const api = await import("../../lib/api");
+		const { loadSyncData } = await import("./index");
+		const olderStatus = deferred<{ peers: [] }>();
+		vi.mocked(api.loadSyncStatus)
+			.mockReturnValueOnce(olderStatus.promise as never)
+			.mockRejectedValueOnce(new Error("newer refresh failed"));
+
+		const olderLoad = loadSyncData();
+		const newerLoad = loadSyncData();
+
+		await expect(newerLoad).resolves.toBe(false);
+		olderStatus.resolve({ peers: [] });
+		await expect(olderLoad).resolves.toBe(false);
 	});
 
 	it("does not extend the health-tab cache ttl on cache hits", async () => {
@@ -439,6 +485,11 @@ describe("loadSyncData", () => {
 			includeJoinRequests: false,
 		});
 	});
+
+	it(
+		"bypasses a cached Health status when recovery requires fresh evidence",
+		verifyRecoveryBypassesCachedHealthStatus,
+	);
 
 	it("does not request secondary sync data when status fails", async () => {
 		const api = await import("../../lib/api");
@@ -598,5 +649,69 @@ describe("loadSyncData", () => {
 
 		expect(api.loadDeviceIdentityInventory).not.toHaveBeenCalled();
 		expect(state.deviceIdentityInventoryLoadError).toBe(true);
+	});
+});
+
+describe("loadSyncData devices surface", () => {
+	beforeEach(() => resetSyncTestState("devices"));
+
+	it("reports success when only auxiliary Advanced data fails", async () => {
+		const api = await import("../../lib/api");
+		const { loadSyncData } = await import("./index");
+		vi.mocked(api.loadSyncStatus).mockResolvedValue({ peers: [] } as never);
+		vi.mocked(api.loadSyncActors).mockRejectedValue(new Error("actors unavailable"));
+		vi.mocked(api.loadCoordinatorAdminStatus).mockRejectedValue(new Error("admin unavailable"));
+		vi.mocked(api.loadShareOperations).mockRejectedValue(new Error("shares unavailable"));
+
+		await expect(loadSyncData({ requiredSurface: "devices" })).resolves.toBe(true);
+		await expect(loadSyncData()).resolves.toBe(false);
+	});
+
+	it("still fails when the primary sync status request fails", async () => {
+		const api = await import("../../lib/api");
+		const { loadSyncData } = await import("./index");
+		vi.mocked(api.loadSyncStatus).mockRejectedValue(new Error("status unavailable"));
+
+		await expect(loadSyncData({ requiredSurface: "devices" })).resolves.toBe(false);
+	});
+});
+
+describe("loadPairingData", () => {
+	it("forwards a superseded load to the newer successful result", async () => {
+		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
+		const { loadPairingData, resetSyncLoadStateForTests } = await import("./index");
+		resetSyncLoadStateForTests();
+		const olderPairing = deferred<Record<string, unknown>>();
+		vi.mocked(api.loadPairing)
+			.mockReturnValueOnce(olderPairing.promise as never)
+			.mockResolvedValueOnce({ command: "newer" } as never);
+
+		const olderLoad = loadPairingData();
+		const newerLoad = loadPairingData();
+		await expect(newerLoad).resolves.toBe(true);
+		olderPairing.resolve({ command: "older" });
+
+		await expect(olderLoad).resolves.toBe(true);
+		expect(state.pairingPayloadRaw).toEqual({ command: "newer" });
+	});
+
+	it("forwards a superseded load to the newer failed result", async () => {
+		const api = await import("../../lib/api");
+		const { state } = await import("../../lib/state");
+		const { loadPairingData, resetSyncLoadStateForTests } = await import("./index");
+		resetSyncLoadStateForTests();
+		const olderPairing = deferred<Record<string, unknown>>();
+		vi.mocked(api.loadPairing)
+			.mockReturnValueOnce(olderPairing.promise as never)
+			.mockRejectedValueOnce(new Error("newer pairing failed"));
+
+		const olderLoad = loadPairingData();
+		const newerLoad = loadPairingData();
+		await expect(newerLoad).resolves.toBe(false);
+		olderPairing.resolve({ command: "older" });
+
+		await expect(olderLoad).resolves.toBe(false);
+		expect(state.pairingPayloadRaw).toBeNull();
 	});
 });

--- a/packages/ui/src/tabs/sync/index.ts
+++ b/packages/ui/src/tabs/sync/index.ts
@@ -122,6 +122,9 @@ function pendingCoordinatorApprovalHashInput(): Array<readonly [string, string, 
 let cachedSyncStatus: { key: string; expiresAtMs: number; payload: SyncStatusResponseLike } | null =
 	null;
 let latestSyncLoadRequestId = 0;
+let latestSyncLoad: Promise<boolean> | null = null;
+let latestPairingLoadRequestId = 0;
+let latestPairingLoad: Promise<boolean> | null = null;
 
 const HEALTH_SYNC_STATUS_CACHE_TTL_MS = 15_000;
 
@@ -166,31 +169,62 @@ function hideStaleSyncSecondarySections() {
 	if (legacyClaimsMeta) legacyClaimsMeta.textContent = "";
 }
 
-export async function loadSyncData() {
-	const requestId = ++latestSyncLoadRequestId;
+export interface SyncDataLoadOptions {
+	requiredSurface?: "all" | "health" | "devices";
+	requireFreshSyncStatus?: boolean;
+}
+
+async function fetchSyncStatusPayload(
+	project: string,
+	options: Required<SyncDataLoadOptions>,
+): Promise<{ payload: SyncStatusResponseLike; fetchedFreshSyncStatus: boolean }> {
+	const useCache = state.activeTab === "health" && !options.requireFreshSyncStatus;
+	if (useCache) {
+		const payload = readCachedSyncStatus(project);
+		if (payload) return { payload, fetchedFreshSyncStatus: false };
+	}
+
+	// Raw diagnostics remain an explicit Advanced-view choice.
+	const includeDiagnostics = !isSyncRedactionEnabled();
+	const payload = await api.loadSyncStatus(includeDiagnostics, project, {
+		includeJoinRequests: false,
+	});
+	return { payload, fetchedFreshSyncStatus: true };
+}
+
+function didRequiredSyncSurfacesRefresh(input: {
+	requiredSurface: "all" | "health" | "devices";
+	actorLoadError: boolean;
+	coordinatorAdminLoadError: boolean;
+	shareOperationsLoadError: boolean;
+	requiresDeviceIdentityInventory: boolean;
+	deviceIdentityInventoryLoadError: boolean;
+}): boolean {
+	// Health and Devices consume only the primary sync status, which has
+	// already loaded by the time this runs; auxiliary surfaces are Advanced-only.
+	if (input.requiredSurface !== "all") return true;
+	if (input.actorLoadError || input.coordinatorAdminLoadError || input.shareOperationsLoadError) {
+		return false;
+	}
+	return !input.requiresDeviceIdentityInventory || !input.deviceIdentityInventoryLoadError;
+}
+
+export function loadSyncData(options: SyncDataLoadOptions = {}): Promise<boolean> {
+	const operation = runLoadSyncData(++latestSyncLoadRequestId, {
+		requiredSurface: options.requiredSurface ?? "all",
+		requireFreshSyncStatus: options.requireFreshSyncStatus ?? false,
+	});
+	latestSyncLoad = operation;
+	return operation;
+}
+
+async function runLoadSyncData(
+	requestId: number,
+	options: Required<SyncDataLoadOptions>,
+): Promise<boolean> {
 	try {
 		const project = state.currentProject || "";
-		const includeJoinRequests = false;
-		const useCache = state.activeTab === "health";
-		let fetchedFreshSyncStatus = false;
-
-		// When the Advanced diagnostics "Redact" toggle is OFF the user is
-		// opting into raw diagnostics — pass includeDiagnostics=true so the
-		// server returns real addresses, pairing payload, and peer errors.
-		const includeDiagnostics = !isSyncRedactionEnabled();
-		let payload: SyncStatusResponseLike;
-		if (useCache) {
-			payload = readCachedSyncStatus(project);
-			if (!payload) {
-				payload = await api.loadSyncStatus(includeDiagnostics, project, {
-					includeJoinRequests: false,
-				});
-				fetchedFreshSyncStatus = true;
-			}
-		} else {
-			payload = await api.loadSyncStatus(includeDiagnostics, project, { includeJoinRequests });
-			fetchedFreshSyncStatus = true;
-		}
+		const { payload, fetchedFreshSyncStatus } = await fetchSyncStatusPayload(project, options);
 
 		let actorsPayload: SyncActorListResponseLike | null = null;
 		let coordinatorAdminStatus: Record<string, unknown> | null = null;
@@ -226,7 +260,15 @@ export async function loadSyncData() {
 			shareOperationsLoadError = true;
 		}
 
-		if (requestId !== latestSyncLoadRequestId) return;
+		if (requestId !== latestSyncLoadRequestId) return latestSyncLoad ?? false;
+		const refreshSucceeded = didRequiredSyncSurfacesRefresh({
+			requiredSurface: options.requiredSurface,
+			actorLoadError,
+			coordinatorAdminLoadError,
+			shareOperationsLoadError,
+			requiresDeviceIdentityInventory: state.activeTab === "advanced",
+			deviceIdentityInventoryLoadError,
+		});
 
 		if (fetchedFreshSyncStatus) {
 			writeCachedSyncStatus(project, normalizeSyncStatusForCache(payload));
@@ -245,7 +287,7 @@ export async function loadSyncData() {
 			duplicatePersonDecisions,
 			pendingCoordinatorApprovalHashInput(),
 		]);
-		if (hash === lastSyncHash) return;
+		if (hash === lastSyncHash) return refreshSucceeded;
 		lastSyncHash = hash;
 
 		const statusPayload =
@@ -317,8 +359,9 @@ export async function loadSyncData() {
 			state.lastSyncCoordinatorAdminStatus = null;
 			renderTeamSync();
 		}
+		return refreshSucceeded;
 	} catch {
-		if (requestId !== latestSyncLoadRequestId) return;
+		if (requestId !== latestSyncLoadRequestId) return latestSyncLoad ?? false;
 		lastSyncHash = "";
 		state.deviceIdentityInventoryLoadError = true;
 		// Clear all skeletons so the error state is visible, not masked by loading placeholders
@@ -329,6 +372,7 @@ export async function loadSyncData() {
 		hideStaleSyncSecondarySections();
 		renderSyncPeopleUnavailable();
 		renderSyncDiagnosticsUnavailable();
+		return false;
 	}
 }
 
@@ -350,19 +394,36 @@ export function resetSyncLoadStateForTests() {
 	lastSyncHash = "";
 	cachedSyncStatus = null;
 	latestSyncLoadRequestId = 0;
+	latestSyncLoad = null;
+	latestPairingLoadRequestId = 0;
+	latestPairingLoad = null;
 }
 
-export async function loadPairingData() {
+async function reloadSyncData(): Promise<void> {
+	await loadSyncData();
+}
+
+export function loadPairingData(): Promise<boolean> {
+	const operation = runLoadPairingData(++latestPairingLoadRequestId);
+	latestPairingLoad = operation;
+	return operation;
+}
+
+async function runLoadPairingData(requestId: number): Promise<boolean> {
 	try {
 		// Pairing payload is always returned in full — it's the actual
 		// command the user shares, not a diagnostic. The "Show pairing
 		// command" disclosure in the UI is the user-facing exposure gate.
 		const payload = await api.loadPairing();
+		if (requestId !== latestPairingLoadRequestId) return latestPairingLoad ?? false;
 		state.pairingPayloadRaw = payload || null;
 		renderPairing();
+		return true;
 	} catch {
+		if (requestId !== latestPairingLoadRequestId) return latestPairingLoad ?? false;
 		state.pairingPayloadRaw = null;
 		renderPairing();
+		return false;
 	}
 }
 
@@ -372,12 +433,12 @@ export function initSyncTab(refreshCallback: () => void) {
 	ensureSyncRenderBoundary();
 	ensureSyncDialogHost();
 	// Wire cross-module callbacks to avoid circular imports
-	setTeamSyncLoadData(loadSyncData);
-	setPeopleLoadData(loadSyncData);
+	setTeamSyncLoadData(reloadSyncData);
+	setPeopleLoadData(reloadSyncData);
 	setRenderSyncPeers(renderSyncPeers);
 
-	initTeamSyncEvents(refreshCallback, loadSyncData);
-	initPeopleEvents(loadSyncData);
+	initTeamSyncEvents(refreshCallback, reloadSyncData);
+	initPeopleEvents(reloadSyncData);
 	initDiagnosticsEvents(refreshCallback);
 
 	// Apply the current #sync vs #sync/diagnostics sub-view and keep it in

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -3310,6 +3310,8 @@
         box-shadow: 0 0 0 4px var(--focus-ring);
       }
       .diagnostics-secondary-controls { flex-shrink: 0; }
+      .diagnostics-secondary-actions { display: flex; flex-wrap: wrap; gap: var(--sp-2); }
+      .diagnostics-copy-status { min-height: 1.25em; color: var(--text-secondary); font-size: var(--font-size-sm); }
       .diagnostics-generated-at,
       .diagnostics-limit-note,
       .diagnostics-filter-context { color: var(--text-tertiary); font-size: var(--font-size-sm); }
@@ -3621,6 +3623,7 @@
         color: var(--text-secondary);
         font-size: var(--font-size-sm);
       }
+      .viewer-reconnect-actions { display: flex; flex-wrap: wrap; gap: var(--sp-2); }
       .viewer-reconnect-spinner {
         width: 14px;
         height: 14px;
@@ -4251,8 +4254,9 @@
           <span class="viewer-reconnect-spinner" aria-hidden="true"></span>
           <span>The page will recover automatically when the server responds.</span>
         </div>
-        <div>
-          <button class="settings-button" id="viewerReconnectRetry">Retry now</button>
+        <div class="viewer-reconnect-actions">
+          <button class="settings-button" id="viewerReconnectRetry" type="button">Retry now</button>
+          <button class="settings-button" id="viewerReconnectDiagnostics" type="button">View connection diagnostics</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description
Adds reconnect, failed-sync, capture backlog, maintenance, and observer entry points to the diagnostics drawer. It also adds bounded browser-session connection events, durable clear-view behavior, warned allowlisted copying, mutable-event refresh handling, focus-safe Settings handoff, and fail-closed enforcement that copied responses declare `redacted: true`.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced