### PR TITLE
fix(recall): scope pack delta baselines to requester continuity

### DIFF
--- a/packages/core/src/pack.test.ts
+++ b/packages/core/src/pack.test.ts
@@ -190,6 +190,46 @@ describe("automatic session continuity", () => {
 		expect(automatic.item_ids).toContain(durableId);
 		expect(generic.pack_text).toContain("Root sibling summary");
 	});
+
+	it("skips pack delta baselines that carry another requester's summary", () => {
+		const otherSessionId = insertTestSession(store.db);
+		const now = new Date().toISOString();
+		const mapHost = store.db.prepare(
+			"INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES (?, ?, ?, ?, ?)",
+		);
+		mapHost.run("opencode", "host-a", "host-a", sessionId, now);
+		mapHost.run("opencode", "host-b", "host-b", otherSessionId, now);
+		const summaryAId = store.remember(
+			sessionId,
+			"session_summary",
+			"Session A delta summary",
+			"delta baseline handoff",
+			0.9,
+		);
+		const durableId = store.remember(
+			otherSessionId,
+			"decision",
+			"Shared delta fact",
+			"delta baseline evidence",
+			0.9,
+		);
+		const packA = store.buildMemoryPack("delta baseline", 10, null, undefined, {
+			source: "opencode",
+			hostSessionId: "host-a",
+		});
+		expect(packA.item_ids).toContain(summaryAId);
+
+		const packB = store.buildMemoryPack("delta baseline", 10, null, undefined, {
+			source: "opencode",
+			hostSessionId: "host-b",
+		});
+
+		expect(packB.item_ids).not.toContain(summaryAId);
+		expect(packB.item_ids).toContain(durableId);
+		expect(packB.metrics.pack_delta_available).toBe(false);
+		expect(packB.metrics.removed_ids).not.toContain(summaryAId);
+		expect(packB.metrics.pack_token_delta).toBe(0);
+	});
 });
 describe("automatic requester sentinel", () => {
 	usePackFixture();

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -30,6 +30,7 @@ import {
 	getSummaryMetadata,
 	isNativeSessionSummaryMemory,
 	isSummaryLikeMemory,
+	summaryContinuityFilter,
 	summaryLikeSqlPredicate,
 } from "./summary-memory.js";
 import type {
@@ -1077,21 +1078,29 @@ function validatePackDeltaBaselineIds(
 	store: StoreHandle,
 	ids: number[],
 	filters: MemoryFilters | null,
+	summarySessionId: number | null | undefined,
 ): number[] | null {
 	if (ids.length === 0) return null;
 	const filterResult = buildFilterClausesWithContext(filters, ownershipFilterContext(store));
+	const continuity = summaryContinuityFilter(summarySessionId);
 	const placeholders = ids.map(() => "?").join(", ");
 	const joinClause = filterResult.joinSessions
 		? "JOIN sessions ON sessions.id = memory_items.session_id"
 		: "";
+	const whereParts = [
+		"memory_items.active = 1",
+		`memory_items.id IN (${placeholders})`,
+		...filterResult.clauses,
+		...continuity.clauses,
+	];
 	const rows = store.db
 		.prepare(
 			`SELECT memory_items.id
 			 FROM memory_items
 			 ${joinClause}
-			 WHERE ${["memory_items.active = 1", `memory_items.id IN (${placeholders})`, ...filterResult.clauses].join(" AND ")}`,
+			 WHERE ${whereParts.join(" AND ")}`,
 		)
-		.all(...ids, ...filterResult.params) as Array<{ id: number }>;
+		.all(...ids, ...filterResult.params, ...continuity.params) as Array<{ id: number }>;
 	const visibleIds = new Set(rows.map((row) => row.id));
 	if (visibleIds.size !== ids.length) return null;
 	return ids.filter((id) => visibleIds.has(id));
@@ -1181,6 +1190,7 @@ function findLatestSummaryLike(
 function getPackDeltaBaseline(
 	store: StoreHandle,
 	filters: MemoryFilters | null,
+	summarySessionId: number | null | undefined,
 ): { previousPackIds: number[] | null; previousPackTokens: number | null } {
 	const project = filters?.project ?? null;
 	const projectBase = project ? projectBasename(project) : null;
@@ -1221,7 +1231,7 @@ function getPackDeltaBaseline(
 
 			const { ids, valid } = coercePackItemIds(metadata.pack_item_ids);
 			if (!valid) continue;
-			const scopedIds = validatePackDeltaBaselineIds(store, ids, filters);
+			const scopedIds = validatePackDeltaBaselineIds(store, ids, filters, summarySessionId);
 			if (scopedIds == null) continue;
 
 			const previousTokens =
@@ -1961,7 +1971,11 @@ function buildPackArtifacts(
 		}
 	}
 
-	const { previousPackIds, previousPackTokens } = getPackDeltaBaseline(store, filters ?? null);
+	const { previousPackIds, previousPackTokens } = getPackDeltaBaseline(
+		store,
+		filters ?? null,
+		summarySessionId,
+	);
 	const packDeltaAvailable = previousPackIds != null && previousPackTokens != null;
 	const previousSet = new Set(previousPackIds ?? []);
 	const currentSet = new Set(allItemIds);


### PR DESCRIPTION
## Description

Follow-up to #1654 addressing the post-merge Codex P2 on `getPackDeltaBaseline()`.

When automatic packs for two mapped OpenCode sessions ran consecutively in the same project, the delta baseline validated the previous pack's item IDs only against `filters`, not the newly resolved requester continuity scope. A summary authorized for session A therefore became a `removed_ids` entry for session B and `pack_token_delta` subtracted A's full token count, producing a false `delta +…/-…` injection toast.

`validatePackDeltaBaselineIds` now applies `summaryContinuityFilter` inside the visibility query, so any prior baseline containing a summary ineligible for the current requester fails validation and is skipped, the same way out-of-scope baselines already are.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

New regression test: two mapped host sessions in one project, pack A includes A's summary, pack B must not report it as removed and must report `pack_delta_available: false` and `pack_token_delta: 0`. Verified the test fails on `main` and passes with this change. `pnpm run tsc` clean; Biome on touched files reports only pre-existing warnings; `pack`, `automatic-recall-pre-policy.eval`, CLI `pack`, and viewer `automatic-recall` suites pass (140 tests).

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
