### PR TITLE
fix(core): use SQLite memory state for WAL setup

### DIFF
--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -72,6 +72,18 @@ describe("connect", () => {
 		}
 	});
 
+	it("enables WAL for a disk filename with an in-memory URI prefix", () => {
+		const cwd = process.cwd();
+		try {
+			process.chdir(tmpDir);
+			db = connect("file::memory:foo");
+			expect(db.memory).toBe(false);
+			expect(db.pragma("journal_mode", { simple: true })).toBe("wal");
+		} finally {
+			process.chdir(cwd);
+		}
+	});
+
 	it("sets busy_timeout to 5000ms", () => {
 		db = connect(join(tmpDir, "test.sqlite"));
 		const timeout = db.pragma("busy_timeout", { simple: true });

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -204,10 +204,6 @@ export function migrateLegacyDbPath(dbPath: string): void {
 	}
 }
 
-function isInMemoryDbPath(dbPath: string): boolean {
-	return dbPath === "" || dbPath === ":memory:" || dbPath.startsWith("file::memory:");
-}
-
 /**
  * Open a better-sqlite3 connection with the standard codemem pragmas.
  *
@@ -230,7 +226,7 @@ export function connect(dbPath: string = DEFAULT_DB_PATH): DatabaseType {
 
 		// In-memory databases cannot use WAL (SQLite reports "memory") and have
 		// no cross-process readers, so skip the pragma and its warning.
-		if (!isInMemoryDbPath(dbPath)) {
+		if (!db.memory) {
 			const journalMode = db.pragma("journal_mode = WAL", { simple: true }) as string;
 			if (journalMode.toLowerCase() !== "wal") {
 				console.warn(

--- a/packages/core/src/legacy-team-setup-completion-manifest.test.ts
+++ b/packages/core/src/legacy-team-setup-completion-manifest.test.ts
@@ -11,6 +11,7 @@ import {
 import {
 	applyLegacyTeamSetupCompletionManifest,
 	areLegacyTeamSetupCompletionPolicyFactsAdditivelyCompatible,
+	containLegacyTeamSetupCompletionConflict,
 	deriveLegacyTeamSetupCompletionManifest,
 	LegacyTeamSetupAdditiveConvergenceError,
 	reconstructLegacyTeamSetupCompletionManifest,
@@ -29,6 +30,7 @@ import {
 	recipientPolicyDigest,
 } from "./recipient-policy-identifiers.js";
 import { renameRecipientPolicyTeam } from "./recipient-policy-team-metadata.js";
+import { resolveSessionScopeId } from "./scope-stamping.js";
 import { initTestSchema } from "./test-utils.js";
 
 const NOW = "2026-09-01T12:00:00.000Z";
@@ -765,6 +767,93 @@ describe("legacy Team setup completion manifests", () => {
 				.pluck()
 				.get(replacement.attemptId),
 		).toBe("completed");
+	});
+
+	it("rejects both canonical mutation APIs outside a transaction", () => {
+		const draft = readyDraft();
+		expect(() =>
+			applyCanonicalLegacyTeamSetupActivationInTransaction(db, {
+				candidateRef: CANDIDATE,
+				attemptId: draft.attemptId,
+				policyRevision: "revision",
+				completedAt: NOW,
+			}),
+		).toThrow("team_setup_failed");
+		expect(() =>
+			applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction(db, {
+				candidateRef: CANDIDATE,
+				attemptId: draft.attemptId,
+				teamId: "team",
+				projectRefs: [PROJECT_REF_A],
+				completedAt: NOW,
+			}),
+		).toThrow("team_setup_failed");
+		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+	});
+
+	it("rolls back earlier additive Project writes when a later recipient write fails", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: CANDIDATE,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const projects = [PROJECT_A, PROJECT_B]
+			.map((identity) => ({ identity, ref: legacyTeamProjectRef(CANDIDATE, identity) }))
+			.sort((a, b) => a.ref.localeCompare(b.ref));
+		for (const project of projects)
+			db.prepare(`INSERT INTO legacy_team_setup_draft_projects(
+			attempt_id, project_ref, source_project_identity, display_name, source_fingerprint,
+			resolution_kind, resolved_project_identity, target_scope_id, updated_at
+		) VALUES (?, ?, ?, 'Project', 'source', 'deterministic', ?, 'scope-engineering', ?)`).run(
+				draft.attemptId,
+				project.ref,
+				project.identity,
+				project.identity,
+				NOW,
+			);
+		const snapshot = () =>
+			[
+				"project_scope_mappings",
+				"project_recipients",
+				"policy_teams",
+				"legacy_team_setup_completions",
+			].map((table) => db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all());
+		const before = snapshot();
+		db.exec(`CREATE TEMP TRIGGER fail_second_recipient BEFORE INSERT ON project_recipients
+			WHEN NEW.canonical_project_identity = '${projects[1].identity}'
+			BEGIN SELECT RAISE(ABORT, 'late additive failure'); END`);
+		let wroteFirstProject = false;
+		expect(() =>
+			db
+				.transaction(() => {
+					try {
+						applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction(db, {
+							candidateRef: CANDIDATE,
+							attemptId: draft.attemptId,
+							teamId: manifest.team_id,
+							projectRefs: projects.map((project) => project.ref),
+							completedAt: NOW,
+						});
+					} catch (error) {
+						wroteFirstProject = Boolean(
+							db
+								.prepare("SELECT 1 FROM project_recipients WHERE canonical_project_identity = ?")
+								.get(projects[0].identity),
+						);
+						throw error;
+					}
+				})
+				.immediate(),
+		).toThrow("team_setup_failed");
+		expect(wroteFirstProject).toBe(true);
+		expect(snapshot()).toEqual(before);
 	});
 
 	it("adds newly resolvable Projects without replaying completed Team policy", async () => {
@@ -1873,6 +1962,60 @@ describe("legacy Team setup completion manifests", () => {
 				loadProjectInventory: () => [],
 			}),
 		).rejects.toThrow("team_setup_confirmation_stale");
+	});
+
+	it("containment removes only setup-owned group routing and is idempotent", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: CANDIDATE,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const insertScope = db.prepare(`INSERT INTO replication_scopes(
+			scope_id, label, kind, authority_type, coordinator_id, group_id, status, created_at, updated_at
+		) VALUES (?, 'Scope', 'team', 'coordinator', ?, ?, ?, ?, ?)`);
+		insertScope.run("retired-scope", COORDINATOR_ID, GROUP_ID, "inactive", NOW, NOW);
+		insertScope.run("other-group", COORDINATOR_ID, "other-group", "active", NOW, NOW);
+		insertScope.run("other-coordinator", "other-coordinator", GROUP_ID, "active", NOW, NOW);
+		const insertMapping = db.prepare(`INSERT INTO project_scope_mappings(
+			workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+		) VALUES (?, ?, ?, 1000, ?, ?, ?)`);
+		for (const [project, scope, source] of [
+			[PROJECT_A, "scope-engineering", "reviewed_team_setup"],
+			[PROJECT_B, "retired-scope", "reviewed_team_setup"],
+			["manual", "scope-engineering", "user"],
+			["foreign-group", "other-group", "reviewed_team_setup"],
+			["foreign-coordinator", "other-coordinator", "reviewed_team_setup"],
+		])
+			insertMapping.run(project, project, scope, source, NOW, NOW);
+		const session = db.prepare(
+			"INSERT INTO sessions(started_at, project, git_remote) VALUES (?, ?, ?)",
+		);
+		const before = Number(session.run(NOW, "api", PROJECT_A).lastInsertRowid);
+		expect(resolveSessionScopeId(db, { sessionId: before })).toBe("scope-engineering");
+
+		await containLegacyTeamSetupCompletionConflict(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+		});
+		await containLegacyTeamSetupCompletionConflict(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+		});
+		const after = Number(session.run(NOW, "api", PROJECT_A).lastInsertRowid);
+		expect(resolveSessionScopeId(db, { sessionId: after })).toBe("local-default");
+		expect(
+			db
+				.prepare("SELECT project_pattern FROM project_scope_mappings ORDER BY project_pattern")
+				.pluck()
+				.all(),
+		).toEqual(["foreign-coordinator", "foreign-group", "manual"]);
 	});
 
 	it("quarantines divergent local policy when the canonical winner cannot be applied", async () => {

--- a/packages/core/src/legacy-team-setup-completion-manifest.ts
+++ b/packages/core/src/legacy-team-setup-completion-manifest.ts
@@ -887,6 +887,18 @@ function quarantineDivergentCompletedPolicy(
 			 WHERE recipient_kind = 'team' AND recipient_id = ?
 			   AND provenance = 'reviewed_team_setup' AND status = 'active'`,
 		).run(team.revision, now, binding.teamId);
+		// Scope stamping ignores recipient status; remove this setup group's
+		// routing on active and retired scopes without touching independently owned mappings.
+		db.prepare(
+			`DELETE FROM project_scope_mappings
+			 WHERE source = 'reviewed_team_setup' AND scope_id IN (
+			   SELECT scope.scope_id FROM replication_scopes AS scope
+			   JOIN legacy_team_setup_drafts AS draft
+			     ON draft.coordinator_id = scope.coordinator_id AND draft.group_id = scope.group_id
+			   WHERE draft.candidate_id = ? AND draft.completed_team_id = ?
+			     AND scope.authority_type = 'coordinator'
+			 )`,
+		).run(binding.candidateRef, binding.teamId);
 		db.prepare(
 			`UPDATE legacy_team_setup_drafts SET finish_digest = NULL
 			 WHERE candidate_id = ? AND completed_team_id = ? AND state = 'completed'`,

--- a/packages/core/src/legacy-team-setup-limits.test.ts
+++ b/packages/core/src/legacy-team-setup-limits.test.ts
@@ -1,0 +1,39 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { requireLegacyTeamSetupReachableDevicesWithinLimit } from "./legacy-team-setup-limits.js";
+
+describe("legacy Team readiness traversal limit", () => {
+	let db: InstanceType<typeof Database>;
+	const devices = Array.from({ length: 500 }, (_, index) => ({ deviceId: `device-${index}` }));
+	const projects = Array.from({ length: 20 }, (_, index) => `project-${index}`);
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		db.exec("CREATE TABLE identity_devices (device_id TEXT PRIMARY KEY)");
+		db.transaction(() => {
+			const insert = db.prepare("INSERT INTO identity_devices VALUES (?)");
+			for (const device of devices) insert.run(device.deviceId);
+		})();
+	});
+	afterEach(() => db.close());
+
+	it("counts already assigned roster devices once at the supported boundary", () => {
+		expect(() =>
+			requireLegacyTeamSetupReachableDevicesWithinLimit(db, devices, projects),
+		).not.toThrow();
+	});
+
+	it("still counts assignments outside the roster", () => {
+		db.prepare("INSERT INTO identity_devices VALUES (?)").run("outside-roster");
+		expect(() => requireLegacyTeamSetupReachableDevicesWithinLimit(db, devices, projects)).toThrow(
+			"legacy_team_setup_roster_too_large",
+		);
+	});
+
+	it("counts an unassigned roster even when there are no persisted assignments", () => {
+		db.exec("DELETE FROM identity_devices");
+		expect(() =>
+			requireLegacyTeamSetupReachableDevicesWithinLimit(db, devices, [...projects, "extra"]),
+		).toThrow("legacy_team_setup_roster_too_large");
+	});
+});

--- a/packages/core/src/legacy-team-setup-limits.ts
+++ b/packages/core/src/legacy-team-setup-limits.ts
@@ -43,15 +43,21 @@ export function requireLegacyTeamSetupAccessDeltaTraversalWithinLimit(input: {
  */
 export function requireLegacyTeamSetupReachableDevicesWithinLimit(
 	db: Database,
-	devices: readonly unknown[],
+	devices: readonly { deviceId: string }[],
 	projects: readonly unknown[],
 ): void {
 	if (projects.length === 0) return;
+	const deviceIds = [...new Set(devices.map((device) => device.deviceId))];
+	const excludeRoster =
+		deviceIds.length > 0 ? `WHERE device_id NOT IN (${deviceIds.map(() => "?").join(", ")})` : "";
 	const assignmentRows = Number(
-		db.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get() ?? 0,
+		db
+			.prepare(`SELECT COUNT(*) FROM identity_devices ${excludeRoster}`)
+			.pluck()
+			.get(...deviceIds) ?? 0,
 	);
 	if (
-		(devices.length + assignmentRows) * projects.length >
+		(deviceIds.length + assignmentRows) * projects.length >
 		LEGACY_TEAM_SETUP_MAX_PROJECT_DEVICE_PAIRS
 	) {
 		throw new Error("legacy_team_setup_roster_too_large");

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
@@ -1609,7 +1609,7 @@ describe("legacy Team setup dialog", () => {
 		expect(document.body.outerHTML).not.toContain(privateRemote);
 	});
 
-	it("reloads stale Project mapping evidence and retries with a plain detail load", async () => {
+	it("reloads stale Project mapping evidence and refreshes on retry", async () => {
 		const initialProject = project();
 		const refreshedProject = project({
 			mappingChoices: [
@@ -1660,22 +1660,21 @@ describe("legacy Team setup dialog", () => {
 			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
 				"changed since it was last reviewed",
 			);
-			expect(document.body.textContent).toContain("Project Gamma");
+			expect(document.body.textContent).toContain("Current setup details are unavailable");
 		});
 		expect(document.body.textContent).not.toContain("team_setup_confirmation_stale");
 		expect(loadDetail).toHaveBeenCalledTimes(2);
-		expect(document.querySelector<HTMLSelectElement>(".legacy-team-project-select")?.value).toBe(
-			"",
-		);
+		expect(document.querySelector(".legacy-team-project-select")).toBeNull();
 
 		act(() => document.getElementById("legacy-team-setup-retry")?.click());
 		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).toBeNull());
+		expect(document.body.textContent).toContain("Project Gamma");
 		expect(document.querySelector<HTMLSelectElement>(".legacy-team-project-select")?.value).toBe(
 			"",
 		);
 		expect(button("Save mapping").getAttribute("aria-disabled")).toBe("true");
-		expect(loadDetail).toHaveBeenCalledTimes(3);
-		expect(refreshCandidate).not.toHaveBeenCalled();
+		expect(loadDetail).toHaveBeenCalledTimes(2);
+		expect(refreshCandidate).toHaveBeenCalledTimes(1);
 	});
 
 	it("does not reload after an authoritative Project mapping response", async () => {
@@ -2884,10 +2883,11 @@ describe("legacy Team setup dialog", () => {
 			viewerAccessDeltaDigest: "fresh-viewer-access-digest",
 		});
 		const loadDetail = vi.fn().mockResolvedValueOnce(initial).mockResolvedValueOnce(refreshed);
+		const refreshCandidate = vi.fn().mockResolvedValue(refreshed);
 		const finish = vi
 			.fn()
 			.mockRejectedValue(new LegacyTeamSetupApiError(409, "team_setup_confirmation_stale"));
-		setup({ finish, loadDetail });
+		setup({ finish, loadDetail, refreshCandidate });
 		await vi.waitFor(() => expect(document.body.textContent).toContain("Finish Team setup"));
 		const confirmation = document.querySelector<HTMLInputElement>(
 			".legacy-team-setup-confirmation input",
@@ -2912,13 +2912,16 @@ describe("legacy Team setup dialog", () => {
 			confirmedAccessDeltaDigest: "opaque-access-digest",
 			confirmedViewerAccessDeltaDigest: "opaque-viewer-access-digest",
 		});
+		expect(document.querySelector(".legacy-team-setup-confirmation input")).toBeNull();
+		act(() => document.getElementById("legacy-team-setup-retry")?.click());
+		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).toBeNull());
+		expect(refreshCandidate).toHaveBeenCalledTimes(1);
 		const refreshedConfirmation = document.querySelector<HTMLInputElement>(
 			".legacy-team-setup-confirmation input",
 		);
 		expect(refreshedConfirmation?.checked).toBe(false);
-		expect(refreshedConfirmation?.getAttribute("aria-disabled")).toBe("true");
 		expect(document.body.textContent).toContain("Add Sam to Example Team.");
-		expect(button("Retry")).toBeTruthy();
+		expect(button("Finish Team setup").getAttribute("aria-disabled")).toBe("true");
 	});
 
 	it("treats a stale finish recovery that is already completed as success", async () => {

--- a/packages/ui/src/tabs/legacy-team-setup-session.test.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-session.test.ts
@@ -782,7 +782,7 @@ describe("legacy Team setup session reducer", () => {
 		);
 	});
 
-	it("uses a plain detail retry when confirmation-stale recovery also fails", () => {
+	it("refreshes the draft when confirmation-stale recovery also fails", () => {
 		let state = reduceSetupSession(loaded(open(), readyView()), { type: "finish" });
 		if (state.status !== "open") throw new Error("expected finish session");
 		const command = state.commands[0];
@@ -802,12 +802,12 @@ describe("legacy Team setup session reducer", () => {
 
 		expect(globalError(state)).toMatchObject({
 			message: expect.stringContaining("changed since it was last reviewed"),
-			retry: "load",
+			retry: "refresh",
 		});
 		expect(globalError(state)?.message).not.toContain("no local changes were applied");
 		state = reduceSetupSession(state, { type: "retry" });
 		expect(state).toMatchObject({
-			commands: [expect.objectContaining({ kind: "load", refresh: false })],
+			commands: [expect.objectContaining({ kind: "load", refresh: true })],
 		});
 	});
 
@@ -873,7 +873,7 @@ describe("legacy Team setup session reducer", () => {
 		},
 	);
 
-	it("uses a plain detail retry when roster-change recovery finds a completed draft", () => {
+	it("refreshes when roster-change recovery reports stale confirmation without a completed view", () => {
 		let state = reduceSetupSession(loaded(open(), readyView()), { type: "finish" });
 		if (state.status !== "open") throw new Error("expected finish session");
 		const command = state.commands[0];
@@ -893,11 +893,11 @@ describe("legacy Team setup session reducer", () => {
 
 		expect(globalError(state)).toMatchObject({
 			message: expect.stringContaining("changed since it was last reviewed"),
-			retry: "load",
+			retry: "refresh",
 		});
 		state = reduceSetupSession(state, { type: "retry" });
 		expect(state).toMatchObject({
-			commands: [expect.objectContaining({ kind: "load", refresh: false })],
+			commands: [expect.objectContaining({ kind: "load", refresh: true })],
 		});
 	});
 

--- a/packages/ui/src/tabs/legacy-team-setup-session.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-session.ts
@@ -633,7 +633,8 @@ function retryFor(
 			cause.errorCode === "team_setup_confirmation_stale") ||
 		(recoveryCause instanceof LegacyTeamSetupApiError &&
 			recoveryCause.errorCode === "team_setup_confirmation_stale");
-	if (confirmationStale || options.terminalRecovery) return "load";
+	if (confirmationStale) return "refresh";
+	if (options.terminalRecovery) return "load";
 	if (options.changed || options.rosterUnavailable) return "refresh";
 	if (command.kind === "refresh") return "refresh";
 	if (command.kind === "load" && command.refresh) return "refresh";


### PR DESCRIPTION
## Description
Use the connection memory flag rather than a filename-prefix heuristic. Regression proves a disk filename resembling a memory URI still enables WAL. Follow-up to #1656.

Tracking: codemem-dh33.14. Commit: `6a9fd43a6`. Layer `04-wal` targets `release/0.44.0-03-readiness`; do not retarget to main while its parent is unmerged.

### Stack Order
1. https://github.com/kunickiaj/codemem/pull/1658
2. https://github.com/kunickiaj/codemem/pull/1659
3. https://github.com/kunickiaj/codemem/pull/1660
4. https://github.com/kunickiaj/codemem/pull/1661 (this PR)
5. https://github.com/kunickiaj/codemem/pull/1662
6. https://github.com/kunickiaj/codemem/pull/1663
7. https://github.com/kunickiaj/codemem/pull/1664

**Release hold: layer 06 metadata MUST NOT be tagged or published until layer 07 containment cleanup is merged and the outstanding release gates pass. Final tagging is allowed only from the reviewed, merged, clean main commit, never a release-branch tip.** No merge or publication is requested by this PR.

## Type of Change
- [ ] Feature (new functionality)
- [x] Bug fix (fixes an issue)
- [ ] Documentation (docs-only change)
- [ ] Maintenance (refactor, chore, CI, etc.)
- [ ] Testing (test-only changes)

## Testing
The following local results apply to the complete candidate tip `bf55ed583`, not independently rerun validation of every intermediate layer. Per-layer CI must still run. Confirmed bug regressions failed before their fixes; parent direct review approved submission, not release.

| Gate | Candidate-tip result |
|---|---|
| `pnpm run build` | Pass, including viewer assets |
| `pnpm run check` | Pass in prescribed order; workspace 6495 passed, 3 TODOs |
| Release / adapter-normalizer / CI-workflow tests | 36 / 4 / 10 passed |
| Targeted completion-manifest, activation, candidate tests | 195 passed |
| `pnpm --filter codemem test:plugin` / `test:smoke` | 347 / 4 passed |
| `test:packed-artifact` for CLI and OpenCode plugin | Pass; CLI-only semantic install included |
| `pnpm --filter @codemem/embeddings test:packed-runtime` | Pass on macOS ARM64 |
| `pnpm --filter @codemem/cloudflare-coordinator-worker test:worker` | Pass |
| E2E smoke, legacy-team-migration, project-sharing, sharing-domains | Pass on rebuilt candidate Docker image |
| `pnpm run release:version -- check`, diff check, pre-commit | Pass |

E2E smoke used `CODEMEM_E2E_BUILD=1 CODEMEM_E2E_JSON=1`; specialized scenarios reused that image with `CODEMEM_E2E_BUILD=0`. Host validation used Node 24.20.0 and pinned pnpm 12.2.1. Lint passes with existing warnings. No live configuration or database was used.

- [x] Relevant checks pass locally (candidate tip, as scoped above)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected in normal-user workload dogfood

**Outstanding release evidence:** exact 0.43.2-to-beta upgrade and vector migration; Windows-specific packed inference; normal-session/OpenCode restart dogfood. Windows CI is skipped on pull requests; Linux E2E and macOS inference do not replace it. The npm latest-tag guard is intentionally verify-only and warning-only, not a publication blocker; no registry settings were changed.

## Checklist
- [x] Code follows project style (candidate-tip lint passes)
- [x] Self-review completed
- [x] Documentation updated where needed (release notes are in layers 06 and 07)
- [ ] No new warnings introduced (existing warnings remain; no warning-free claim)
