### PR TITLE
chore(release): prepare 0.44.0 stable candidate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
   },
   "metadata": {
     "description": "Official CodeMem plugins for Claude Code",
-    "version": "0.44.0-beta.1"
+    "version": "0.44.0"
   },
   "plugins": [
     {
       "name": "codemem",
       "source": "./plugins/claude",
       "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-      "version": "0.44.0-beta.1",
+      "version": "0.44.0",
       "author": {
         "name": "Adam Kunicki"
       },

--- a/docs/release-0.44.0.md
+++ b/docs/release-0.44.0.md
@@ -1,0 +1,25 @@
+# Codemem 0.44.0 Release Notes
+
+This local stable candidate combines semantic installation, safer automatic recall, and Team setup corrections; it is not yet published.
+
+## Included Changes
+
+The candidate includes the beta release and the following improvements on top of it.
+
+- Automatic OpenCode recall checks requester-session eligibility before retrieval and fallback, and isolates delta baselines by requester continuity. Missing session mapping blocks continuity summaries without excluding useful historical facts.
+- Automatic recall preserves retained context and deduplicates unchanged items. The retained-token ceiling remains off by default; Health reports bounded injection measurements rather than provider token usage or answer quality.
+- Viewer diagnostics provide contextual actions and redacted event details. Observer output follows provider capabilities, with deterministic envelope and forced-tool evaluation coverage.
+- Team setup retries refresh stale confirmation evidence and require renewed confirmation. Readiness counts roster devices and persisted assignments once, while still bounding unrelated assignment work.
+- Team conflict containment removes setup-owned routing mappings on the affected coordinator group's active and retired scopes in the same transaction. User-owned mappings and other coordinator groups remain unchanged; this is not a historical-data rewrite.
+- SQLite uses the connection's actual in-memory state when deciding whether to enable WAL, so disk filenames resembling memory URIs retain WAL behavior.
+- The CLI-only packed install verifies the matching optional embedding runtime, real inference, and semantic retrieval. Lexical fallback remains available when the runtime cannot initialize.
+
+## Limits And Follow-Ups
+
+Session eligibility is not task classification, and this candidate does not claim to solve every same-session task transition.
+
+Remaining recall stages and expanded evaluation move to 0.45+, preserving the completed incident baseline. Source-window provenance supersedes the earlier mandatory task-classification proposal; no new source-window suppression ships here. Dual OpenCode V1/V2 support remains planned for 0.45.
+
+The npm latest-tag guard remains verify-only and warning-only. Stable publication uses `--tag latest`; publishing a new stable embeddings version can advance its tag naturally, but skipping an already-published version does not repair tags. No registry mutation is part of this preparation.
+
+Independent review and the release task's upgrade, supported-platform, and workload evidence must be reconciled before publication. Tagging remains restricted to the merged, clean main commit under [the versioning policy](versioning.md).

--- a/packages/cli/.opencode/plugins/codemem.js
+++ b/packages/cli/.opencode/plugins/codemem.js
@@ -1,4 +1,4 @@
-const PINNED_BACKEND_VERSION = "0.44.0-beta.1";
+const PINNED_BACKEND_VERSION = "0.44.0";
 
 export {
 	default,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "codemem",
-	"version": "0.44.0-beta.1",
+	"version": "0.44.0",
 	"description": "Memory layer for AI coding agents — search, recall, and sync context across sessions",
 	"type": "module",
 	"bin": {

--- a/packages/cli/scripts/packed-artifact-smoke.mjs
+++ b/packages/cli/scripts/packed-artifact-smoke.mjs
@@ -703,7 +703,16 @@ try {
 	mkdirSync(semanticInstallDir, { recursive: true });
 	writeFileSync(
 		join(semanticInstallDir, "package.json"),
-		JSON.stringify({ private: true }),
+		JSON.stringify({
+			private: true,
+			// Resolve unpublished workspace packages locally, but install only the CLI.
+			overrides: {
+				"@codemem/core": `file:${coreTarball}`,
+				"@codemem/embeddings": `file:${embeddingsTarball}`,
+				"@codemem/mcp": `file:${mcpTarball}`,
+				"@codemem/server": `file:${serverTarball}`,
+			},
+		}),
 		"utf8",
 	);
 	run(
@@ -712,10 +721,6 @@ try {
 			"install",
 			"--prefix",
 			semanticInstallDir,
-			coreTarball,
-			embeddingsTarball,
-			mcpTarball,
-			serverTarball,
 			packedTarball,
 		],
 		packageRoot,
@@ -853,6 +858,38 @@ try {
 			],
 			transformersPackageDir,
 		);
+		const semanticHome = join(tempDir, "semantic-home");
+		mkdirSync(semanticHome, { recursive: true });
+		run(process.execPath, ["--input-type=module", "--eval", `
+			import assert from "node:assert/strict";
+			import { MemoryStore, backfillVectors, getEmbeddingClient, semanticSearch } from "@codemem/core";
+			const client = await getEmbeddingClient();
+			assert(client, "CLI-only install must initialize semantic runtime");
+			const vectors = await client.embed(["A feline sleeps on the sofa", "Database transaction rollback"]);
+			assert.equal(vectors.length, 2);
+			assert(vectors.every(vector => vector.length === 384 && vector.every(Number.isFinite)));
+			const store = new MemoryStore(process.env.CODEMEM_DB);
+			try {
+				const session = store.startSession({ project: "packed-semantic" });
+				const id = store.remember(session, "discovery", "Feline rest", "A feline sleeps on the sofa");
+				await backfillVectors(store.db);
+				const matches = await semanticSearch(store.db, "A cat resting on a couch", 5, null, {
+					actorId: store.actorId, deviceId: store.deviceId, claimedDeviceIds: [], legacyActorIds: [],
+				});
+				assert(matches.some(match => match.id === id), "CLI-only install must retrieve a semantic match");
+			} finally { store.close(); }
+		`], semanticInstallDir, {
+			...process.env,
+			HOME: semanticHome,
+			XDG_CONFIG_HOME: join(semanticHome, "config"),
+			CODEMEM_DB: join(semanticHome, "mem.sqlite"),
+			CODEMEM_CONFIG: join(semanticHome, "codemem.json"),
+			CODEMEM_KEYS_DIR: join(semanticHome, "keys"),
+			CODEMEM_EMBEDDING_DISABLED: "0",
+			CODEMEM_EMBEDDING_OFFLINE: "0",
+			CODEMEM_EMBEDDING_MODEL: "Xenova/bge-small-en-v1.5",
+			CODEMEM_EMBEDDING_REVISION: "ea104dacec62c0de699686887e3f920caeb4f3e3",
+		});
 	}
 
 	const installedPackageRoot = join(installDir, "node_modules", "codemem");

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/core",
-	"version": "0.44.0-beta.1",
+	"version": "0.44.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/core/src/db.test.ts
+++ b/packages/core/src/db.test.ts
@@ -72,6 +72,18 @@ describe("connect", () => {
 		}
 	});
 
+	it("enables WAL for a disk filename with an in-memory URI prefix", () => {
+		const cwd = process.cwd();
+		try {
+			process.chdir(tmpDir);
+			db = connect("file::memory:foo");
+			expect(db.memory).toBe(false);
+			expect(db.pragma("journal_mode", { simple: true })).toBe("wal");
+		} finally {
+			process.chdir(cwd);
+		}
+	});
+
 	it("sets busy_timeout to 5000ms", () => {
 		db = connect(join(tmpDir, "test.sqlite"));
 		const timeout = db.pragma("busy_timeout", { simple: true });

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -204,10 +204,6 @@ export function migrateLegacyDbPath(dbPath: string): void {
 	}
 }
 
-function isInMemoryDbPath(dbPath: string): boolean {
-	return dbPath === "" || dbPath === ":memory:" || dbPath.startsWith("file::memory:");
-}
-
 /**
  * Open a better-sqlite3 connection with the standard codemem pragmas.
  *
@@ -230,7 +226,7 @@ export function connect(dbPath: string = DEFAULT_DB_PATH): DatabaseType {
 
 		// In-memory databases cannot use WAL (SQLite reports "memory") and have
 		// no cross-process readers, so skip the pragma and its warning.
-		if (!isInMemoryDbPath(dbPath)) {
+		if (!db.memory) {
 			const journalMode = db.pragma("journal_mode = WAL", { simple: true }) as string;
 			if (journalMode.toLowerCase() !== "wal") {
 				console.warn(

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -3,6 +3,6 @@ import { VERSION } from "./index.js";
 
 describe("core", () => {
 	it("exports a version string", () => {
-		expect(VERSION).toBe("0.44.0-beta.1");
+		expect(VERSION).toBe("0.44.0");
 	});
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  * and type definitions shared across the codemem TS backend.
  */
 
-export const VERSION = "0.44.0-beta.1";
+export const VERSION = "0.44.0";
 
 export * as Api from "./api-types.js";
 export { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";

--- a/packages/core/src/legacy-team-setup-completion-manifest.test.ts
+++ b/packages/core/src/legacy-team-setup-completion-manifest.test.ts
@@ -11,6 +11,7 @@ import {
 import {
 	applyLegacyTeamSetupCompletionManifest,
 	areLegacyTeamSetupCompletionPolicyFactsAdditivelyCompatible,
+	containLegacyTeamSetupCompletionConflict,
 	deriveLegacyTeamSetupCompletionManifest,
 	LegacyTeamSetupAdditiveConvergenceError,
 	reconstructLegacyTeamSetupCompletionManifest,
@@ -29,6 +30,7 @@ import {
 	recipientPolicyDigest,
 } from "./recipient-policy-identifiers.js";
 import { renameRecipientPolicyTeam } from "./recipient-policy-team-metadata.js";
+import { resolveSessionScopeId } from "./scope-stamping.js";
 import { initTestSchema } from "./test-utils.js";
 
 const NOW = "2026-09-01T12:00:00.000Z";
@@ -765,6 +767,93 @@ describe("legacy Team setup completion manifests", () => {
 				.pluck()
 				.get(replacement.attemptId),
 		).toBe("completed");
+	});
+
+	it("rejects both canonical mutation APIs outside a transaction", () => {
+		const draft = readyDraft();
+		expect(() =>
+			applyCanonicalLegacyTeamSetupActivationInTransaction(db, {
+				candidateRef: CANDIDATE,
+				attemptId: draft.attemptId,
+				policyRevision: "revision",
+				completedAt: NOW,
+			}),
+		).toThrow("team_setup_failed");
+		expect(() =>
+			applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction(db, {
+				candidateRef: CANDIDATE,
+				attemptId: draft.attemptId,
+				teamId: "team",
+				projectRefs: [PROJECT_REF_A],
+				completedAt: NOW,
+			}),
+		).toThrow("team_setup_failed");
+		expect(db.prepare("SELECT COUNT(*) FROM policy_teams").pluck().get()).toBe(0);
+	});
+
+	it("rolls back earlier additive Project writes when a later recipient write fails", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: CANDIDATE,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const projects = [PROJECT_A, PROJECT_B]
+			.map((identity) => ({ identity, ref: legacyTeamProjectRef(CANDIDATE, identity) }))
+			.sort((a, b) => a.ref.localeCompare(b.ref));
+		for (const project of projects)
+			db.prepare(`INSERT INTO legacy_team_setup_draft_projects(
+			attempt_id, project_ref, source_project_identity, display_name, source_fingerprint,
+			resolution_kind, resolved_project_identity, target_scope_id, updated_at
+		) VALUES (?, ?, ?, 'Project', 'source', 'deterministic', ?, 'scope-engineering', ?)`).run(
+				draft.attemptId,
+				project.ref,
+				project.identity,
+				project.identity,
+				NOW,
+			);
+		const snapshot = () =>
+			[
+				"project_scope_mappings",
+				"project_recipients",
+				"policy_teams",
+				"legacy_team_setup_completions",
+			].map((table) => db.prepare(`SELECT * FROM ${table} ORDER BY rowid`).all());
+		const before = snapshot();
+		db.exec(`CREATE TEMP TRIGGER fail_second_recipient BEFORE INSERT ON project_recipients
+			WHEN NEW.canonical_project_identity = '${projects[1].identity}'
+			BEGIN SELECT RAISE(ABORT, 'late additive failure'); END`);
+		let wroteFirstProject = false;
+		expect(() =>
+			db
+				.transaction(() => {
+					try {
+						applyAdditiveCanonicalLegacyTeamSetupProjectsInTransaction(db, {
+							candidateRef: CANDIDATE,
+							attemptId: draft.attemptId,
+							teamId: manifest.team_id,
+							projectRefs: projects.map((project) => project.ref),
+							completedAt: NOW,
+						});
+					} catch (error) {
+						wroteFirstProject = Boolean(
+							db
+								.prepare("SELECT 1 FROM project_recipients WHERE canonical_project_identity = ?")
+								.get(projects[0].identity),
+						);
+						throw error;
+					}
+				})
+				.immediate(),
+		).toThrow("team_setup_failed");
+		expect(wroteFirstProject).toBe(true);
+		expect(snapshot()).toEqual(before);
 	});
 
 	it("adds newly resolvable Projects without replaying completed Team policy", async () => {
@@ -1873,6 +1962,60 @@ describe("legacy Team setup completion manifests", () => {
 				loadProjectInventory: () => [],
 			}),
 		).rejects.toThrow("team_setup_confirmation_stale");
+	});
+
+	it("containment removes only setup-owned group routing and is idempotent", async () => {
+		const draft = readyDraft();
+		const manifest = deriveLegacyTeamSetupCompletionManifest(db, {
+			candidateRef: CANDIDATE,
+			attemptId: draft.attemptId,
+			completedAt: NOW,
+		});
+		await applyLegacyTeamSetupCompletionManifest(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+			freshRoster: FRESH_ROSTER,
+			manifest,
+		});
+		const insertScope = db.prepare(`INSERT INTO replication_scopes(
+			scope_id, label, kind, authority_type, coordinator_id, group_id, status, created_at, updated_at
+		) VALUES (?, 'Scope', 'team', 'coordinator', ?, ?, ?, ?, ?)`);
+		insertScope.run("retired-scope", COORDINATOR_ID, GROUP_ID, "inactive", NOW, NOW);
+		insertScope.run("other-group", COORDINATOR_ID, "other-group", "active", NOW, NOW);
+		insertScope.run("other-coordinator", "other-coordinator", GROUP_ID, "active", NOW, NOW);
+		const insertMapping = db.prepare(`INSERT INTO project_scope_mappings(
+			workspace_identity, project_pattern, scope_id, priority, source, created_at, updated_at
+		) VALUES (?, ?, ?, 1000, ?, ?, ?)`);
+		for (const [project, scope, source] of [
+			[PROJECT_A, "scope-engineering", "reviewed_team_setup"],
+			[PROJECT_B, "retired-scope", "reviewed_team_setup"],
+			["manual", "scope-engineering", "user"],
+			["foreign-group", "other-group", "reviewed_team_setup"],
+			["foreign-coordinator", "other-coordinator", "reviewed_team_setup"],
+		])
+			insertMapping.run(project, project, scope, source, NOW, NOW);
+		const session = db.prepare(
+			"INSERT INTO sessions(started_at, project, git_remote) VALUES (?, ?, ?)",
+		);
+		const before = Number(session.run(NOW, "api", PROJECT_A).lastInsertRowid);
+		expect(resolveSessionScopeId(db, { sessionId: before })).toBe("scope-engineering");
+
+		await containLegacyTeamSetupCompletionConflict(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+		});
+		await containLegacyTeamSetupCompletionConflict(db, {
+			coordinatorId: COORDINATOR_ID,
+			groupId: GROUP_ID,
+		});
+		const after = Number(session.run(NOW, "api", PROJECT_A).lastInsertRowid);
+		expect(resolveSessionScopeId(db, { sessionId: after })).toBe("local-default");
+		expect(
+			db
+				.prepare("SELECT project_pattern FROM project_scope_mappings ORDER BY project_pattern")
+				.pluck()
+				.all(),
+		).toEqual(["foreign-coordinator", "foreign-group", "manual"]);
 	});
 
 	it("quarantines divergent local policy when the canonical winner cannot be applied", async () => {

--- a/packages/core/src/legacy-team-setup-completion-manifest.ts
+++ b/packages/core/src/legacy-team-setup-completion-manifest.ts
@@ -887,6 +887,18 @@ function quarantineDivergentCompletedPolicy(
 			 WHERE recipient_kind = 'team' AND recipient_id = ?
 			   AND provenance = 'reviewed_team_setup' AND status = 'active'`,
 		).run(team.revision, now, binding.teamId);
+		// Scope stamping ignores recipient status; remove this setup group's
+		// routing on active and retired scopes without touching independently owned mappings.
+		db.prepare(
+			`DELETE FROM project_scope_mappings
+			 WHERE source = 'reviewed_team_setup' AND scope_id IN (
+			   SELECT scope.scope_id FROM replication_scopes AS scope
+			   JOIN legacy_team_setup_drafts AS draft
+			     ON draft.coordinator_id = scope.coordinator_id AND draft.group_id = scope.group_id
+			   WHERE draft.candidate_id = ? AND draft.completed_team_id = ?
+			     AND scope.authority_type = 'coordinator'
+			 )`,
+		).run(binding.candidateRef, binding.teamId);
 		db.prepare(
 			`UPDATE legacy_team_setup_drafts SET finish_digest = NULL
 			 WHERE candidate_id = ? AND completed_team_id = ? AND state = 'completed'`,

--- a/packages/core/src/legacy-team-setup-limits.test.ts
+++ b/packages/core/src/legacy-team-setup-limits.test.ts
@@ -1,0 +1,39 @@
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { requireLegacyTeamSetupReachableDevicesWithinLimit } from "./legacy-team-setup-limits.js";
+
+describe("legacy Team readiness traversal limit", () => {
+	let db: InstanceType<typeof Database>;
+	const devices = Array.from({ length: 500 }, (_, index) => ({ deviceId: `device-${index}` }));
+	const projects = Array.from({ length: 20 }, (_, index) => `project-${index}`);
+
+	beforeEach(() => {
+		db = new Database(":memory:");
+		db.exec("CREATE TABLE identity_devices (device_id TEXT PRIMARY KEY)");
+		db.transaction(() => {
+			const insert = db.prepare("INSERT INTO identity_devices VALUES (?)");
+			for (const device of devices) insert.run(device.deviceId);
+		})();
+	});
+	afterEach(() => db.close());
+
+	it("counts already assigned roster devices once at the supported boundary", () => {
+		expect(() =>
+			requireLegacyTeamSetupReachableDevicesWithinLimit(db, devices, projects),
+		).not.toThrow();
+	});
+
+	it("still counts assignments outside the roster", () => {
+		db.prepare("INSERT INTO identity_devices VALUES (?)").run("outside-roster");
+		expect(() => requireLegacyTeamSetupReachableDevicesWithinLimit(db, devices, projects)).toThrow(
+			"legacy_team_setup_roster_too_large",
+		);
+	});
+
+	it("counts an unassigned roster even when there are no persisted assignments", () => {
+		db.exec("DELETE FROM identity_devices");
+		expect(() =>
+			requireLegacyTeamSetupReachableDevicesWithinLimit(db, devices, [...projects, "extra"]),
+		).toThrow("legacy_team_setup_roster_too_large");
+	});
+});

--- a/packages/core/src/legacy-team-setup-limits.ts
+++ b/packages/core/src/legacy-team-setup-limits.ts
@@ -43,15 +43,21 @@ export function requireLegacyTeamSetupAccessDeltaTraversalWithinLimit(input: {
  */
 export function requireLegacyTeamSetupReachableDevicesWithinLimit(
 	db: Database,
-	devices: readonly unknown[],
+	devices: readonly { deviceId: string }[],
 	projects: readonly unknown[],
 ): void {
 	if (projects.length === 0) return;
+	const deviceIds = [...new Set(devices.map((device) => device.deviceId))];
+	const excludeRoster =
+		deviceIds.length > 0 ? `WHERE device_id NOT IN (${deviceIds.map(() => "?").join(", ")})` : "";
 	const assignmentRows = Number(
-		db.prepare("SELECT COUNT(*) FROM identity_devices").pluck().get() ?? 0,
+		db
+			.prepare(`SELECT COUNT(*) FROM identity_devices ${excludeRoster}`)
+			.pluck()
+			.get(...deviceIds) ?? 0,
 	);
 	if (
-		(devices.length + assignmentRows) * projects.length >
+		(deviceIds.length + assignmentRows) * projects.length >
 		LEGACY_TEAM_SETUP_MAX_PROJECT_DEVICE_PAIRS
 	) {
 		throw new Error("legacy_team_setup_roster_too_large");

--- a/packages/embeddings/package.json
+++ b/packages/embeddings/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/embeddings",
-	"version": "0.44.0-beta.1",
+	"version": "0.44.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/mcp",
-	"version": "0.44.0-beta.1",
+	"version": "0.44.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -25,7 +25,7 @@ import {
 
 const TRUTHY_VALUES = ["1", "true", "yes"];
 const DISABLED_VALUES = ["0", "false", "off"];
-const PINNED_BACKEND_VERSION = "0.44.0-beta.1";
+const PINNED_BACKEND_VERSION = "0.44.0";
 const COMPAT_CHECK_DELAY_MS = 1500;
 const COMPAT_CHECK_CACHE_TTL_MS = 5 * 60 * 1000;
 const MAX_UPDATE_STATUS_BYTES = 16 * 1024;

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/opencode-plugin",
-	"version": "0.44.0-beta.1",
+	"version": "0.44.0",
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",

--- a/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
+++ b/packages/ui/src/tabs/legacy-team-setup-dialog.test.tsx
@@ -1609,7 +1609,7 @@ describe("legacy Team setup dialog", () => {
 		expect(document.body.outerHTML).not.toContain(privateRemote);
 	});
 
-	it("reloads stale Project mapping evidence and retries with a plain detail load", async () => {
+	it("reloads stale Project mapping evidence and refreshes on retry", async () => {
 		const initialProject = project();
 		const refreshedProject = project({
 			mappingChoices: [
@@ -1660,22 +1660,21 @@ describe("legacy Team setup dialog", () => {
 			expect(document.querySelector('[role="alert"]')?.textContent).toContain(
 				"changed since it was last reviewed",
 			);
-			expect(document.body.textContent).toContain("Project Gamma");
+			expect(document.body.textContent).toContain("Current setup details are unavailable");
 		});
 		expect(document.body.textContent).not.toContain("team_setup_confirmation_stale");
 		expect(loadDetail).toHaveBeenCalledTimes(2);
-		expect(document.querySelector<HTMLSelectElement>(".legacy-team-project-select")?.value).toBe(
-			"",
-		);
+		expect(document.querySelector(".legacy-team-project-select")).toBeNull();
 
 		act(() => document.getElementById("legacy-team-setup-retry")?.click());
 		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).toBeNull());
+		expect(document.body.textContent).toContain("Project Gamma");
 		expect(document.querySelector<HTMLSelectElement>(".legacy-team-project-select")?.value).toBe(
 			"",
 		);
 		expect(button("Save mapping").getAttribute("aria-disabled")).toBe("true");
-		expect(loadDetail).toHaveBeenCalledTimes(3);
-		expect(refreshCandidate).not.toHaveBeenCalled();
+		expect(loadDetail).toHaveBeenCalledTimes(2);
+		expect(refreshCandidate).toHaveBeenCalledTimes(1);
 	});
 
 	it("does not reload after an authoritative Project mapping response", async () => {
@@ -2884,10 +2883,11 @@ describe("legacy Team setup dialog", () => {
 			viewerAccessDeltaDigest: "fresh-viewer-access-digest",
 		});
 		const loadDetail = vi.fn().mockResolvedValueOnce(initial).mockResolvedValueOnce(refreshed);
+		const refreshCandidate = vi.fn().mockResolvedValue(refreshed);
 		const finish = vi
 			.fn()
 			.mockRejectedValue(new LegacyTeamSetupApiError(409, "team_setup_confirmation_stale"));
-		setup({ finish, loadDetail });
+		setup({ finish, loadDetail, refreshCandidate });
 		await vi.waitFor(() => expect(document.body.textContent).toContain("Finish Team setup"));
 		const confirmation = document.querySelector<HTMLInputElement>(
 			".legacy-team-setup-confirmation input",
@@ -2912,13 +2912,16 @@ describe("legacy Team setup dialog", () => {
 			confirmedAccessDeltaDigest: "opaque-access-digest",
 			confirmedViewerAccessDeltaDigest: "opaque-viewer-access-digest",
 		});
+		expect(document.querySelector(".legacy-team-setup-confirmation input")).toBeNull();
+		act(() => document.getElementById("legacy-team-setup-retry")?.click());
+		await vi.waitFor(() => expect(document.querySelector('[role="alert"]')).toBeNull());
+		expect(refreshCandidate).toHaveBeenCalledTimes(1);
 		const refreshedConfirmation = document.querySelector<HTMLInputElement>(
 			".legacy-team-setup-confirmation input",
 		);
 		expect(refreshedConfirmation?.checked).toBe(false);
-		expect(refreshedConfirmation?.getAttribute("aria-disabled")).toBe("true");
 		expect(document.body.textContent).toContain("Add Sam to Example Team.");
-		expect(button("Retry")).toBeTruthy();
+		expect(button("Finish Team setup").getAttribute("aria-disabled")).toBe("true");
 	});
 
 	it("treats a stale finish recovery that is already completed as success", async () => {

--- a/packages/ui/src/tabs/legacy-team-setup-session.test.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-session.test.ts
@@ -782,7 +782,7 @@ describe("legacy Team setup session reducer", () => {
 		);
 	});
 
-	it("uses a plain detail retry when confirmation-stale recovery also fails", () => {
+	it("refreshes the draft when confirmation-stale recovery also fails", () => {
 		let state = reduceSetupSession(loaded(open(), readyView()), { type: "finish" });
 		if (state.status !== "open") throw new Error("expected finish session");
 		const command = state.commands[0];
@@ -802,12 +802,12 @@ describe("legacy Team setup session reducer", () => {
 
 		expect(globalError(state)).toMatchObject({
 			message: expect.stringContaining("changed since it was last reviewed"),
-			retry: "load",
+			retry: "refresh",
 		});
 		expect(globalError(state)?.message).not.toContain("no local changes were applied");
 		state = reduceSetupSession(state, { type: "retry" });
 		expect(state).toMatchObject({
-			commands: [expect.objectContaining({ kind: "load", refresh: false })],
+			commands: [expect.objectContaining({ kind: "load", refresh: true })],
 		});
 	});
 
@@ -873,7 +873,7 @@ describe("legacy Team setup session reducer", () => {
 		},
 	);
 
-	it("uses a plain detail retry when roster-change recovery finds a completed draft", () => {
+	it("refreshes when roster-change recovery reports stale confirmation without a completed view", () => {
 		let state = reduceSetupSession(loaded(open(), readyView()), { type: "finish" });
 		if (state.status !== "open") throw new Error("expected finish session");
 		const command = state.commands[0];
@@ -893,11 +893,11 @@ describe("legacy Team setup session reducer", () => {
 
 		expect(globalError(state)).toMatchObject({
 			message: expect.stringContaining("changed since it was last reviewed"),
-			retry: "load",
+			retry: "refresh",
 		});
 		state = reduceSetupSession(state, { type: "retry" });
 		expect(state).toMatchObject({
-			commands: [expect.objectContaining({ kind: "load", refresh: false })],
+			commands: [expect.objectContaining({ kind: "load", refresh: true })],
 		});
 	});
 

--- a/packages/ui/src/tabs/legacy-team-setup-session.ts
+++ b/packages/ui/src/tabs/legacy-team-setup-session.ts
@@ -633,7 +633,8 @@ function retryFor(
 			cause.errorCode === "team_setup_confirmation_stale") ||
 		(recoveryCause instanceof LegacyTeamSetupApiError &&
 			recoveryCause.errorCode === "team_setup_confirmation_stale");
-	if (confirmationStale || options.terminalRecovery) return "load";
+	if (confirmationStale) return "refresh";
+	if (options.terminalRecovery) return "load";
 	if (options.changed || options.rosterUnavailable) return "refresh";
 	if (command.kind === "refresh") return "refresh";
 	if (command.kind === "load" && command.refresh) return "refresh";

--- a/packages/viewer-server/package.json
+++ b/packages/viewer-server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemem/server",
-	"version": "0.44.0-beta.1",
+	"version": "0.44.0",
 	"type": "module",
 	"types": "./dist/index.d.ts",
 	"exports": {

--- a/plugins/claude/.claude-plugin/plugin.json
+++ b/plugins/claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codemem",
   "description": "Persistent memory for Claude Code. Capture work across sessions and recall relevant context.",
-  "version": "0.44.0-beta.1",
+  "version": "0.44.0",
   "author": {
     "name": "Adam Kunicki"
   },

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codemem",
-  "version": "0.44.0-beta.1",
+  "version": "0.44.0",
   "description": "Persistent memory for Codex. Capture work across sessions and recall relevant context.",
   "author": {
     "name": "Adam Kunicki"


### PR DESCRIPTION
## Description
Stage stable metadata through the existing release-version script and add concise release notes. Remaining recall is deferred to 0.45+; OpenCode V1/V2 support stays in 0.45. This is candidate preparation, not release authorization.

Tracking: codemem-dh33.3. Commit: `0055008bc`. Layer `06-metadata` targets `release/0.44.0-05-packed-semantic`; do not retarget to main while its parent is unmerged.

### Stack Order
1. https://github.com/kunickiaj/codemem/pull/1658
2. https://github.com/kunickiaj/codemem/pull/1659
3. https://github.com/kunickiaj/codemem/pull/1660
4. https://github.com/kunickiaj/codemem/pull/1661
5. https://github.com/kunickiaj/codemem/pull/1662
6. https://github.com/kunickiaj/codemem/pull/1663 (this PR)
7. https://github.com/kunickiaj/codemem/pull/1664

**Release hold: layer 06 metadata MUST NOT be tagged or published until layer 07 containment cleanup is merged and the outstanding release gates pass. Final tagging is allowed only from the reviewed, merged, clean main commit, never a release-branch tip.** No merge or publication is requested by this PR.

## Type of Change
- [ ] Feature (new functionality)
- [ ] Bug fix (fixes an issue)
- [ ] Documentation (docs-only change)
- [x] Maintenance (refactor, chore, CI, etc.)
- [ ] Testing (test-only changes)

## Testing
The following local results apply to the complete candidate tip `bf55ed583`, not independently rerun validation of every intermediate layer. Per-layer CI must still run. Confirmed bug regressions failed before their fixes; parent direct review approved submission, not release.

| Gate | Candidate-tip result |
|---|---|
| `pnpm run build` | Pass, including viewer assets |
| `pnpm run check` | Pass in prescribed order; workspace 6495 passed, 3 TODOs |
| Release / adapter-normalizer / CI-workflow tests | 36 / 4 / 10 passed |
| Targeted completion-manifest, activation, candidate tests | 195 passed |
| `pnpm --filter codemem test:plugin` / `test:smoke` | 347 / 4 passed |
| `test:packed-artifact` for CLI and OpenCode plugin | Pass; CLI-only semantic install included |
| `pnpm --filter @codemem/embeddings test:packed-runtime` | Pass on macOS ARM64 |
| `pnpm --filter @codemem/cloudflare-coordinator-worker test:worker` | Pass |
| E2E smoke, legacy-team-migration, project-sharing, sharing-domains | Pass on rebuilt candidate Docker image |
| `pnpm run release:version -- check`, diff check, pre-commit | Pass |

E2E smoke used `CODEMEM_E2E_BUILD=1 CODEMEM_E2E_JSON=1`; specialized scenarios reused that image with `CODEMEM_E2E_BUILD=0`. Host validation used Node 24.20.0 and pinned pnpm 12.2.1. Lint passes with existing warnings. No live configuration or database was used.

- [x] Relevant checks pass locally (candidate tip, as scoped above)
- [ ] Added/updated tests for changes
- [ ] Manually verified changes work as expected in normal-user workload dogfood

**Outstanding release evidence:** exact 0.43.2-to-beta upgrade and vector migration; Windows-specific packed inference; normal-session/OpenCode restart dogfood. Windows CI is skipped on pull requests; Linux E2E and macOS inference do not replace it. The npm latest-tag guard is intentionally verify-only and warning-only, not a publication blocker; no registry settings were changed.

## Checklist
- [x] Code follows project style (candidate-tip lint passes)
- [x] Self-review completed
- [x] Documentation updated where needed (release notes are in layers 06 and 07)
- [ ] No new warnings introduced (existing warnings remain; no warning-free claim)
