### PR TITLE
test(recall): preserve immutable pre-policy source baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          # The automatic-recall baseline test archives a pinned historical main commit.
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@v5

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ sources. If both load Codemem for one Project, the first registration wins and l
 their hooks with a warning. Remove the configured npm entry when testing a source checkout so the
 checkout-local plugin loads first; otherwise your edits may appear to do nothing.
 
+Requester-session eligibility for automatic recall is not implemented yet. The
+pre-policy source identity and invented gold fixture have preflight clearance;
+plugin/CLI incident evaluation and implementation review remain pending. See
+[the historical baseline procedure](docs/opencode-retained-recall.md#historical-incident-baseline).
+
 ### Claude Code (marketplace install)
 
 1. Install codemem's Claude MCP config:

--- a/docs/opencode-retained-recall.md
+++ b/docs/opencode-retained-recall.md
@@ -86,7 +86,9 @@ This does not solve multiple tasks within one session. The retained cap remains 
 
 Run `node scripts/eval/run-automatic-recall-baseline.mjs` to export the full pinned
 `ad50a6a4` tree into a new temporary snapshot and overlay the byte-verified harness
-from `5de04daf`. The historical test still checks all listed working-source blobs
+from the committed copies under `scripts/eval/frozen/automatic-recall-pre-policy/`
+(originally frozen in `5de04daf`, which squash merges leave unreachable; CI fetches
+full history only for the `ad50a6a4` archive). The historical test still checks all listed working-source blobs
 in that snapshot against the pinned Git objects. It exercises the real Core
 selector/renderer and Viewer route, not a mocked whole-pack baseline. The snapshot
 is retained for inspection; the runner does not update the recorded report.

--- a/docs/opencode-retained-recall.md
+++ b/docs/opencode-retained-recall.md
@@ -78,6 +78,30 @@ Reasons are `delivered`, `replay`, `allowance_exhausted`, `unchanged_memories`, 
 
 Deterministic local tests exercise lifecycle and transport behavior without paid provider calls.
 
+### Historical Incident Baseline
+
+The source identity and frozen gold preflight is cleared; requester eligibility,
+plugin/CLI incident evaluation, and independent implementation reviews remain pending.
+This does not solve multiple tasks within one session. The retained cap remains off.
+
+Run `node scripts/eval/run-automatic-recall-baseline.mjs` to export the full pinned
+`ad50a6a4` tree into a new temporary snapshot and overlay the byte-verified harness
+from `5de04daf`. The historical test still checks all listed working-source blobs
+in that snapshot against the pinned Git objects. It exercises the real Core
+selector/renderer and Viewer route, not a mocked whole-pack baseline. The snapshot
+is retained for inspection; the runner does not update the recorded report.
+
+The current checkout's provenance test verifies the immutable harness bytes,
+not production working-file hashes. Its pack calls are explicit-pack compatibility
+checks, not evidence of automatic requester eligibility. The frozen report retains
+its original pending-review fields as historical evidence; the manifest records the
+later user-reported source-and-gold clearance separately.
+
+Limits: the runner reuses installed external dependencies rather than proving a
+fresh frozen-lockfile install. Workspace package links point into the historical
+snapshot. The fixture has no expected updates, its wrapping estimate is synthetic,
+and it does not prove cross-session durable-fact coverage or plugin delivery.
+
 Run `pnpm --filter codemem test:plugin` for all plugin regressions, or add `.opencode/tests/plugin-retained-recall.test.js` to select the lifecycle/measurement fixtures. `plugin-transform-hook.test.js` includes real hook tests for Viewer and CLI fallback budgets, changed facts, continuation skips, restart byte stability, and log reconciliation. Run `pnpm exec vitest run packages/core/src/pack.test.ts` for standard/compact renderer spans and budget checks. From `packages/cli`, run the comparative fixtures with:
 
 ```fish

--- a/packages/core/src/automatic-recall-pre-policy.eval.test.ts
+++ b/packages/core/src/automatic-recall-pre-policy.eval.test.ts
@@ -1,0 +1,198 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import manifest from "../../../scripts/eval/automatic-recall-pre-policy.json";
+import report from "../../../scripts/eval/baselines/automatic-recall-pre-policy.json";
+import fixture from "../../../scripts/eval/fixtures/automatic-recall-pre-policy.json";
+import { buildMemoryPackTrace, estimateTokens } from "./pack.js";
+import { MemoryStore } from "./store.js";
+
+type FixtureMemory = (typeof fixture.sessions)[number]["memories"][number];
+
+function canonicalJson(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+	if (value !== null && typeof value === "object") {
+		const fields = Object.entries(value).sort(([left], [right]) => left.localeCompare(right, "en"));
+		return `{${fields.map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`).join(",")}}`;
+	}
+	return JSON.stringify(value) as string;
+}
+
+function verifySourceIdentity() {
+	const cwd = fileURLToPath(new URL("../../../", import.meta.url));
+	const git = (...args: string[]) => execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+	expect(git("rev-parse", `${manifest.source.commit}^{tree}`)).toBe(manifest.source.tree);
+	for (const [path, blob] of Object.entries(manifest.source.blobs)) {
+		expect(git("rev-parse", `${manifest.source.commit}:${path}`), path).toBe(blob);
+		expect(git("hash-object", path), path).toBe(blob);
+	}
+	for (const [path, hash] of Object.entries(report.provenance.harness_sha256)) {
+		expect(
+			createHash("sha256")
+				.update(readFileSync(new URL(`../../../${path}`, import.meta.url)))
+				.digest("hex"),
+			path,
+		).toBe(hash);
+	}
+}
+
+function seedIncident(store: MemoryStore): Map<string, number> {
+	const ids = new Map<string, number>();
+	for (const session of fixture.sessions) {
+		const sessionId = store.getOrCreateSessionForOpencodeSession({
+			opencodeSessionId: session.host_session_id,
+			project: fixture.project,
+			startedAt: session.started_at,
+		});
+		for (const memory of session.memories) {
+			ids.set(memory.key, insertMemory(store, sessionId, memory));
+		}
+	}
+	return ids;
+}
+
+function insertMemory(store: MemoryStore, sessionId: number, memory: FixtureMemory): number {
+	const id = store.remember(
+		sessionId,
+		memory.kind,
+		memory.title,
+		memory.body,
+		memory.confidence,
+		memory.tags,
+		memory.metadata,
+	);
+	store.db
+		.prepare("UPDATE memory_items SET created_at = ?, updated_at = ? WHERE id = ?")
+		.run(memory.created_at, memory.created_at, id);
+	return id;
+}
+
+function stableOutcome(store: MemoryStore, query: string, ids: Map<string, number>) {
+	const trace = buildMemoryPackTrace(
+		store,
+		query,
+		fixture.limit,
+		fixture.core_token_budget,
+		{ project: fixture.project },
+		undefined,
+		{ compressionMode: fixture.compression_mode },
+	);
+	const selectedIds = Object.values(trace.assembly.sections).flat();
+	const keysFor = (sectionIds: number[]) =>
+		[...ids]
+			.filter(([, id]) => sectionIds.includes(id))
+			.map(([key]) => key)
+			.sort();
+	const selectedKeys = [...ids]
+		.filter(([, id]) => selectedIds.includes(id))
+		.map(([key]) => key)
+		.sort();
+	return {
+		mode: trace.mode.selected,
+		selected_keys: selectedKeys,
+		summary_keys: keysFor(trace.assembly.sections.summary),
+		timeline_keys: keysFor(trace.assembly.sections.timeline),
+		pack_tokens: trace.output.estimated_tokens,
+		wrapped_estimated_tokens: {
+			new: estimateTokens(`${fixture.synthetic_wrapper_prefix}${trace.output.pack_text}`),
+			retained: 0,
+		},
+	};
+}
+
+function countMatches(selectedKeys: string[], expectedKeys: readonly string[]): number {
+	return expectedKeys.filter((key) => selectedKeys.includes(key)).length;
+}
+
+describe("automatic recall actual-source pre-policy baseline", () => {
+	let store: MemoryStore;
+	let ids: Map<string, number>;
+
+	beforeEach(() => {
+		vi.useFakeTimers({ toFake: ["Date"] });
+		vi.setSystemTime(new Date(fixture.clock));
+		store = new MemoryStore(":memory:");
+		ids = seedIncident(store);
+	});
+
+	afterEach(() => {
+		store.close();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("pins fixture provenance and the missing host-to-numeric session mapping", () => {
+		// Arrange
+		const digestInput = canonicalJson(fixture);
+
+		// Act
+		const digest = createHash("sha256").update(digestInput).digest("hex");
+		const mappings = store.db
+			.prepare(
+				"SELECT stream_id, session_id FROM opencode_sessions WHERE source = 'opencode' ORDER BY stream_id",
+			)
+			.all() as Array<{ stream_id: string; session_id: number }>;
+
+		// Assert
+		expect(digest).toBe(manifest.gates.incident_fixture_digest);
+		expect(report.provenance.source_commit).toBe(manifest.source.commit);
+		expect(report.provenance.source_tree).toBe(manifest.source.tree);
+		expect(report.provenance.fixture_sha256).toBe(digest);
+		expect(mappings).toHaveLength(fixture.sessions.length);
+		expect(mappings.every((mapping) => Number.isSafeInteger(mapping.session_id))).toBe(true);
+	});
+
+	it("verifies pinned Git blobs and separately hashed harness content", verifySourceIdentity);
+
+	it("records the unwanted generic Continue inclusion separately from desired gold", () => {
+		// Arrange
+		const gold = fixture.gold.generic_continue;
+
+		// Act
+		const first = stableOutcome(store, fixture.query, ids);
+		const second = stableOutcome(store, fixture.query, ids);
+
+		// Assert
+		expect(first).toEqual(second);
+		expect(first).toMatchObject(report.observed.generic_continue);
+		expect(first.selected_keys).toEqual(
+			expect.arrayContaining([...gold.required_keys, ...gold.forbidden_keys]),
+		);
+		expect(report.gold.generic_continue.forbidden_keys).toEqual(gold.forbidden_keys);
+		expect(report.incident.generic_continue.useful_fact_coverage).toEqual({
+			present: countMatches(first.selected_keys, gold.required_keys),
+			total: gold.required_keys.length,
+		});
+		expect(report.incident.generic_continue.wrongful_summary_inclusion).toEqual({
+			count: countMatches(first.selected_keys, gold.forbidden_keys),
+			total: gold.forbidden_keys.length,
+		});
+		expect(report.incident.generic_continue.missed_updates).toEqual({ count: 0, total: 0 });
+	});
+
+	it("keeps the relevant durable fact without the unrelated summary under explicit retrieval", () => {
+		// Arrange
+		const gold = fixture.gold.explicit_control;
+
+		// Act
+		const first = stableOutcome(store, fixture.explicit_control_query, ids);
+		const second = stableOutcome(store, fixture.explicit_control_query, ids);
+
+		// Assert
+		expect(first).toEqual(second);
+		expect(first).toMatchObject(report.observed.explicit_control);
+		expect(first.selected_keys).toEqual(expect.arrayContaining(gold.required_keys));
+		expect(first.selected_keys).not.toEqual(expect.arrayContaining(gold.forbidden_keys));
+		expect(report.incident.explicit_control.useful_fact_coverage).toEqual({
+			present: countMatches(first.selected_keys, gold.required_keys),
+			total: gold.required_keys.length,
+		});
+		expect(report.incident.explicit_control.wrongful_summary_inclusion).toEqual({
+			count: countMatches(first.selected_keys, gold.forbidden_keys),
+			total: gold.forbidden_keys.length,
+		});
+		expect(report.incident.explicit_control.missed_updates).toEqual({ count: 0, total: 0 });
+	});
+});

--- a/packages/core/src/automatic-recall-pre-policy.eval.test.ts
+++ b/packages/core/src/automatic-recall-pre-policy.eval.test.ts
@@ -1,6 +1,5 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import manifest from "../../../scripts/eval/automatic-recall-pre-policy.json";
@@ -10,6 +9,22 @@ import { buildMemoryPackTrace, estimateTokens } from "./pack.js";
 import { MemoryStore } from "./store.js";
 
 type FixtureMemory = (typeof fixture.sessions)[number]["memories"][number];
+
+it("executes the immutable historical source and frozen harness separately", () => {
+	const cwd = fileURLToPath(new URL("../../../", import.meta.url));
+	const output = execFileSync(
+		process.execPath,
+		["scripts/eval/run-automatic-recall-baseline.mjs"],
+		{
+			cwd,
+			encoding: "utf8",
+			timeout: 60_000,
+		},
+	);
+	expect(output).toContain(`Historical source: ${manifest.source.commit}`);
+	expect(output).toContain(`frozen harness: ${manifest.artifacts.frozen_harness_commit}`);
+	expect(output).toMatch(/12 passed/);
+}, 65_000);
 
 function canonicalJson(value: unknown): string {
 	if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
@@ -26,12 +41,15 @@ function verifySourceIdentity() {
 	expect(git("rev-parse", `${manifest.source.commit}^{tree}`)).toBe(manifest.source.tree);
 	for (const [path, blob] of Object.entries(manifest.source.blobs)) {
 		expect(git("rev-parse", `${manifest.source.commit}:${path}`), path).toBe(blob);
-		expect(git("hash-object", path), path).toBe(blob);
 	}
 	for (const [path, hash] of Object.entries(report.provenance.harness_sha256)) {
 		expect(
 			createHash("sha256")
-				.update(readFileSync(new URL(`../../../${path}`, import.meta.url)))
+				.update(
+					execFileSync("git", ["show", `${manifest.artifacts.frozen_harness_commit}:${path}`], {
+						cwd,
+					}),
+				)
 				.digest("hex"),
 			path,
 		).toBe(hash);
@@ -106,7 +124,8 @@ function countMatches(selectedKeys: string[], expectedKeys: readonly string[]): 
 	return expectedKeys.filter((key) => selectedKeys.includes(key)).length;
 }
 
-describe("automatic recall actual-source pre-policy baseline", () => {
+// Historical execution lives in run-automatic-recall-baseline.mjs; these calls retain explicit-pack semantics.
+describe("frozen baseline provenance and current explicit-pack compatibility", () => {
 	let store: MemoryStore;
 	let ids: Map<string, number>;
 

--- a/packages/viewer-server/src/routes/automatic-recall.test.ts
+++ b/packages/viewer-server/src/routes/automatic-recall.test.ts
@@ -3,7 +3,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { MemoryStore } from "@codemem/core";
 import { Hono } from "hono";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fixture from "../../../../scripts/eval/fixtures/automatic-recall-pre-policy.json";
 import { insertTestSession } from "../../../core/src/test-utils.js";
 import { packTransportRoutes } from "./pack.js";
 import { statsRoutes } from "./stats.js";
@@ -19,6 +20,30 @@ const empty = {
 	invalidRetainedMetadata: false,
 	packMetadata: "valid",
 };
+
+function seedRecallFixture(store: MemoryStore) {
+	for (const session of fixture.sessions) {
+		const sessionId = store.getOrCreateSessionForOpencodeSession({
+			opencodeSessionId: session.host_session_id,
+			project: fixture.project,
+			startedAt: session.started_at,
+		});
+		for (const memory of session.memories) {
+			const id = store.remember(
+				sessionId,
+				memory.kind,
+				memory.title,
+				memory.body,
+				memory.confidence,
+				memory.tags,
+				memory.metadata,
+			);
+			store.db
+				.prepare("UPDATE memory_items SET created_at = ?, updated_at = ? WHERE id = ?")
+				.run(memory.created_at, memory.created_at, id);
+		}
+	}
+}
 
 describe("automatic recall existing HTTP transport", () => {
 	let directory: string;
@@ -232,3 +257,47 @@ describe("automatic recall existing HTTP transport", () => {
 		).toEqual({ delivery_status: "handed_off" });
 	});
 });
+
+it(
+	"returns the actual pre-policy generic Continue incident through the Viewer route",
+	verifyViewerBaseline,
+);
+
+async function verifyViewerBaseline() {
+	vi.useFakeTimers({ toFake: ["Date"] });
+	vi.setSystemTime(new Date(fixture.clock));
+	const store = new MemoryStore(":memory:");
+	try {
+		// Arrange
+		seedRecallFixture(store);
+		const app = new Hono().route(
+			"/",
+			packTransportRoutes(() => store),
+		);
+
+		// Act
+		const response = await app.request("/api/pack", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				context: fixture.query,
+				project: fixture.project,
+				limit: fixture.limit,
+				token_budget: fixture.core_token_budget,
+			}),
+		});
+		const body = (await response.json()) as {
+			pack_text: string;
+			metrics: { mode: string };
+		};
+
+		// Assert
+		expect(response.status).toBe(200);
+		expect(body.metrics.mode).toBe("task");
+		expect(body.pack_text).toContain("QUARTZ_DURABLE_FACT");
+		expect(body.pack_text).toContain("ORCHID_UNRELATED_CONTINUITY");
+	} finally {
+		store.close();
+		vi.useRealTimers();
+	}
+}

--- a/scripts/eval/automatic-recall-pre-policy.json
+++ b/scripts/eval/automatic-recall-pre-policy.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 1,
+  "purpose": "Actual-source pre-policy baseline candidate; gate pending independent parent review",
+  "source": {
+    "commit": "ad50a6a41d5ee78f36e8c96a2000648cf8a5863d",
+    "tree": "4ca51b5a75a79b4c0cf9ba1aca4354119f6ac83e",
+    "merged_foundation": "d95d4959d985bdab91a7b05997d276cbb48dbd6f",
+    "version": "0.44.0-beta.1",
+    "identity_scheme": "Git SHA-1 object IDs; full tree pins transitive source dependencies",
+    "blobs": {
+      "pnpm-lock.yaml": "4a4ea1675083be52f6339fedd2a8ff35ee3aaf73",
+      "packages/core/src/pack.ts": "3db2093fc757c6acffb5d735885ea95a8499d534",
+      "packages/core/src/search.ts": "4529529f686bc04c3e78b61cd5fd7f867cc53a62",
+      "packages/core/src/summary-memory.ts": "fc1c16a20e73b34a05273b93fa690fb853b01a39",
+      "packages/core/src/store.ts": "89a7d0cbde0509e1112e95f7fe6c2141510f043f",
+      "packages/core/src/schema.ts": "9e3cb1a772da0681e33caa22caa4cf2dab24c319",
+      "packages/core/src/types.ts": "02c95b8fda28c49d24ffdd63bfc05ccc92df0216",
+      "packages/cli/src/commands/pack.ts": "a9fe476d5fc672f6fbcc12fae0a7505676f619cd",
+      "packages/viewer-server/src/routes/pack.ts": "38a0f5303c2d03c531018fc3c5cd1843bc5adac9",
+      "packages/opencode-plugin/.opencode/plugins/codemem.js": "d208ab6910b42d0aeb8d94a21f51a0414848777f",
+      "packages/cli/.opencode/plugins/codemem.js": "ca854258a4011f83996bb38f237a61b8c47891e0",
+      "packages/cli/.opencode/tests/retained-recall-comparison.eval.test.js": "b0a0bf34cef05d85ace02d090a7a1c4c1262b044",
+      "packages/cli/.opencode/tests/retained-recall-comparison.eval-fixtures.js": "d2b5e8ab2bd33ab2ce4f4d9028728e51877ea784"
+    }
+  },
+  "observed_environment": {
+    "platform": "darwin",
+    "architecture": "arm64",
+    "node": "24.20.0",
+    "pnpm": "12.2.1",
+    "installed_dependencies": {
+      "@opencode-ai/plugin": "1.18.25",
+      "better-sqlite3": "13.0.3",
+      "sqlite-vec": "0.1.9",
+      "drizzle-orm": "0.45.2",
+      "hono": "4.13.5",
+      "tsx": "4.23.13",
+      "typescript": "7.0.2",
+      "vite": "8.2.2",
+      "vitest": "4.1.11"
+    },
+    "evidence": "node --version; pnpm --version; pnpm list --depth 0 -r --json; ESM SDK resolution from canonical plugin directory",
+    "limits": "Installed inventory is not a fresh frozen-lockfile install or proof of the live host plugin/Core. Nested runtime install reproducibility must be checked before evaluation."
+  },
+  "evaluation_contract": {
+    "baseline": "Execute the complete pinned merged source tree in a separate approved temporary snapshot; never use moving origin/main, candidate source, or runStageOneBaseline as historical policy.",
+    "runtime": "Current evidence executes Core selector/renderer and real Viewer routes via Vitest source resolution. Plugin hooks and CLI child processes are not executed. Git blob checks compare working source bytes and pinned commit objects, not JSON equality. No fresh frozen-lockfile install is claimed.",
+    "fixtures": "Invent public-safe incident rows and prompts, freeze their digest and gold facts/updates/negative summaries before execution, and seed independent temporary databases identically for baseline and candidate.",
+    "controls": "Core budget 795, compression off. Fixture prefix wrapping is a synthetic estimate, not a plugin hook or 800-token budget test. Viewer asserts inclusion/mode with default compression, not comparable token counts. Fake JavaScript Date plus seeded row times; SQLite now is not frozen. No live database or paid/provider calls.",
+    "reuse": "Reuse retained-recall reporting conventions and scripts/eval prompt-path transport setup, not the retained comparison's handwritten baseline or pre-rendered packs as actual-policy evidence.",
+    "measurement": "Run twice; compare stable metrics excluding documented timing fields. Report useful-fact coverage, wrongful summary inclusion, missed updates and new/retained estimated tokens with denominators and per-case losses."
+  },
+  "artifacts": {
+    "fixture": "scripts/eval/fixtures/automatic-recall-pre-policy.json",
+    "report": "scripts/eval/baselines/automatic-recall-pre-policy.json",
+    "regression": "packages/core/src/automatic-recall-pre-policy.eval.test.ts",
+    "viewer_regression": "packages/viewer-server/src/routes/automatic-recall.test.ts"
+  },
+  "gates": {
+    "source_identity_verified": true,
+    "source_identity_evidence": "git rev-parse commit^{tree}; all 13 listed blobs checked using git rev-parse commit:path and git hash-object working-path, with equal observed IDs. This verifies listed source bytes, not execution of plugin/CLI surfaces.",
+    "incident_fixture_digest": "7ea10a40b20f177df3f7c289916f2527349a13b113cde071a6bf2af0fadbcf12",
+    "incident_evaluation_executed": true,
+    "baseline_gate": "pending independent parent review",
+    "independent_parent_review": "pending",
+    "code_reviewer_and_adversarial_reviews": "pending",
+    "stage_1_policy_edits_cleared": false
+  }
+}

--- a/scripts/eval/automatic-recall-pre-policy.json
+++ b/scripts/eval/automatic-recall-pre-policy.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "purpose": "Actual-source pre-policy baseline candidate; gate pending independent parent review",
+  "purpose": "Reviewed source identity and frozen gold baseline; requester eligibility implementation and plugin/CLI incident evaluation remain pending",
   "source": {
     "commit": "ad50a6a41d5ee78f36e8c96a2000648cf8a5863d",
     "tree": "4ca51b5a75a79b4c0cf9ba1aca4354119f6ac83e",
@@ -44,13 +44,15 @@
   },
   "evaluation_contract": {
     "baseline": "Execute the complete pinned merged source tree in a separate approved temporary snapshot; never use moving origin/main, candidate source, or runStageOneBaseline as historical policy.",
-    "runtime": "Current evidence executes Core selector/renderer and real Viewer routes via Vitest source resolution. Plugin hooks and CLI child processes are not executed. Git blob checks compare working source bytes and pinned commit objects, not JSON equality. No fresh frozen-lockfile install is claimed.",
+    "runtime": "Historical runner executes Core selector/renderer and real Viewer routes from the pinned source snapshot with the immutable frozen harness. Its Git blob checks compare snapshot working bytes and pinned objects. Current checkout tests verify immutable harness provenance and explicit-pack compatibility separately. Plugin hooks and CLI child processes are not incident-evaluated. No fresh frozen-lockfile install is claimed.",
     "fixtures": "Invent public-safe incident rows and prompts, freeze their digest and gold facts/updates/negative summaries before execution, and seed independent temporary databases identically for baseline and candidate.",
     "controls": "Core budget 795, compression off. Fixture prefix wrapping is a synthetic estimate, not a plugin hook or 800-token budget test. Viewer asserts inclusion/mode with default compression, not comparable token counts. Fake JavaScript Date plus seeded row times; SQLite now is not frozen. No live database or paid/provider calls.",
     "reuse": "Reuse retained-recall reporting conventions and scripts/eval prompt-path transport setup, not the retained comparison's handwritten baseline or pre-rendered packs as actual-policy evidence.",
     "measurement": "Run twice; compare stable metrics excluding documented timing fields. Report useful-fact coverage, wrongful summary inclusion, missed updates and new/retained estimated tokens with denominators and per-case losses."
   },
   "artifacts": {
+    "frozen_harness_commit": "5de04daf3727fabe848ae29b9f5747c10aa77eb3",
+    "historical_runner": "scripts/eval/run-automatic-recall-baseline.mjs",
     "fixture": "scripts/eval/fixtures/automatic-recall-pre-policy.json",
     "report": "scripts/eval/baselines/automatic-recall-pre-policy.json",
     "regression": "packages/core/src/automatic-recall-pre-policy.eval.test.ts",
@@ -61,9 +63,11 @@
     "source_identity_evidence": "git rev-parse commit^{tree}; all 13 listed blobs checked using git rev-parse commit:path and git hash-object working-path, with equal observed IDs. This verifies listed source bytes, not execution of plugin/CLI surfaces.",
     "incident_fixture_digest": "7ea10a40b20f177df3f7c289916f2527349a13b113cde071a6bf2af0fadbcf12",
     "incident_evaluation_executed": true,
-    "baseline_gate": "pending independent parent review",
-    "independent_parent_review": "pending",
-    "code_reviewer_and_adversarial_reviews": "pending",
-    "stage_1_policy_edits_cleared": false
+    "baseline_gate": "source identity and frozen gold cleared only; plugin/CLI incident evaluation pending",
+    "independent_parent_review": "User reports AdversarialReviewer all5fixed clearance of source identity and gold preflight",
+    "code_reviewer_and_adversarial_reviews": "Requester eligibility implementation reviews pending; preflight clearance is not implementation approval",
+    "stage_1_policy_edits_cleared": true,
+    "requester_eligibility_implemented": false,
+    "plugin_cli_incident_evaluation": "pending"
   }
 }

--- a/scripts/eval/baselines/automatic-recall-pre-policy.json
+++ b/scripts/eval/baselines/automatic-recall-pre-policy.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": 1,
+  "label": "actual-source-pre-policy-generic-continue-v1",
+  "provenance": {
+    "source_commit": "ad50a6a41d5ee78f36e8c96a2000648cf8a5863d",
+    "source_tree": "4ca51b5a75a79b4c0cf9ba1aca4354119f6ac83e",
+    "fixture_digest_scheme": "SHA-256 of compact JSON with recursively sorted object keys (en locale), preserving array order; entire fixture including sessions, gold and controls. Digest lives outside the fixture.",
+    "harness_digest_scheme": "SHA-256 of file bytes; fixture and test files only. Manifest/report excluded to avoid recursive self hashes.",
+    "harness_sha256": {
+      "scripts/eval/fixtures/automatic-recall-pre-policy.json": "ef5eadc6bc96abb28cc8369816cae2d3a57aaff8638f5b7577f2ca863b1716ab",
+      "packages/core/src/automatic-recall-pre-policy.eval.test.ts": "0775384a82ca00996bc7ad61cb4f2a16d5e62d763749fae61151d01eaa9d3276",
+      "packages/viewer-server/src/routes/automatic-recall.test.ts": "d3e4b9a8fe05c34925b76ee7232369a4573ff8ea8f075e6102de95eed8130d72"
+    },
+    "fixture_sha256": "7ea10a40b20f177df3f7c289916f2527349a13b113cde071a6bf2af0fadbcf12"
+  },
+  "observed": {
+    "generic_continue": {
+      "mode": "task",
+      "selected_keys": [
+        "newest_unrelated_continuity",
+        "relevant_durable_parallel_fact"
+      ],
+      "summary_keys": ["newest_unrelated_continuity"],
+      "timeline_keys": ["relevant_durable_parallel_fact"],
+      "pack_tokens": 119,
+      "wrapped_estimated_tokens": { "new": 124, "retained": 0 }
+    },
+    "explicit_control": {
+      "mode": "recall",
+      "selected_keys": ["relevant_durable_parallel_fact"],
+      "summary_keys": [],
+      "timeline_keys": ["relevant_durable_parallel_fact"],
+      "pack_tokens": 82,
+      "wrapped_estimated_tokens": { "new": 86, "retained": 0 }
+    }
+  },
+  "gold": {
+    "generic_continue": {
+      "required_keys": ["relevant_durable_parallel_fact"],
+      "forbidden_keys": ["newest_unrelated_continuity"]
+    },
+    "explicit_control": {
+      "required_keys": ["relevant_durable_parallel_fact"],
+      "forbidden_keys": ["newest_unrelated_continuity"]
+    }
+  },
+  "incident": {
+    "generic_continue": {
+      "useful_fact_coverage": { "present": 1, "total": 1 },
+      "wrongful_summary_inclusion": { "count": 1, "total": 1 },
+      "missed_updates": { "count": 0, "total": 0 }
+    },
+    "explicit_control": {
+      "useful_fact_coverage": { "present": 1, "total": 1 },
+      "wrongful_summary_inclusion": { "count": 0, "total": 1 },
+      "missed_updates": { "count": 0, "total": 0 }
+    },
+    "interpretation": "Observed pre-policy output includes the newest unrelated continuity summary after generic Continue. Desired gold excludes it while retaining the relevant durable parallel fact."
+  },
+  "stability": {
+    "status": "corrected harness executed twice in isolated worktree; both runs passed all 12 tests",
+    "runs": 2,
+    "stable_fields": [
+      "mode",
+      "selected_keys",
+      "summary_keys",
+      "timeline_keys",
+      "pack_tokens",
+      "wrapped_estimated_tokens"
+    ],
+    "metric_sources": {
+      "pack_tokens": "trace.output.estimated_tokens from the actual Core renderer",
+      "wrapped_estimated_tokens.new": "estimateTokens(fixture.synthetic_wrapper_prefix + trace.output.pack_text); synthetic wrapper estimate only, not plugin execution or delivery",
+      "wrapped_estimated_tokens.retained": "fixture assumption of zero retained context; no plugin retention path executed",
+      "useful_fact_coverage": "selected_keys intersected with gold.required_keys",
+      "wrongful_summary_inclusion": "selected_keys intersected with gold.forbidden_keys",
+      "missed_updates": "fixture expected_updates is empty, so the denominator is zero; update handling is not evaluated"
+    },
+    "excluded_fields": ["timing", "usage-event pack delta"],
+    "clock_limits": "JavaScript Date is faked and seed memory/session times are fixed; SQLite now and usage event timestamps are not frozen"
+  },
+  "executed_command": "pnpm exec vitest run packages/core/src/automatic-recall-pre-policy.eval.test.ts packages/viewer-server/src/routes/automatic-recall.test.ts",
+  "validation": {
+    "tests": "12 passed in each of two actual Vitest 4.1.11 invocations; assertions confirmed recorded Core and synthetic-wrapper estimates after production remember seeding",
+    "typecheck": "pnpm run tsc passed",
+    "scoped_lint": "pnpm exec biome check packages/core/src/automatic-recall-pre-policy.eval.test.ts packages/viewer-server/src/routes/automatic-recall.test.ts exited 0; no new diagnostics; one existing noExcessiveLinesPerFunction warning in unchanged HTTP transport describe callback",
+    "diff_check": "git diff --check passed",
+    "source_identity": "All 13 listed working-file git hash-object values equal git rev-parse ad50a6a4:path and manifest blob IDs; commit tree matches pinned tree. Core uses relative source imports and Viewer Vite config aliases @codemem/core to core/src/index.ts with source conditions.",
+    "baseline_gate": "pending independent parent review",
+    "stage_1_policy_edits_cleared": false
+  },
+  "surfaces": {
+    "core": "actual buildMemoryPackTrace selector and renderer",
+    "viewer": "real /api/pack generic Continue inclusion and task mode only, default compression; no token comparability to Core compression off",
+    "plugin": "not executed; fixture prefix wrapping is a Core text estimate, not a hook test",
+    "cli": "not executed"
+  }
+}

--- a/scripts/eval/fixtures/automatic-recall-pre-policy.json
+++ b/scripts/eval/fixtures/automatic-recall-pre-policy.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "fixture_id": "generic-continue-cross-session-v1",
+  "clock": "2026-09-08T12:00:00.000Z",
+  "project": "public-fixture-project",
+  "requester_host_session_id": "host-quartz-task",
+  "query": "Continue",
+  "explicit_control_query": "What did we decide last time about quartz cache migration?",
+  "limit": 10,
+  "synthetic_wrapper_prefix": "[codemem context]\n",
+  "wrapper_scope": "Core text wrapped in a fixture prefix for an estimate only; no plugin hook or plugin budget enforcement executed",
+  "core_token_budget": 795,
+  "compression_mode": "off",
+  "viewer_compression_mode": "default; inclusion and mode assertions only, no token comparability",
+  "clock_scope": "JavaScript Date is faked; memory created_at/updated_at and session started_at are seeded; SQLite clock is not frozen",
+  "expected_updates": [],
+  "sessions": [
+    {
+      "host_session_id": "host-quartz-task",
+      "started_at": "2026-09-08T10:00:00.000Z",
+      "memories": [
+        {
+          "key": "relevant_durable_parallel_fact",
+          "kind": "decision",
+          "title": "Quartz cache migration next step",
+          "body": "QUARTZ_DURABLE_FACT: Keep the blue cache reader enabled until checksum parity reaches 100%.",
+          "confidence": 0.95,
+          "tags": ["quartz", "cache", "migration", "checksum"],
+          "created_at": "2026-09-08T10:05:00.000Z",
+          "metadata": { "artifact_class": "durable" }
+        }
+      ]
+    },
+    {
+      "host_session_id": "host-orchid-task",
+      "started_at": "2026-09-08T11:00:00.000Z",
+      "memories": [
+        {
+          "key": "newest_unrelated_continuity",
+          "kind": "session_summary",
+          "title": "Orchid release continuity",
+          "body": "ORCHID_UNRELATED_CONTINUITY: Continue the unrelated release checklist by polishing announcement copy.",
+          "confidence": 0.8,
+          "tags": ["orchid", "release"],
+          "created_at": "2026-09-08T11:05:00.000Z",
+          "metadata": { "is_summary": true, "artifact_class": "recap" }
+        }
+      ]
+    }
+  ],
+  "gold": {
+    "generic_continue": {
+      "required_keys": ["relevant_durable_parallel_fact"],
+      "forbidden_keys": ["newest_unrelated_continuity"]
+    },
+    "explicit_control": {
+      "required_keys": ["relevant_durable_parallel_fact"],
+      "forbidden_keys": ["newest_unrelated_continuity"]
+    }
+  }
+}

--- a/scripts/eval/frozen/automatic-recall-pre-policy/packages/core/src/automatic-recall-pre-policy.eval.test.ts
+++ b/scripts/eval/frozen/automatic-recall-pre-policy/packages/core/src/automatic-recall-pre-policy.eval.test.ts
@@ -1,7 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import manifest from "../../../scripts/eval/automatic-recall-pre-policy.json";
@@ -11,22 +10,6 @@ import { buildMemoryPackTrace, estimateTokens } from "./pack.js";
 import { MemoryStore } from "./store.js";
 
 type FixtureMemory = (typeof fixture.sessions)[number]["memories"][number];
-
-it("executes the immutable historical source and frozen harness separately", () => {
-	const cwd = fileURLToPath(new URL("../../../", import.meta.url));
-	const output = execFileSync(
-		process.execPath,
-		["scripts/eval/run-automatic-recall-baseline.mjs"],
-		{
-			cwd,
-			encoding: "utf8",
-			timeout: 60_000,
-		},
-	);
-	expect(output).toContain(`Historical source: ${manifest.source.commit}`);
-	expect(output).toContain(`frozen harness: ${manifest.artifacts.frozen_harness_commit}`);
-	expect(output).toMatch(/12 passed/);
-}, 65_000);
 
 function canonicalJson(value: unknown): string {
 	if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
@@ -43,30 +26,16 @@ function verifySourceIdentity() {
 	expect(git("rev-parse", `${manifest.source.commit}^{tree}`)).toBe(manifest.source.tree);
 	for (const [path, blob] of Object.entries(manifest.source.blobs)) {
 		expect(git("rev-parse", `${manifest.source.commit}:${path}`), path).toBe(blob);
+		expect(git("hash-object", path), path).toBe(blob);
 	}
-	// Committed frozen copies replace the harness commit, which squash merges leave unreachable.
-	const frozenDir = join(cwd, manifest.artifacts.frozen_harness_directory);
 	for (const [path, hash] of Object.entries(report.provenance.harness_sha256)) {
 		expect(
 			createHash("sha256")
-				.update(readFileSync(join(frozenDir, path)))
+				.update(readFileSync(new URL(`../../../${path}`, import.meta.url)))
 				.digest("hex"),
 			path,
 		).toBe(hash);
 	}
-	expect(
-		JSON.parse(
-			readFileSync(join(frozenDir, "scripts/eval/automatic-recall-pre-policy.json"), "utf8"),
-		).source,
-	).toEqual(manifest.source);
-	expect(
-		JSON.parse(
-			readFileSync(
-				join(frozenDir, "scripts/eval/baselines/automatic-recall-pre-policy.json"),
-				"utf8",
-			),
-		),
-	).toEqual(report);
 }
 
 function seedIncident(store: MemoryStore): Map<string, number> {
@@ -137,8 +106,7 @@ function countMatches(selectedKeys: string[], expectedKeys: readonly string[]): 
 	return expectedKeys.filter((key) => selectedKeys.includes(key)).length;
 }
 
-// Historical execution lives in run-automatic-recall-baseline.mjs; these calls retain explicit-pack semantics.
-describe("frozen baseline provenance and current explicit-pack compatibility", () => {
+describe("automatic recall actual-source pre-policy baseline", () => {
 	let store: MemoryStore;
 	let ids: Map<string, number>;
 

--- a/scripts/eval/frozen/automatic-recall-pre-policy/packages/viewer-server/src/routes/automatic-recall.test.ts
+++ b/scripts/eval/frozen/automatic-recall-pre-policy/packages/viewer-server/src/routes/automatic-recall.test.ts
@@ -1,0 +1,303 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MemoryStore } from "@codemem/core";
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fixture from "../../../../scripts/eval/fixtures/automatic-recall-pre-policy.json";
+import { insertTestSession } from "../../../core/src/test-utils.js";
+import { packTransportRoutes } from "./pack.js";
+import { statsRoutes } from "./stats.js";
+
+const attemptId = "018f2db4-f9d3-7a22-8d18-000000000001";
+const empty = {
+	v: 1,
+	candidateItems: 0,
+	duplicatesOmitted: 0,
+	beforeTokens: 0,
+	afterTokens: 0,
+	missingRetainedMetadata: false,
+	invalidRetainedMetadata: false,
+	packMetadata: "valid",
+};
+
+function seedRecallFixture(store: MemoryStore) {
+	for (const session of fixture.sessions) {
+		const sessionId = store.getOrCreateSessionForOpencodeSession({
+			opencodeSessionId: session.host_session_id,
+			project: fixture.project,
+			startedAt: session.started_at,
+		});
+		for (const memory of session.memories) {
+			const id = store.remember(
+				sessionId,
+				memory.kind,
+				memory.title,
+				memory.body,
+				memory.confidence,
+				memory.tags,
+				memory.metadata,
+			);
+			store.db
+				.prepare("UPDATE memory_items SET created_at = ?, updated_at = ? WHERE id = ?")
+				.run(memory.created_at, memory.created_at, id);
+		}
+	}
+}
+
+describe("automatic recall existing HTTP transport", () => {
+	let directory: string;
+	let store: MemoryStore;
+	let app: Hono;
+	beforeEach(() => {
+		directory = mkdtempSync(join(tmpdir(), "recall-api-"));
+		store = new MemoryStore(join(directory, "test.sqlite"));
+		app = new Hono()
+			.route(
+				"/",
+				packTransportRoutes(() => store),
+			)
+			.route(
+				"/",
+				statsRoutes(() => store),
+			);
+	});
+	afterEach(() => {
+		store.close();
+		rmSync(directory, { recursive: true, force: true });
+	});
+	const post = (path: string, body: unknown) =>
+		app.request(path, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		});
+	async function pack(id = attemptId) {
+		const response = await post("/api/pack", {
+			context: "recall candidate",
+			all_projects: true,
+			token_budget: 795,
+			attempt: { attempt_id: id, source: "opencode", request_id: `api-request-${id}` },
+		});
+		expect(response.status).toBe(200);
+		return response.json() as Promise<{ pack_text: string; metrics: { total_items: number } }>;
+	}
+	it("persists delivery measurements once and serves a bounded count-only Health summary", async () => {
+		store.remember(
+			insertTestSession(store.db),
+			"decision",
+			"recall candidate",
+			"private fixture body",
+			0.9,
+		);
+		const response = await pack();
+		const measurement = {
+			...empty,
+			candidateItems: response.metrics.total_items,
+			duplicatesOmitted: response.metrics.total_items,
+			beforeTokens: Math.ceil(`[codemem context]\n${response.pack_text}`.length / 4),
+		};
+		const payload = {
+			action: "delivery",
+			attempt_id: attemptId,
+			delivery_status: "unknown",
+			automatic_recall: measurement,
+			evaluation_key: "a".repeat(64),
+		};
+		expect((await post("/api/prompt-pack-ledger", payload)).status).toBe(200);
+		expect((await post("/api/prompt-pack-ledger", payload)).status).toBe(200);
+		const stats = await (await app.request("/api/stats")).json();
+		expect(stats.automatic_recall).toMatchObject({
+			availability: "available",
+			freshEvaluations: 1,
+			evaluationsWithDuplicates: 1,
+			estimatedTokensAvoided: measurement.beforeTokens,
+			captureVersion: "opencode-retained-v1",
+		});
+		expect(JSON.stringify(stats.automatic_recall)).not.toMatch(
+			/private|api-request|attempt_id|memory_id/,
+		);
+	});
+	it("records an empty evaluation without delivery and rejects spoofed counts or target mismatch", async () => {
+		await pack();
+		const payload = {
+			action: "recall",
+			attempt_id: attemptId,
+			automatic_recall: empty,
+			evaluation_key: "b".repeat(64),
+		};
+		expect(
+			(
+				await post("/api/prompt-pack-ledger", {
+					...payload,
+					db_path: join(directory, "other.sqlite"),
+				})
+			).status,
+		).toBe(409);
+		for (const automatic_recall of [
+			{ ...empty, candidateItems: 10 },
+			{ ...empty, beforeTokens: 999, afterTokens: 999 },
+			{ ...empty, memory_ids: [1] },
+		]) {
+			expect((await post("/api/prompt-pack-ledger", { ...payload, automatic_recall })).status).toBe(
+				400,
+			);
+		}
+		expect((await post("/api/prompt-pack-ledger", payload)).status).toBe(200);
+		const stats = await (await app.request("/api/stats")).json();
+		expect(stats.automatic_recall).toMatchObject({
+			freshEvaluations: 1,
+			estimatedTokensAvoided: 0,
+		});
+		expect(
+			store.db
+				.prepare("SELECT delivery_status FROM retrieval_attempts WHERE attempt_id = ?")
+				.get(attemptId),
+		).toEqual({ delivery_status: "not_attempted" });
+	});
+	it.each(["missing", "invalid", "no_results", "downgrade"])(
+		"does not persist measurements for rejected %s delivery",
+		async (scenario) => {
+			if (scenario !== "no_results") {
+				store.remember(
+					insertTestSession(store.db),
+					"decision",
+					"recall candidate",
+					"bounded fixture body",
+					0.9,
+				);
+			}
+			const response = await pack();
+			const payload = {
+				action: "delivery",
+				attempt_id: attemptId,
+				delivery_status: "handed_off",
+			};
+			if (scenario === "downgrade") {
+				expect((await post("/api/prompt-pack-ledger", payload)).status).toBe(200);
+			}
+			const before = store.db.prepare("SELECT * FROM retrieval_attempts").all();
+			let deliveryStatus: string | undefined = "failed";
+			if (scenario === "missing") deliveryStatus = undefined;
+			if (scenario === "invalid") deliveryStatus = "invalid";
+			const rejected = await post("/api/prompt-pack-ledger", {
+				...payload,
+				delivery_status: deliveryStatus,
+				evaluation_key: "d".repeat(64),
+				automatic_recall: {
+					...empty,
+					candidateItems: response.metrics.total_items,
+					duplicatesOmitted: response.metrics.total_items,
+					beforeTokens:
+						scenario === "no_results"
+							? 0
+							: Math.ceil(`[codemem context]\n${response.pack_text}`.length / 4),
+				},
+			});
+			expect(rejected.status).toBe(400);
+			expect(store.db.prepare("SELECT * FROM retrieval_attempts").all()).toEqual(before);
+			const stats = await (await app.request("/api/stats")).json();
+			expect(stats.automatic_recall).toMatchObject({
+				freshEvaluations: 0,
+				estimatedTokensAvoided: 0,
+			});
+		},
+	);
+	it("keeps delivery validation authoritative when diagnostics fail", async () => {
+		store.remember(
+			insertTestSession(store.db),
+			"decision",
+			"recall candidate",
+			"bounded fixture body",
+			0.9,
+		);
+		await pack();
+		const invalidDiagnostic = {
+			action: "delivery",
+			attempt_id: attemptId,
+			delivery_status: "handed_off",
+			automatic_recall: { ...empty, private_field: "rejected" },
+			evaluation_key: "c".repeat(64),
+		};
+		expect((await post("/api/prompt-pack-ledger", invalidDiagnostic)).status).toBe(200);
+		expect(
+			store.db
+				.prepare("SELECT delivery_status FROM retrieval_attempts WHERE attempt_id = ?")
+				.get(attemptId),
+		).toEqual({ delivery_status: "handed_off" });
+		expect(
+			(await post("/api/prompt-pack-ledger", { ...invalidDiagnostic, delivery_status: "invalid" }))
+				.status,
+		).toBe(400);
+		expect(
+			(
+				await post("/api/prompt-pack-ledger", {
+					...invalidDiagnostic,
+					db_path: join(directory, "other.sqlite"),
+				})
+			).status,
+		).toBe(409);
+
+		const secondAttempt = "018f2db4-f9d3-7a22-8d18-000000000002";
+		await pack(secondAttempt);
+		store.db.exec("ALTER TABLE retrieval_attempts DROP COLUMN automatic_recall_json");
+		expect(
+			(
+				await post("/api/prompt-pack-ledger", {
+					...invalidDiagnostic,
+					attempt_id: secondAttempt,
+					automatic_recall: empty,
+				})
+			).status,
+		).toBe(200);
+		expect(
+			store.db
+				.prepare("SELECT delivery_status FROM retrieval_attempts WHERE attempt_id = ?")
+				.get(secondAttempt),
+		).toEqual({ delivery_status: "handed_off" });
+	});
+});
+
+it(
+	"returns the actual pre-policy generic Continue incident through the Viewer route",
+	verifyViewerBaseline,
+);
+
+async function verifyViewerBaseline() {
+	vi.useFakeTimers({ toFake: ["Date"] });
+	vi.setSystemTime(new Date(fixture.clock));
+	const store = new MemoryStore(":memory:");
+	try {
+		// Arrange
+		seedRecallFixture(store);
+		const app = new Hono().route(
+			"/",
+			packTransportRoutes(() => store),
+		);
+
+		// Act
+		const response = await app.request("/api/pack", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				context: fixture.query,
+				project: fixture.project,
+				limit: fixture.limit,
+				token_budget: fixture.core_token_budget,
+			}),
+		});
+		const body = (await response.json()) as {
+			pack_text: string;
+			metrics: { mode: string };
+		};
+
+		// Assert
+		expect(response.status).toBe(200);
+		expect(body.metrics.mode).toBe("task");
+		expect(body.pack_text).toContain("QUARTZ_DURABLE_FACT");
+		expect(body.pack_text).toContain("ORCHID_UNRELATED_CONTINUITY");
+	} finally {
+		store.close();
+		vi.useRealTimers();
+	}
+}

--- a/scripts/eval/frozen/automatic-recall-pre-policy/scripts/eval/automatic-recall-pre-policy.json
+++ b/scripts/eval/frozen/automatic-recall-pre-policy/scripts/eval/automatic-recall-pre-policy.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "purpose": "Reviewed source identity and frozen gold baseline; requester eligibility implementation and plugin/CLI incident evaluation remain pending",
+  "purpose": "Actual-source pre-policy baseline candidate; gate pending independent parent review",
   "source": {
     "commit": "ad50a6a41d5ee78f36e8c96a2000648cf8a5863d",
     "tree": "4ca51b5a75a79b4c0cf9ba1aca4354119f6ac83e",
@@ -44,17 +44,13 @@
   },
   "evaluation_contract": {
     "baseline": "Execute the complete pinned merged source tree in a separate approved temporary snapshot; never use moving origin/main, candidate source, or runStageOneBaseline as historical policy.",
-    "runtime": "Historical runner executes Core selector/renderer and real Viewer routes from the pinned source snapshot with the immutable frozen harness. Its Git blob checks compare snapshot working bytes and pinned objects. Current checkout tests verify immutable harness provenance and explicit-pack compatibility separately. Plugin hooks and CLI child processes are not incident-evaluated. No fresh frozen-lockfile install is claimed.",
+    "runtime": "Current evidence executes Core selector/renderer and real Viewer routes via Vitest source resolution. Plugin hooks and CLI child processes are not executed. Git blob checks compare working source bytes and pinned commit objects, not JSON equality. No fresh frozen-lockfile install is claimed.",
     "fixtures": "Invent public-safe incident rows and prompts, freeze their digest and gold facts/updates/negative summaries before execution, and seed independent temporary databases identically for baseline and candidate.",
     "controls": "Core budget 795, compression off. Fixture prefix wrapping is a synthetic estimate, not a plugin hook or 800-token budget test. Viewer asserts inclusion/mode with default compression, not comparable token counts. Fake JavaScript Date plus seeded row times; SQLite now is not frozen. No live database or paid/provider calls.",
     "reuse": "Reuse retained-recall reporting conventions and scripts/eval prompt-path transport setup, not the retained comparison's handwritten baseline or pre-rendered packs as actual-policy evidence.",
     "measurement": "Run twice; compare stable metrics excluding documented timing fields. Report useful-fact coverage, wrongful summary inclusion, missed updates and new/retained estimated tokens with denominators and per-case losses."
   },
   "artifacts": {
-    "frozen_harness_commit": "5de04daf3727fabe848ae29b9f5747c10aa77eb3",
-    "frozen_harness_directory": "scripts/eval/frozen/automatic-recall-pre-policy",
-    "frozen_harness_note": "Byte-exact copies of the harness commit's manifest, report, fixture, and two test files. Runtime reads these copies, never the commit, because squash merges and shallow checkouts do not retain it.",
-    "historical_runner": "scripts/eval/run-automatic-recall-baseline.mjs",
     "fixture": "scripts/eval/fixtures/automatic-recall-pre-policy.json",
     "report": "scripts/eval/baselines/automatic-recall-pre-policy.json",
     "regression": "packages/core/src/automatic-recall-pre-policy.eval.test.ts",
@@ -65,11 +61,9 @@
     "source_identity_evidence": "git rev-parse commit^{tree}; all 13 listed blobs checked using git rev-parse commit:path and git hash-object working-path, with equal observed IDs. This verifies listed source bytes, not execution of plugin/CLI surfaces.",
     "incident_fixture_digest": "7ea10a40b20f177df3f7c289916f2527349a13b113cde071a6bf2af0fadbcf12",
     "incident_evaluation_executed": true,
-    "baseline_gate": "source identity and frozen gold cleared only; plugin/CLI incident evaluation pending",
-    "independent_parent_review": "User reports AdversarialReviewer all5fixed clearance of source identity and gold preflight",
-    "code_reviewer_and_adversarial_reviews": "Requester eligibility implementation reviews pending; preflight clearance is not implementation approval",
-    "stage_1_policy_edits_cleared": true,
-    "requester_eligibility_implemented": false,
-    "plugin_cli_incident_evaluation": "pending"
+    "baseline_gate": "pending independent parent review",
+    "independent_parent_review": "pending",
+    "code_reviewer_and_adversarial_reviews": "pending",
+    "stage_1_policy_edits_cleared": false
   }
 }

