### PR TITLE
fix(core): remove contained Team routing in transaction

### DIFF
--- a/packages/core/src/legacy-team-setup-completion-manifest.test.ts
+++ b/packages/core/src/legacy-team-setup-completion-manifest.test.ts
@@ -11,6 +11,7 @@ import {
 import {
 	applyLegacyTeamSetupCompletionManifest,
 	areLegacyTeamSetupCompletionPolicyFactsAdditivelyCompatible,
+	containLegacyTeamSetupCompletionConflict,
 	deriveLegacyTeamSetupCompletionManifest,
 	LegacyTeamSetupAdditiveConvergenceError,
 	reconstructLegacyTeamSetupCompletionManifest,
@@ -29,6 +30,7 @@ import {
 	recipientPolicyDigest,
 } from "./recipient-policy-identifiers.js";
 import { renameRecipientPolicyTeam } from "./recipient-policy-team-metadata.js";
+import { resolveSessionScopeId } from "./scope-stamping.js";
 import { initTestSchema } from "./test-utils.js";
 
 const NOW = "2026-09-01T12:00:00.000Z";
@@ -765,6 +767,93 @@ describe("legacy Team setup completion manifests", () => {
 				.pluck()
 				.get(replacement.attemptId),
 		).toBe("completed");
+	});
+
+	it("rejects both canonical mutation APIs outside a transaction", () => {
+		const draft = readyDraft();
+		expect(() =>
+			applyCanonicalLegacyTeamSetupActivationInTransaction(db, {
+				candidateRef: CANDIDATE,
+				attemptId: draft.attemptId,
+				policyRevision: "revision",
+				completedAt: NOW,
+			}),
+		).toThrow("team_setup_failed");
+		expect(() =>
+			applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction(db, {
+				candidateRef: CANDIDATE,
+				attemptId: draft.attemptId,
+				teamId: "team",
+				projectRefs: [PROJECT_REF_A],
+				completedAt: NOW,
+			}),
+		).toThrow("team_setup_failed");
+		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+	});
+
+	it("rolls back earlier additive Project writes when a later recipient write fails", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: CANDIDATE,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const projects = [PROJECT_A, PROJECT_B]
+			.map((identity) => ({ identity, ref: legacyTeamProjectRef(CANDIDATE, identity) }))
+			.sort((a, b) => a.ref.localeCompare(b.ref));
+		for (const project of projects)
+			db.prepare(`INSERT INTO legacy_team_setup_draft_projects(
+			attempt_id, project_ref, source_project_identity, display_name, source_fingerprint,
+			resolution_kind, resolved_project_identity, target_scope_id, updated_at
+		) VALUES (?, ?, ?, 'Project', 'source', 'deterministic', ?, 'scope-engineering', ?)`).run(
+				draft.attemptId,
+				project.ref,
+				project.identity,
+				project.identity,
+				NOW,
+			);
+		const snapshot = () =>
+			[
+				"project_scope_mappings",
+				"project_recipients",
+				"policy_teams",
+				"legacy_team_setup_completions",
+			].map((table) => db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all());
+		const before = snapshot();
+		db.exec(`CREATE TEMP TRIGGER fail_second_recipient BEFORE INSERT ON project_recipients
+			WHEN NEW.canonical_project_identity = '${projects[1].identity}'
+			BEGIN SELECT RAISE(ABORT, 'late additive failure'); END`);
+		let wroteFirstProject = false;
+		expect(() =>
+			db
+				.transaction(() => {
+					try {
+						applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction(db, {
+							candidateRef: CANDIDATE,
+							attemptId: draft.attemptId,
+							teamId: manifest.team_id,
+							projectRefs: projects.map((project) => project.ref),
+							completedAt: NOW,
+						});
+					} catch (error) {
+						wroteFirstProject = Boolean(
+							db
+								.prepare("SELECT 1 FROM project_recipients WHERE canonical_project_identity = ?")
+								.get(projects[0].identity),
+						);
+						throw error;
+					}
+				})
+				.immediate(),
+		).toThrow("team_setup_failed");
+		expect(wroteFirstProject).toBe(true);
+		expect(snapshot()).toEqual(before);
 	});
 
 	it("adds newly resolvable Projects without replaying completed Team policy", async () => {
@@ -1873,6 +1962,60 @@ describe("legacy Team setup completion manifests", () => {
 				loadProjectInventory: () => [],
 			}),
 		).rejects.toThrow("team_setup_confirmation_stale");
+	});
+
+	it("containment removes only setup-owned group routing and is idempotent", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: CANDIDATE,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const insertScope = db.prepare(`INSERT INTO replication_scopes(
+			scope_id, label, kind, authority_type, coordinator_id, group_id, status, created_at, updated_at
+		) VALUES (?, 'Scope', 'team', 'coordinator', ?, ?, ?, ?, ?)`);
+		insertScope.run("retired-scope", COORDINATOR_ID, GROUP_ID, "inactive", NOW, NOW);
+		insertScope.run("other-group", COORDINATOR_ID, "other-group", "active", NOW, NOW);
+		insertScope.run("other-coordinator", "other-coordinator", GROUP_ID, "active", NOW, NOW);
+		const insertMapping = db.prepare(`INSERT INTO project_scope_mappings(
+			workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+		) VALUES (?, ?, ?, 1000, ?, ?, ?)`);
+		for (const [project, scope, source] of [
+			[PROJECT_A, "scope-engineering", "reviewed_team_setup"],
+			[PROJECT_B, "retired-scope", "reviewed_team_setup"],
+			["manual", "scope-engineering", "user"],
+			["foreign-group", "other-group", "reviewed_team_setup"],
+			["foreign-coordinator", "other-coordinator", "reviewed_team_setup"],
+		])
+			insertMapping.run(project, project, scope, source, NOW, NOW);
+		const session = db.prepare(
+			"INSERT INTO sessions(started_at, project, git_remote) VALUES (?, ?, ?)",
+		);
+		const before = Number(session.run(NOW, "api", PROJECT_A).lastInsertRowid);
+		expect(resolveSessionScopeId(db, { sessionId: before })).toBe("scope-engineering");
+
+		await containLegacyTeamSetupCompletionConflict(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+		});
+		await containLegacyTeamSetupCompletionConflict(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+		});
+		const after = Number(session.run(NOW, "api", PROJECT_A).lastInsertRowid);
+		expect(resolveSessionScopeId(db, { sessionId: after })).toBe("local-default");
+		expect(
+			db
+				.prepare("SELECT project_pattern FROM project_scope_mappings ORDER BY project_pattern")
+				.pluck()
+				.all(),
+		).toEqual(["foreign-coordinator", "foreign-group", "manual"]);
 	});
 
 	it("quarantines divergent local policy when the canonical winner cannot be applied", async () => {

--- a/packages/core/src/legacy-team-setup-completion-manifest.ts
+++ b/packages/core/src/legacy-team-setup-completion-manifest.ts
@@ -887,6 +887,18 @@ function quarantineDivergentCompletedPolicy(
 			 WHERE recipient_kind = 'team' AND recipient_id = ?
 			   AND provenance = 'reviewed_team_setup' AND status = 'active'`,
 		).run(team.revision, now, binding.teamId);
+		// Scope stamping ignores recipient status; remove this setup group's
+		// routing on active and retired scopes without touching independently owned mappings.
+		db.prepare(
+			`DELETE FROM project_scope_mappings
+			 WHERE source = 'reviewed_team_setup' AND scope_id IN (
+			   SELECT scope.scope_id FROM replication_scopes AS scope
+			   JOIN legacy_team_setup_drafts AS draft
+			     ON draft.coordinator_id = scope.coordinator_id AND draft.group_id = scope.group_id
+			   WHERE draft.candidate_id = ? AND draft.completed_team_id = ?
+			     AND scope.authority_type = 'coordinator'
+			 )`,
+		).run(binding.candidateRef, binding.teamId);
 		db.prepare(
 			`UPDATE legacy_team_setup_drafts SET finish_digest = NULL
 			 WHERE candidate_id = ? AND completed_team_id = ? AND state = 'completed'`,


### PR DESCRIPTION
## Description
Remove setup-owned routing in the containment transaction, preserving user-owned and foreign-group mappings. Add transaction-only API and late-additive rollback evidence. The legacy-inactive follow-up in layer 07 is required before release.

Tracking: codemem-osom; codemem-h2f1. Commit: `b3723652f`. Layer `01-containment` targets `main`; do not retarget to main while its parent is unmerged.

### Stack Order
1. https://github.com/kunickiaj/codemem/pull/1658 (this PR)
2. https://github.com/kunickiaj/codemem/pull/1659
3. https://github.com/kunickiaj/codemem/pull/1660
4. https://github.com/kunickiaj/codemem/pull/1661
5. https://github.com/kunickiaj/codemem/pull/1662
6. https://github.com/kunickiaj/codemem/pull/1663
7. https://github.com/kunickiaj/codemem/pull/1664

**Release hold: layer 06 metadata MUST NOT be tagged or published until layer 07 containment cleanup is merged and the outstanding release gates pass. Final tagging is allowed only from the reviewed, merged, clean main commit, never a release-branch tip.** No merge or publication is requested by this PR.

## Type of Change
- [ ] Feature (new functionality)
- [x] Bug fix (fixes an issue)
- [ ] Documentation (docs-only change)
- [ ] Maintenance (refactor, chore, CI, etc.)
- [ ] Testing (test-only changes)

## Testing
The following local results apply to the complete candidate tip `bf55ed583`, not independently rerun validation of every intermediate layer. Per-layer CI must still run. Confirmed bug regressions failed before their fixes; parent direct review approved submission, not release.

| Gate | Candidate-tip result |
|---|---|
| `pnpm run build` | Pass, including viewer assets |
| `pnpm run check` | Pass in prescribed order; workspace 6495 passed, 3 TODOs |
| Release / adapter-normalizer / CI-workflow tests | 36 / 4 / 10 passed |
| Targeted completion-manifest, activation, candidate tests | 195 passed |
| `pnpm --filter codemem test:plugin` / `test:smoke` | 347 / 4 passed |
| `test:packed-artifact` for CLI and OpenCode plugin | Pass; CLI-only semantic install included |
| `pnpm --filter @codemem/embeddings test:packed-runtime` | Pass on macOS ARM64 |
| `pnpm --filter @codemem/cloudflare-coordinator-worker test:worker` | Pass |
| E2E smoke, legacy-team-migration, project-sharing, sharing-domains | Pass on rebuilt candidate Docker image |
| `pnpm run release:version -- check`, diff check, pre-commit | Pass |

E2E smoke used `CODEMEM_E2E_BUILD=1 CODEMEM_E2E_JSON=1`; specialized scenarios reused that image with `CODEMEM_E2E_BUILD=0`. Host validation used Node 24.20.0 and pinned pnpm 12.2.1. Lint passes with existing warnings. No live configuration or database was used.

- [x] Relevant checks pass locally (candidate tip, as scoped above)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected in normal-user workload dogfood

**Outstanding release evidence:** exact 0.43.2-to-beta upgrade and vector migration; Windows-specific packed inference; normal-session/OpenCode restart dogfood. Windows CI is skipped on pull requests; Linux E2E and macOS inference do not replace it. The npm latest-tag guard is intentionally verify-only and warning-only, not a publication blocker; no registry settings were changed.

## Checklist
- [x] Code follows project style (candidate-tip lint passes)
- [x] Self-review completed
- [x] Documentation updated where needed (release notes are in layers 06 and 07)
- [ ] No new warnings introduced (existing warnings remain; no warning-free claim)
