### PR TITLE
fix(core): skip WAL pragma for in-memory databases

### DIFF
--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -60,6 +60,18 @@ describe("connect", () => {
 		expect(mode.toLowerCase()).toBe("wal");
 	});
 
+	it("opens an in-memory database without attempting WAL or warning", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			db = connect(":memory:");
+			const mode = db.pragma("journal_mode", { simple: true }) as string;
+			expect(mode.toLowerCase()).toBe("memory");
+			expect(warn).not.toHaveBeenCalledWith(expect.stringContaining("Failed to enable WAL mode"));
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
 	it("sets busy_timeout to 5000ms", () => {
 		db = connect(join(tmpDir, "test.sqlite"));
 		const timeout = db.pragma("busy_timeout", { simple: true });

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -204,6 +204,10 @@ export function migrateLegacyDbPath(dbPath: string): void {
 	}
 }
 
+function isInMemoryDbPath(dbPath: string): boolean {
+	return dbPath === "" || dbPath === ":memory:" || dbPath.startsWith("file::memory:");
+}
+
 /**
  * Open a better-sqlite3 connection with the standard codemem pragmas.
  *
@@ -224,11 +228,15 @@ export function connect(dbPath: string = DEFAULT_DB_PATH): DatabaseType {
 		ensureSchemaBootstrapped(db);
 		if (!configureWal) return db;
 
-		const journalMode = db.pragma("journal_mode = WAL", { simple: true }) as string;
-		if (journalMode.toLowerCase() !== "wal") {
-			console.warn(
-				`Failed to enable WAL mode (got ${journalMode}). Concurrent access may not work correctly.`,
-			);
+		// In-memory databases cannot use WAL (SQLite reports "memory") and have
+		// no cross-process readers, so skip the pragma and its warning.
+		if (!isInMemoryDbPath(dbPath)) {
+			const journalMode = db.pragma("journal_mode = WAL", { simple: true }) as string;
+			if (journalMode.toLowerCase() !== "wal") {
+				console.warn(
+					`Failed to enable WAL mode (got ${journalMode}). Concurrent access may not work correctly.`,
+				);
+			}
 		}
 
 		db.pragma("synchronous = NORMAL");


### PR DESCRIPTION
## Description

`connect()` tried `PRAGMA journal_mode = WAL` on every database, including `:memory:`. SQLite cannot use WAL for in-memory databases and returns `memory`, so every test that opened an in-memory store logged `Failed to enable WAL mode (got memory). Concurrent access may not work correctly.` — dozens of times per CI run, with no actionable signal.

This skips the WAL pragma and its warning for in-memory paths (`:memory:`, `""`, `file::memory:`). In-memory databases have no cross-process readers, so the concurrency warning does not apply. File-backed databases still enable WAL and still warn when it fails.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

`pnpm run tsc` clean; `pnpm run lint` reports only pre-existing warnings. `packages/core/src/db.test.ts` passes (89 tests) with a new case asserting in-memory opens do not emit the WAL warning. Running `maintenance-worker-runtime`, `diagnostics`, and `team-setup` suites now emits 0 WAL warnings (previously dozens).

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