--- a/scripts/eval/frozen/automatic-recall-pre-policy/scripts/eval/baselines/automatic-recall-pre-policy.json
+++ b/scripts/eval/frozen/automatic-recall-pre-policy/scripts/eval/baselines/automatic-recall-pre-policy.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": 1,
+  "label": "actual-source-pre-policy-generic-continue-v1",
+  "provenance": {
+    "source_commit": "ad50a6a41d5ee78f36e8c96a2000648cf8a5863d",
+    "source_tree": "4ca51b5a75a79b4c0cf9ba1aca4354119f6ac83e",
+    "fixture_digest_scheme": "SHA-256 of compact JSON with recursively sorted object keys (en locale), preserving array order; entire fixture including sessions, gold and controls. Digest lives outside the fixture.",
+    "harness_digest_scheme": "SHA-256 of file bytes; fixture and test files only. Manifest/report excluded to avoid recursive self hashes.",
+    "harness_sha256": {
+      "scripts/eval/fixtures/automatic-recall-pre-policy.json": "ef5eadc6bc96abb28cc8369816cae2d3a57aaff8638f5b7577f2ca863b1716ab",
+      "packages/core/src/automatic-recall-pre-policy.eval.test.ts": "0775384a82ca00996bc7ad61cb4f2a16d5e62d763749fae61151d01eaa9d3276",
+      "packages/viewer-server/src/routes/automatic-recall.test.ts": "d3e4b9a8fe05c34925b76ee7232369a4573ff8ea8f075e6102de95eed8130d72"
+    },
+    "fixture_sha256": "7ea10a40b20f177df3f7c289916f2527349a13b113cde071a6bf2af0fadbcf12"
+  },
+  "observed": {
+    "generic_continue": {
+      "mode": "task",
+      "selected_keys": [
+        "newest_unrelated_continuity",
+        "relevant_durable_parallel_fact"
+      ],
+      "summary_keys": ["newest_unrelated_continuity"],
+      "timeline_keys": ["relevant_durable_parallel_fact"],
+      "pack_tokens": 119,
+      "wrapped_estimated_tokens": { "new": 124, "retained": 0 }
+    },
+    "explicit_control": {
+      "mode": "recall",
+      "selected_keys": ["relevant_durable_parallel_fact"],
+      "summary_keys": [],
+      "timeline_keys": ["relevant_durable_parallel_fact"],
+      "pack_tokens": 82,
+      "wrapped_estimated_tokens": { "new": 86, "retained": 0 }
+    }
+  },
+  "gold": {
+    "generic_continue": {
+      "required_keys": ["relevant_durable_parallel_fact"],
+      "forbidden_keys": ["newest_unrelated_continuity"]
+    },
+    "explicit_control": {
+      "required_keys": ["relevant_durable_parallel_fact"],
+      "forbidden_keys": ["newest_unrelated_continuity"]
+    }
+  },
+  "incident": {
+    "generic_continue": {
+      "useful_fact_coverage": { "present": 1, "total": 1 },
+      "wrongful_summary_inclusion": { "count": 1, "total": 1 },
+      "missed_updates": { "count": 0, "total": 0 }
+    },
+    "explicit_control": {
+      "useful_fact_coverage": { "present": 1, "total": 1 },
+      "wrongful_summary_inclusion": { "count": 0, "total": 1 },
+      "missed_updates": { "count": 0, "total": 0 }
+    },
+    "interpretation": "Observed pre-policy output includes the newest unrelated continuity summary after generic Continue. Desired gold excludes it while retaining the relevant durable parallel fact."
+  },
+  "stability": {
+    "status": "corrected harness executed twice in isolated worktree; both runs passed all 12 tests",
+    "runs": 2,
+    "stable_fields": [
+      "mode",
+      "selected_keys",
+      "summary_keys",
+      "timeline_keys",
+      "pack_tokens",
+      "wrapped_estimated_tokens"
+    ],
+    "metric_sources": {
+      "pack_tokens": "trace.output.estimated_tokens from the actual Core renderer",
+      "wrapped_estimated_tokens.new": "estimateTokens(fixture.synthetic_wrapper_prefix + trace.output.pack_text); synthetic wrapper estimate only, not plugin execution or delivery",
+      "wrapped_estimated_tokens.retained": "fixture assumption of zero retained context; no plugin retention path executed",
+      "useful_fact_coverage": "selected_keys intersected with gold.required_keys",
+      "wrongful_summary_inclusion": "selected_keys intersected with gold.forbidden_keys",
+      "missed_updates": "fixture expected_updates is empty, so the denominator is zero; update handling is not evaluated"
+    },
+    "excluded_fields": ["timing", "usage-event pack delta"],
+    "clock_limits": "JavaScript Date is faked and seed memory/session times are fixed; SQLite now and usage event timestamps are not frozen"
+  },
+  "executed_command": "pnpm exec vitest run packages/core/src/automatic-recall-pre-policy.eval.test.ts packages/viewer-server/src/routes/automatic-recall.test.ts",
+  "validation": {
+    "tests": "12 passed in each of two actual Vitest 4.1.11 invocations; assertions confirmed recorded Core and synthetic-wrapper estimates after production remember seeding",
+    "typecheck": "pnpm run tsc passed",
+    "scoped_lint": "pnpm exec biome check packages/core/src/automatic-recall-pre-policy.eval.test.ts packages/viewer-server/src/routes/automatic-recall.test.ts exited 0; no new diagnostics; one existing noExcessiveLinesPerFunction warning in unchanged HTTP transport describe callback",
+    "diff_check": "git diff --check passed",
+    "source_identity": "All 13 listed working-file git hash-object values equal git rev-parse ad50a6a4:path and manifest blob IDs; commit tree matches pinned tree. Core uses relative source imports and Viewer Vite config aliases @codemem/core to core/src/index.ts with source conditions.",
+    "baseline_gate": "pending independent parent review",
+    "stage_1_policy_edits_cleared": false
+  },
+  "surfaces": {
+    "core": "actual buildMemoryPackTrace selector and renderer",
+    "viewer": "real /api/pack generic Continue inclusion and task mode only, default compression; no token comparability to Core compression off",
+    "plugin": "not executed; fixture prefix wrapping is a Core text estimate, not a hook test",
+    "cli": "not executed"
+  }
+}

