### PR TITLE
test(core): seed cleanup-reconnect corpus in one transaction

### DIFF
--- a/packages/core/src/vector-migration.test.ts
+++ b/packages/core/src/vector-migration.test.ts
@@ -1426,10 +1426,16 @@ describe("vector migration", () => {
 			firstDb = new Database(dbPath);
 			initTestSchema(firstDb);
 			const sessionId = insertTestSession(firstDb);
-			for (let id = 1; id <= 251; id++) {
-				seedMemory(firstDb, id, sessionId, `Memory ${id}`, `Body ${id}`);
-				seedVector(firstDb, id, "old-model");
-			}
+			// Seed in one transaction: this is a file-backed database with the
+			// default rollback journal, so per-statement autocommits each fsync
+			// and the 500+ seed writes became disk-latency-bound on CI runners.
+			const seedCorpus = firstDb.transaction(() => {
+				for (let id = 1; id <= 251; id++) {
+					seedMemory(firstDb as Database, id, sessionId, `Memory ${id}`, `Body ${id}`);
+					seedVector(firstDb as Database, id, "old-model");
+				}
+			});
+			seedCorpus();
 			let stopRequested = false;
 			let staleBatchSelections = 0;
 			const prepareSpy = vi.spyOn(firstDb, "prepare");


### PR DESCRIPTION
## Description
`vector-migration.test.ts > revalidates target coverage after cleanup resumes on a new connection` intermittently exceeds the 5s vitest timeout on CI (6.1s observed on #1649's run; 1.4s on a healthy rerun; also reproduces on `main`).

Root cause: the test opens a raw file-backed `better-sqlite3` connection (no `db.ts` WAL/`synchronous=NORMAL` pragmas), so its 500+ seed statements each autocommit and fsync. That makes setup disk-latency-bound on CI runners.

Fix: seed the corpus inside a single transaction so setup costs one fsync. Sibling file-backed tests seed 1–4 rows so they don't need the change. Migration-pass behavior and the cross-connection `data_version` fencing those siblings exercise are untouched.

## Type of Change
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Ran the file 3× locally: the test dropped from ~550ms to ~310ms on a fast SSD; all 47 tests pass. CI gain should be larger since fsync latency dominated there.

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