--- a/scripts/eval/frozen/automatic-recall-pre-policy/scripts/eval/fixtures/automatic-recall-pre-policy.json
+++ b/scripts/eval/frozen/automatic-recall-pre-policy/scripts/eval/fixtures/automatic-recall-pre-policy.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": 1,
+  "fixture_id": "generic-continue-cross-session-v1",
+  "clock": "2026-09-08T12:00:00.000Z",
+  "project": "public-fixture-project",
+  "requester_host_session_id": "host-quartz-task",
+  "query": "Continue",
+  "explicit_control_query": "What did we decide last time about quartz cache migration?",
+  "limit": 10,
+  "synthetic_wrapper_prefix": "[codemem context]\n",
+  "wrapper_scope": "Core text wrapped in a fixture prefix for an estimate only; no plugin hook or plugin budget enforcement executed",
+  "core_token_budget": 795,
+  "compression_mode": "off",
+  "viewer_compression_mode": "default; inclusion and mode assertions only, no token comparability",
+  "clock_scope": "JavaScript Date is faked; memory created_at/updated_at and session started_at are seeded; SQLite clock is not frozen",
+  "expected_updates": [],
+  "sessions": [
+    {
+      "host_session_id": "host-quartz-task",
+      "started_at": "2026-09-08T10:00:00.000Z",
+      "memories": [
+        {
+          "key": "relevant_durable_parallel_fact",
+          "kind": "decision",
+          "title": "Quartz cache migration next step",
+          "body": "QUARTZ_DURABLE_FACT: Keep the blue cache reader enabled until checksum parity reaches 100%.",
+          "confidence": 0.95,
+          "tags": ["quartz", "cache", "migration", "checksum"],
+          "created_at": "2026-09-08T10:05:00.000Z",
+          "metadata": { "artifact_class": "durable" }
+        }
+      ]
+    },
+    {
+      "host_session_id": "host-orchid-task",
+      "started_at": "2026-09-08T11:00:00.000Z",
+      "memories": [
+        {
+          "key": "newest_unrelated_continuity",
+          "kind": "session_summary",
+          "title": "Orchid release continuity",
+          "body": "ORCHID_UNRELATED_CONTINUITY: Continue the unrelated release checklist by polishing announcement copy.",
+          "confidence": 0.8,
+          "tags": ["orchid", "release"],
+          "created_at": "2026-09-08T11:05:00.000Z",
+          "metadata": { "is_summary": true, "artifact_class": "recap" }
+        }
+      ]
+    }
+  ],
+  "gold": {
+    "generic_continue": {
+      "required_keys": ["relevant_durable_parallel_fact"],
+      "forbidden_keys": ["newest_unrelated_continuity"]
+    },
+    "explicit_control": {
+      "required_keys": ["relevant_durable_parallel_fact"],
+      "forbidden_keys": ["newest_unrelated_continuity"]
+    }
+  }
+}

--- a/scripts/eval/run-automatic-recall-baseline.mjs
+++ b/scripts/eval/run-automatic-recall-baseline.mjs
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = realpathSync(fileURLToPath(new URL("../../", import.meta.url)));
@@ -42,14 +42,44 @@ function linkDependencies(source, target) {
     }
     if (name.startsWith(".")) continue;
     const dependency = realpathSync(join(source, name));
-    const local = relative(root, dependency);
-    const destination = local.startsWith("packages/") ? resolve(snapshot, local) : dependency;
+    const destination = workspacePackageSegments(dependency)
+      ? join(snapshot, ...workspacePackageSegments(dependency))
+      : dependency;
     symlinkSync(destination, join(target, name), "dir");
   }
 }
+
+// Platform-independent containment check: path.relative yields backslashes on
+// Windows, so a string prefix test would keep candidate Core linked into the
+// historical snapshot and silently invalidate the baseline.
+function workspacePackageSegments(dependency) {
+  const local = relative(root, dependency);
+  if (!local || local.startsWith("..") || isAbsolute(local)) return null;
+  const segments = local.split(sep);
+  return segments[0] === "packages" && segments.length > 1 ? segments : null;
+}
+
+// Fail loudly if any workspace dependency would still resolve into the candidate checkout.
+function assertNoCandidateWorkspaceLinks(dir) {
+  for (const name of readdirSync(dir)) {
+    const entry = join(dir, name);
+    if (name.startsWith("@")) {
+      assertNoCandidateWorkspaceLinks(entry);
+      continue;
+    }
+    if (name.startsWith(".")) continue;
+    if (workspacePackageSegments(realpathSync(entry))) {
+      throw new Error(`Historical snapshot still links candidate workspace package: ${name}`);
+    }
+  }
+}
 linkDependencies(join(root, "node_modules"), join(snapshot, "node_modules"));
+assertNoCandidateWorkspaceLinks(join(snapshot, "node_modules"));
 for (const name of readdirSync(join(snapshot, "packages"))) {
   linkDependencies(join(root, "packages", name, "node_modules"), join(snapshot, "packages", name, "node_modules"));
+  if (existsSync(join(snapshot, "packages", name, "node_modules"))) {
+    assertNoCandidateWorkspaceLinks(join(snapshot, "packages", name, "node_modules"));
+  }
 }
 
 // Git reads objects from the original clone and hashes working bytes from the snapshot.

--- a/scripts/eval/run-automatic-recall-baseline.mjs
+++ b/scripts/eval/run-automatic-recall-baseline.mjs
@@ -7,19 +7,22 @@ import { fileURLToPath } from "node:url";
 const root = realpathSync(fileURLToPath(new URL("../../", import.meta.url)));
 const manifest = JSON.parse(readFileSync(join(root, "scripts/eval/automatic-recall-pre-policy.json"), "utf8"));
 const git = (...args) => execFileSync("git", args, { cwd: root, maxBuffer: 64 * 1024 * 1024 });
-const frozen = manifest.artifacts.frozen_harness_commit;
+// Frozen harness bytes are committed copies; squash merges make the original
+// harness commit unreachable, and shallow CI checkouts never had it.
+const frozenDir = join(root, manifest.artifacts.frozen_harness_directory);
 const reportPath = "scripts/eval/baselines/automatic-recall-pre-policy.json";
-const report = JSON.parse(git("show", `${frozen}:${reportPath}`));
+const report = JSON.parse(readFileSync(join(frozenDir, reportPath), "utf8"));
 const scratch = join(root, ".tmp");
 mkdirSync(scratch, { recursive: true });
 const snapshot = mkdtempSync(join(scratch, "codemem-recall-baseline-"));
 
 // Export the historical tree, not candidate files or a handwritten selector substitute.
+// The historical commit is on main; CI must fetch full history for it.
 execFileSync("tar", ["-xf", "-", "-C", snapshot], {
   input: git("archive", manifest.source.commit),
 });
 for (const path of ["scripts/eval/automatic-recall-pre-policy.json", reportPath, ...Object.keys(report.provenance.harness_sha256)]) {
-  const bytes = git("show", `${frozen}:${path}`);
+  const bytes = readFileSync(join(frozenDir, path));
   const expected = report.provenance.harness_sha256[path];
   if (expected && createHash("sha256").update(bytes).digest("hex") !== expected) {
     throw new Error(`Frozen harness digest mismatch: ${path}`);
@@ -51,7 +54,9 @@ for (const name of readdirSync(join(snapshot, "packages"))) {
 
 // Git reads objects from the original clone and hashes working bytes from the snapshot.
 // Keep the snapshot for inspection; never overwrite the frozen report or a user database.
-console.log(`Historical source: ${manifest.source.commit}; frozen harness: ${frozen}`);
+console.log(
+  `Historical source: ${manifest.source.commit}; frozen harness: ${manifest.artifacts.frozen_harness_commit} (${manifest.artifacts.frozen_harness_directory})`,
+);
 console.log(`Baseline snapshot: ${snapshot}`);
 execFileSync(process.execPath, [join(root, "node_modules/vitest/vitest.mjs"), "run",
   "packages/core/src/automatic-recall-pre-policy.eval.test.ts",

--- a/scripts/eval/run-automatic-recall-baseline.mjs
+++ b/scripts/eval/run-automatic-recall-baseline.mjs
@@ -1,0 +1,67 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = realpathSync(fileURLToPath(new URL("../../", import.meta.url)));
+const manifest = JSON.parse(readFileSync(join(root, "scripts/eval/automatic-recall-pre-policy.json"), "utf8"));
+const git = (...args) => execFileSync("git", args, { cwd: root, maxBuffer: 64 * 1024 * 1024 });
+const frozen = manifest.artifacts.frozen_harness_commit;
+const reportPath = "scripts/eval/baselines/automatic-recall-pre-policy.json";
+const report = JSON.parse(git("show", `${frozen}:${reportPath}`));
+const scratch = join(root, ".tmp");
+mkdirSync(scratch, { recursive: true });
+const snapshot = mkdtempSync(join(scratch, "codemem-recall-baseline-"));
+
+// Export the historical tree, not candidate files or a handwritten selector substitute.
+execFileSync("tar", ["-xf", "-", "-C", snapshot], {
+  input: git("archive", manifest.source.commit),
+});
+for (const path of ["scripts/eval/automatic-recall-pre-policy.json", reportPath, ...Object.keys(report.provenance.harness_sha256)]) {
+  const bytes = git("show", `${frozen}:${path}`);
+  const expected = report.provenance.harness_sha256[path];
+  if (expected && createHash("sha256").update(bytes).digest("hex") !== expected) {
+    throw new Error(`Frozen harness digest mismatch: ${path}`);
+  }
+  mkdirSync(dirname(join(snapshot, path)), { recursive: true });
+  writeFileSync(join(snapshot, path), bytes);
+}
+
+// Reuse installed external dependencies, but redirect workspace packages into the historical tree.
+function linkDependencies(source, target) {
+  if (!existsSync(source)) return;
+  mkdirSync(target, { recursive: true });
+  for (const name of readdirSync(source)) {
+    if (name.startsWith("@")) {
+      linkDependencies(join(source, name), join(target, name));
+      continue;
+    }
+    if (name.startsWith(".")) continue;
+    const dependency = realpathSync(join(source, name));
+    const local = relative(root, dependency);
+    const destination = local.startsWith("packages/") ? resolve(snapshot, local) : dependency;
+    symlinkSync(destination, join(target, name), "dir");
+  }
+}
+linkDependencies(join(root, "node_modules"), join(snapshot, "node_modules"));
+for (const name of readdirSync(join(snapshot, "packages"))) {
+  linkDependencies(join(root, "packages", name, "node_modules"), join(snapshot, "packages", name, "node_modules"));
+}
+
+// Git reads objects from the original clone and hashes working bytes from the snapshot.
+// Keep the snapshot for inspection; never overwrite the frozen report or a user database.
+console.log(`Historical source: ${manifest.source.commit}; frozen harness: ${frozen}`);
+console.log(`Baseline snapshot: ${snapshot}`);
+execFileSync(process.execPath, [join(root, "node_modules/vitest/vitest.mjs"), "run",
+  "packages/core/src/automatic-recall-pre-policy.eval.test.ts",
+  "packages/viewer-server/src/routes/automatic-recall.test.ts"], {
+  cwd: snapshot,
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    GIT_DIR: git("rev-parse", "--absolute-git-dir").toString().trim(),
+    GIT_WORK_TREE: snapshot,
+    CODEMEM_EMBEDDING_DISABLED: "1",
+  },
+});


### PR DESCRIPTION
## Description
This lower layer preserves the reviewed pre-policy source and invented incident fixture for requester eligibility in #1654. It contains only baseline preservation and historical execution, not the eligibility implementation.

- Preserve source commit `ad50a6a41d5ee78f36e8c96a2000648cf8a5863d` and its tree plus selected blob identities.
- `5de04daf` froze the original harness; the historical-execution commit (now `ecf3fddf` after the branch was rebased onto current `main`) added separate execution without weakening source-byte checks.
- `7bc0488a` (review follow-up, originally `82c80a1d`) commits byte-exact copies of the frozen manifest, report, fixture, and two test files under `scripts/eval/frozen/automatic-recall-pre-policy/`. The runner and provenance test read those copies instead of `git show 5de04daf:<path>`, and the `ts-test` CI job now uses `fetch-depth: 0` so `git archive ad50a6a4` (a permanent `main` ancestor) works in CI.

This is the baseline-preservation portion of codemem-9azf.10; that task stays in progress for multi-task expansion. Parent-reported independent baseline/adversarial clearance preceded policy implementation. No paid evaluation or live database was used.

## Review feedback
Codex P2 (`run-automatic-recall-baseline.mjs:46`, Windows path prefix check): **valid, fixed in `d39c1e59`**. Workspace containment uses `path.relative` split on `path.sep`, and the runner asserts after linking that no `node_modules` entry still resolves into a candidate `packages/*` directory.

Codex P1 (`run-automatic-recall-baseline.mjs:12`, pinned commits unavailable in shallow checkouts): **valid, fixed in `7bc0488a`**. CI reproduced it exactly (`fatal: path ... exists on disk, but not in 5de04daf...` and `unknown revision ad50a6a4...^{tree}`). The repository is squash-merge-only with branch deletion, so `5de04daf` would also have become unreachable on `main` after merge; committed copies remove that dependency entirely. The three frozen harness copies hash to the report's recorded `harness_sha256` values (`ef5eadc6...`, `0775384a...`, `d3e4b9a8...`).

## Type of Change
- [ ] Feature (new functionality)
- [ ] Bug fix (fixes an issue)
- [ ] Documentation (docs-only change)
- [ ] Maintenance (refactor, chore, CI, etc.)
- [x] Testing (test-only changes)

## Testing
| Evidence | Result |
|---|---|
| `pnpm exec vitest run packages/core/src/automatic-recall-pre-policy.eval.test.ts packages/viewer-server/src/routes/automatic-recall.test.ts` at `82c80a1d` | 13 passed (includes nested historical 12-test run) |
| Squash simulation: synthetic squash of this tree onto `main`, cloned `--no-local` so `5de04daf` is absent and `ad50a6a4` present | new runner/provenance test 5/5 pass; the `19014686` runner reproduces the CI `fatal` |
| Frozen copy digests after commit hooks | all three equal report `harness_sha256` |
| `pnpm run test:ci-workflow` | 10 pass |
| `git diff --check` | Pass |
| Full default `pnpm run check` at stack head `d909da7e` (includes this layer, on current `main`) in a `codemem`-named clone | 267 files, 6,481 passed, 3 todo, exit 0 |
| CI on `d39c1e59` | All checks SUCCESS; Codex completed, zero unresolved threads |

Local full-suite note: in a checkout whose directory is not named `codemem`, four pre-existing tests fail at the untouched `main` baseline `5a4f4366` (`packages/core/src/export-import.test.ts` x3, `packages/mcp-server/src/project-scope.test.ts` x1) because `resolveProject` derives the default project from the checkout directory name. Same commit, same `node_modules`, renamed to `codemem`: 17/17 pass. Not touched by this stack; CI checkouts are named `codemem`.

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`) in a `codemem`-named clone
- [x] Added/updated tests for changes
- [x] Manually verified historical runner, source identity, and squash-merge simulation

## Checklist
- [x] Code follows project style (lint exits successfully with pre-existing warnings)
- [x] Self-review completed
- [x] Documentation updated
- [ ] No new warnings introduced

Limits: baseline wrapper estimates are synthetic Core text estimates, not plugin execution or provider token counts. #1654 adds actual plugin/Viewer/CLI incident measurements. JavaScript Date is frozen, SQLite clock is not; dependencies were reused rather than freshly installed. This branch was rebased onto current `main` (`20b0959d`) by the repository owner after publication; the pinned `ad50a6a4` source identity and the frozen copies are unaffected by that rebase. Submitted ready for review only. Do not merge or enable automerge.
