### PR TITLE
chore(opencode): align v1 compatibility baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,16 +12,3 @@ updates:
     labels:
       - dependencies
       - npm
-
-  - package-ecosystem: npm
-    directory: "/.opencode"
-    schedule:
-      interval: daily
-      time: "09:15"
-      timezone: "UTC"
-    open-pull-requests-limit: 2
-    allow:
-      - dependency-name: "@opencode-ai/plugin"
-    labels:
-      - dependencies
-      - npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,13 +133,13 @@ jobs:
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install plugin runtime dependency
+      - name: Install minimum supported OpenCode 1 plugin runtime
         run: |
-          npm install --prefix packages/cli/.opencode --no-save @opencode-ai/plugin@1.2.27
-          npm install --prefix packages/opencode-plugin/.opencode --no-save @opencode-ai/plugin@1.2.27
+          npm install --prefix packages/cli/.opencode --no-save @opencode-ai/plugin@1.18.29
+          npm install --prefix packages/opencode-plugin/.opencode --no-save @opencode-ai/plugin@1.18.29
 
       - name: Run plugin unit tests
-        run: pnpm --filter codemem test:plugin && pnpm --filter codemem test:smoke
+        run: pnpm --filter codemem test:plugin && pnpm --filter @codemem/opencode-plugin test && pnpm --filter codemem test:smoke
 
   packaged-plugin-smoke:
     name: Packaged Plugin Smoke Test

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ viewer_ui/.vite/
 codemem/viewer_static/app.js.map
 
 # OpenCode runtime artifacts
+.opencode/package.json
 .opencode/package-lock.json
 
 # Agent skills (project-local installs, regenerate with: npx skills add)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ codemem keeps one minimum Node.js version across published packages and workspac
 
 ### OpenCode
 
+Codemem requires OpenCode 1.18.29 or newer.
+
 1. Install the OpenCode plugin and MCP config:
 
 ```text

--- a/docs/plans/2026-09-08-opencode-2-dual-support-design.md
+++ b/docs/plans/2026-09-08-opencode-2-dual-support-design.md
@@ -1,0 +1,263 @@
+# OpenCode 2 dual-support design
+
+**Status:** Approved
+**Date:** 2026-09-08
+**Tracking:** `codemem-cwl4`
+**Target release:** Codemem 0.45
+
+## Decision
+
+Codemem 0.45 will make OpenCode 2 support its primary release feature while
+preserving OpenCode 1 support in the existing `@codemem/opencode-plugin`
+package.
+
+The 0.44 release will finish without OpenCode 2 implementation work. Existing
+OpenCode 1 contract corrections discovered during this investigation move to
+the first 0.45 milestone so late compatibility work does not expand the 0.44
+release scope.
+
+## Why this matters
+
+OpenCode 2 replaces the plugin API that Codemem uses for capture, automatic
+recall, custom tools, and plugin lifecycle management.
+
+OpenCode 2 has replacements for those capabilities, but they use an imperative
+`setup(ctx)` model instead of the OpenCode 1 function that returns a hook map.
+Supporting both hosts from one package preserves the current installation path
+and gives users a side-by-side migration path while OpenCode 2 remains beta.
+
+## Release boundary
+
+The release boundary keeps 0.44 focused and gives 0.45 an explicit compatibility
+contract.
+
+| Release | Included | Excluded |
+| --- | --- | --- |
+| 0.44 | Current release completion and existing release gates | OpenCode 2 dependencies, adapters, setup changes, or support claims |
+| 0.45 | OpenCode 1.18.29+ contract baseline, shared adapter boundary, OpenCode 2 support, dual-host tests, and migration docs | Removing all OpenCode 1 support or silently reducing recall behavior |
+
+Raising the V1 floor from the older versions accepted by the current function
+entrypoint to 1.18.29 is a breaking compatibility change. The 0.45 release notes,
+versioning policy, and plugin reference will state that requirement before users
+upgrade.
+
+## Current integration
+
+An adapter is the host-specific code that translates OpenCode events and hooks
+into Codemem's capture, retrieval, and viewer lifecycle behavior.
+
+The current adapter is a single JavaScript module at
+`packages/opencode-plugin/.opencode/plugins/codemem.js`. It depends on these
+OpenCode 1 surfaces:
+
+- plugin factory inputs: `project`, `client`, `directory`, and `worktree`;
+- returned hooks: `event`, `tool.execute.after`,
+  `experimental.session.compacting`,
+  `experimental.chat.messages.transform`, and
+  `experimental.chat.system.transform`;
+- returned custom tools: `mem-status`, `mem-recent`, and `mem-stats`;
+- client methods: `client.app.log` and `client.tui.showToast`;
+- cleanup through the returned `dispose` callback.
+
+The module also owns host-neutral behavior: viewer startup and health checks,
+raw-event delivery and spooling, CLI fallbacks, retrieval, injection caching,
+delivery-ledger writes, retained-recall measurements, and backend update checks.
+That mixture makes a second set of inline host conditionals unsafe.
+
+## Confirmed baseline defects
+
+The 0.45 baseline milestone will correct known OpenCode 1 contract drift before
+introducing a second adapter.
+
+- Session events expose identity through nested event data that current fixtures
+  do not model consistently.
+- Message events can carry session identity in message or part data rather than
+  the top-level property the current extractor expects.
+- `client.app.log` requires the current SDK request body shape.
+- Assistant token usage uses the current nested token structure rather than only
+  the legacy snake-case structure.
+- Tool completion and failure should use declared hook fields instead of probing
+  undocumented alternatives.
+- At planning start, the package depended on `@opencode-ai/plugin` 1.18.25,
+  checked-in nested plugin manifests and CI installed 1.2.27, and the ignored
+  contributor-runtime manifest could retain a separate local version such as
+  1.4.3. PR 1 aligns the checked-in and CI surfaces to the 1.18.29 floor.
+- At planning start, the repository-root plugin wrapper was not exercised by the
+  root configuration. PR 1 adds direct wrapper smoke coverage.
+
+These are existing OpenCode 1 issues, not reasons to reopen the 0.44 feature
+scope.
+
+## OpenCode 2 mapping
+
+OpenCode 2 provides direct replacements for most current behavior through the
+new `@opencode/plugin` API.
+
+| Codemem behavior | OpenCode 1 | OpenCode 2 |
+| --- | --- | --- |
+| Plugin activation | exported async function | `Plugin.define({ id, setup })` |
+| Workspace metadata | factory arguments | `ctx.location` |
+| Public events | returned `event` hook | `ctx.event.subscribe()` |
+| Prompt injection | experimental message/system transforms | `ctx.session.hook("context")` |
+| Tool capture | returned `tool.execute.after` hook | `ctx.tool.hook("execute.after")` |
+| Custom tools | returned `tool` map | `ctx.tool.transform()` |
+| Cleanup | returned `dispose` hook | cleanup function returned by `setup` |
+| Plugin configuration | `plugin` | native `plugins`; V1 syntax is translated by V2 |
+
+OpenCode 2 documentation explicitly supports one package entrypoint with a V1
+`server()` function and a V2 `setup()` function. OpenCode 1 supports that object
+form starting with 1.18.29, so Codemem will raise its OpenCode 1 compatibility
+floor to that release for the dual package.
+
+## Architecture
+
+The 0.45 implementation will use thin host adapters around one shared plugin
+runtime.
+
+```text
+package entrypoint
+  ├── server(v1 context) -> OpenCode 1 adapter
+  └── setup(v2 context)  -> OpenCode 2 adapter
+                              │
+                              ▼
+                   shared Codemem plugin runtime
+                   - normalized host events
+                   - session state and working set
+                   - viewer lifecycle and transport
+                   - retrieval and delivery ledger
+                   - recall cache and measurements
+                   - backend compatibility checks
+```
+
+The package entrypoint will export one object containing both contracts. Named
+compatibility exports may remain, but OpenCode host loading must use the default
+dual entrypoint.
+
+Host adapters will normalize these values before calling shared behavior:
+
+- location, project identity, and a separately resolved worktree;
+- session and message identity;
+- user and assistant message content;
+- assistant token usage;
+- completed and failed tool executions;
+- session lifecycle and compaction signals;
+- outbound context messages and system parts;
+- host logging and optional user-notification methods.
+
+The shared runtime will not import either OpenCode SDK. This keeps beta API
+changes at the adapter edge and lets both host contracts exercise the same
+transport and state tests.
+
+## Injection contract
+
+OpenCode 2 support will not be declared complete until automatic recall preserves
+Codemem's delivery and replay guarantees.
+
+The V2 adapter must:
+
+1. retrieve at most one fresh pack for a new eligible user turn;
+2. avoid injecting into transient generation and compaction;
+3. preserve stable prior recall blocks across tool continuations;
+4. retain session and message identity when the host exposes it;
+5. keep token budgets, duplicate filtering, delivery receipts, and fail-open
+   retrieval behavior aligned with OpenCode 1;
+6. inject only into outbound model context, which OpenCode 2 documents as
+   separate from persisted history and configuration.
+
+The documented V2 `context` hook runs for normal model calls, tool continuations,
+transient generation, and compaction. Its current public shape does not expose a
+documented request `kind`, but adjacent `model.request` and HTTP hooks identify
+`primary`, `compaction`, `title`, and `generate` calls. The first V2 spike must
+prove that Codemem can safely correlate that signal with context calls despite
+concurrency and retries. If it cannot, V2 automatic recall stays disabled and the
+0.45 support claim remains beta or incomplete.
+
+## Capture contract
+
+OpenCode 2 capture will produce the same normalized raw-event envelope used by
+OpenCode 1.
+
+The V2 event subscription and tool hook must preserve source, session identity,
+event identity, ordering, bounded payloads, repository-relative working-set
+paths, and existing retry/spool behavior. Host-specific event schemas must not
+leak into viewer routes or storage.
+
+Event subscription will use an `AbortController`. Plugin cleanup will abort the
+stream, stop health monitoring, release duplicate-registration ownership, and
+dispose every V2 hook or transform registration.
+
+## Packaging and configuration
+
+The existing npm package and setup command remain the user-facing installation
+surface.
+
+Codemem setup will initially continue writing the V1 `plugin` key because
+OpenCode 2 translates supported V1 configuration and OpenCode 1 requires it.
+Native `plugins` output can follow after OpenCode 1 support ends or after setup
+can safely detect and target one host without breaking the other.
+
+The package will pin exact `opencode-ai` and `@opencode/plugin` beta revisions. A
+moving beta tag is not suitable for release builds or required CI. The
+implementation spike will choose whether typed TypeScript source can be shipped
+directly to both hosts or must be compiled to JavaScript; the packed artifact,
+not only the workspace copy, decides that outcome.
+
+OpenCode 2 normalizes unsupported characters in tool names to underscores.
+Codemem will keep the V1 names stable and document V2's effective
+`mem_status`, `mem_recent`, and `mem_stats` IDs unless the spike finds a supported
+way to preserve the hyphenated names.
+
+## Failure handling
+
+Host API failures must not break prompt execution unless OpenCode itself defines
+the intercepted operation as fail-closed.
+
+- Retrieval, viewer health, local logging, and capture delivery retain their
+  current bounded fallback behavior.
+- V2 notifications are optional. If the public plugin context has no toast API,
+  Codemem records the same bounded local diagnostic and skips the toast.
+- V2 event-stream termination is logged without content and does not restart in
+  an unbounded loop.
+- Failed V2 setup disposes completed registrations before returning the error.
+- Unknown event variants are ignored and covered by bounded diagnostics.
+- API-shape mismatches fail contract tests instead of being hidden behind broad
+  property probing.
+
+## Verification and release gate
+
+The release gate requires contract tests and real packed-host smoke tests for
+both OpenCode generations.
+
+Required coverage includes:
+
+- SDK-shaped unit fixtures for the minimum supported OpenCode 1 release;
+- typed V2 adapter tests against the exact pinned beta SDK;
+- packed-package loading under the `opencode` and `opencode2` binaries;
+- prompt, tool call, tool continuation, compaction, session deletion, and plugin
+  reload flows;
+- raw-event transport failure and spool replay;
+- automatic recall delivery, byte-stable replay, retained budget, duplicate
+  filtering, and ledger recording;
+- custom memory tools and cleanup of every registration;
+- the repository's normal TypeScript, lint, test, and packed-artifact gates.
+
+Codemem may label OpenCode 2 support beta while OpenCode 2 itself is beta. It
+must not call the integration feature-complete while capture, compaction safety,
+or automatic recall parity is knowingly missing.
+
+## Rollback
+
+The dual entrypoint makes rollback a host-edge change rather than a transport or
+storage rollback.
+
+If a pinned OpenCode 2 beta breaks the adapter, Codemem can disable the V2
+`setup()` path or pin the last verified beta while leaving V1 `server()` behavior
+and all shared backend contracts intact. No database migration is required for
+OpenCode 2 support.
+
+## Sources
+
+The design uses the current official OpenCode 2 beta documentation:
+
+- [Build plugins](https://opencode.ai/v2/docs/build/plugins)
+- [Migrate from V1](https://opencode.ai/v2/docs/migrate-v1)

--- a/docs/plans/2026-09-08-opencode-2-dual-support-implementation.md
+++ b/docs/plans/2026-09-08-opencode-2-dual-support-implementation.md
@@ -1,0 +1,446 @@
+# OpenCode 2 dual-support implementation plan
+
+**Design:** [OpenCode 2 dual support](./2026-09-08-opencode-2-dual-support-design.md)
+**Tracking epic:** `codemem-5v7c`
+**Completed investigation:** `codemem-cwl4`
+**Status:** In progress for 0.45; 0.44.0 shipped from `main`
+**Date:** 2026-09-08
+
+## Outcome
+
+Codemem 0.45 will ship one `@codemem/opencode-plugin` package that supports
+OpenCode 1.18.29+ and a pinned OpenCode 2 beta with equivalent capture, automatic
+recall, custom tools, and cleanup behavior.
+
+## Prerequisites
+
+The 0.44.0 release is complete, so the implementation gate is open.
+
+- Tag and publish 0.44 through the existing release process.
+- Start 0.45 work from updated `main`, not from the 0.44 release branch.
+- Record the exact OpenCode 2 CLI and `@opencode/plugin` beta revisions selected
+  by the contract spike.
+- Keep the current package name and backend wire contracts.
+- Do not mix unrelated viewer, sync, observer, or UI work into this stack.
+
+## Proposed Graphite stack
+
+The stack isolates contract correction, API discovery, shared-code extraction,
+and user-facing support so each pull request can fail or roll back independently.
+
+```text
+main after 0.44
+  <- PR 1: align the OpenCode 1 package baseline
+  <- PR 2: correct OpenCode 1 contract drift
+  <- PR 3: prove the pinned OpenCode 2 contract
+  <- PR 4: extract the shared plugin runtime
+  <- PR 5: add the dual package entrypoint
+  <- PR 6: add OpenCode 2 capture and lifecycle
+  <- PR 7: add OpenCode 2 recall and memory tools
+  <- PR 8: ship dual-host setup, CI, and documentation
+```
+
+Before implementation, confirm this stack under the repository's Graphite
+workflow. Each PR must pass its focused checks and remain independently
+reviewable.
+
+## PR 1: Align the OpenCode 1 package baseline
+
+**Bead:** `codemem-5v7c.1`
+
+The first PR creates one tested V1 baseline and documents its compatibility
+break before behavior changes.
+
+### Tasks
+
+1. Raise the tested OpenCode 1 floor to 1.18.29.
+2. Align the package dependency, nested `.opencode` manifests, lockfile, and
+   plugin-smoke CI on that version.
+3. Add a real `test` package script so package-scoped test commands cannot pass
+   without running tests.
+4. Add a smoke test for the repository-root wrapper, which is valid but not
+   loaded by the current root configuration.
+5. Document the OpenCode 1.18.29 minimum as a breaking 0.45 compatibility change
+   in versioning guidance; PR 8 owns the final 0.45 release-note input.
+6. Keep the root Dependabot SDK-update job and remove the ineffective job for the
+   ignored contributor-runtime manifest.
+7. Document a local refresh command for the ignored `.opencode/package.json`
+   contributor-runtime manifest; do not add that local file to Git.
+
+### Main files
+
+- `packages/opencode-plugin/package.json`
+- `packages/opencode-plugin/.opencode/package.json`
+- `packages/cli/.opencode/package.json`
+- `packages/opencode-plugin/vite.config.ts`
+- Focused package smoke tests
+- `.github/workflows/ci.yml`
+- `.github/dependabot.yml`
+- `pnpm-lock.yaml`
+- `.opencode/plugins/codemem.js`
+- `docs/versioning.md`
+
+### Validation
+
+```fish
+pnpm --filter codemem test:plugin
+pnpm --filter @codemem/opencode-plugin test
+pnpm --filter @codemem/opencode-plugin test:packed-artifact
+pnpm run tsc
+pnpm run lint
+```
+
+### Exit gate
+
+The package, nested manifests, CI, and lockfile use one V1 SDK version; the
+package test command runs real tests; and the compatibility floor is documented.
+
+## PR 2: Correct OpenCode 1 contract drift
+
+**Bead:** `codemem-5v7c.2`
+
+The second PR fixes the existing adapter against the V1 baseline without mixing
+those behavior changes into dependency alignment.
+
+### Tasks
+
+1. Replace handwritten session and message identity assumptions with fixtures
+   shaped from the SDK declarations.
+2. Read session identity from the documented session, message, and part fields.
+3. Send `client.app.log` requests through the documented request body.
+4. Normalize current assistant token data while retaining intentional legacy
+   compatibility only where a fixture proves it.
+5. Normalize completed and failed tool results from declared hook variants.
+6. Preserve retrieval, capture, update-notification, and raw-event behavior.
+
+### Main files
+
+- `packages/opencode-plugin/.opencode/plugins/codemem.js`
+- `packages/cli/.opencode/tests/plugin-transform-hook.test.js`
+- Other focused V1 contract fixtures only when needed
+
+### Validation
+
+```fish
+pnpm --filter codemem test:plugin
+pnpm --filter @codemem/opencode-plugin test
+pnpm --filter @codemem/opencode-plugin test:packed-artifact
+pnpm run tsc
+pnpm run lint
+```
+
+### Exit gate
+
+SDK-shaped session creation, deletion, message, usage, logging, and tool-result
+fixtures pass without undocumented top-level fields.
+
+## PR 3: Prove the pinned OpenCode 2 contract
+
+**Bead:** `codemem-5v7c.3`
+
+The third PR answers beta API questions with executable contract tests before
+shared code is reshaped around assumptions.
+
+### Tasks
+
+1. Pin exact matching revisions of the `opencode-ai` V2 CLI package and
+   `@opencode/plugin`; do not depend on moving beta tags.
+2. Add a minimal V2 plugin fixture using `Plugin.define({ id, setup })`.
+3. Prove package loading from an installed tarball rather than only a workspace
+   link.
+4. Capture and snapshot generic, session, message, and tool events without
+   storing prompt or result content in committed fixtures.
+5. Prove `ctx.location` behavior for project identity and determine the worktree
+   source separately through the documented VCS or worktree surfaces.
+6. Prove `ctx.session.hook("context")` message identity and mutation semantics
+   for initial prompts, tool continuations, transient generation, and compaction.
+7. Correlate the documented `kind` from adjacent model-request or HTTP hooks with
+   context calls, then test concurrency, retries, auxiliary generation, and
+   compaction before accepting it as the discriminator.
+8. Prove completed and failed `ctx.tool.hook("execute.after")` variants.
+9. Confirm the effective IDs produced for hyphenated custom-tool names and retain
+   the V1 names unless the V2 API offers a supported equivalent.
+10. Prove event-stream abort, registration disposal, reload, package unload,
+    `ctx.options`, and `ctx.storage` behavior.
+11. Determine whether the public V2 context exposes logging or toast methods. If
+    it does not, keep local file logging and treat user notifications as no-ops.
+12. Decide whether the dual entrypoint ships TypeScript source or compiled
+    JavaScript based on both packed-host smoke tests.
+
+### Main files
+
+- Add focused fixtures under `packages/opencode-plugin/src/` and its tests.
+- Update `packages/opencode-plugin/package.json` and `pnpm-lock.yaml`.
+- Update `packages/opencode-plugin/scripts/packed-artifact-smoke.mjs` or add a
+  dedicated V2 host smoke script.
+- Update CI only enough to run the pinned spike contract.
+
+### Validation
+
+```fish
+pnpm --filter @codemem/opencode-plugin test
+pnpm --filter @codemem/opencode-plugin test:packed-artifact
+pnpm run tsc
+```
+
+Run the pinned `opencode2` smoke command selected by the spike and document it in
+the package scripts so CI and contributors use the same invocation.
+
+### Exit gate
+
+Do not proceed to shared-runtime extraction until the spike proves auxiliary-call
+safety, stable turn identity, packed-package loading, and deterministic cleanup.
+If the beta API cannot prove those contracts, pin the investigation and report
+the upstream API gap instead of guessing around it.
+
+## PR 4: Extract the shared plugin runtime
+
+**Bead:** `codemem-5v7c.4`
+
+The fourth PR separates host translation from Codemem behavior without changing
+OpenCode 1 output.
+
+### Tasks
+
+1. Define small host-neutral interfaces for location, event capture, prompt
+   context, tool results, logging, optional notifications, and disposal.
+2. Move session state, viewer lifecycle, raw-event transport, CLI fallbacks,
+   retrieval, recall caching, ledger writes, and update checks behind one runtime
+   constructor.
+3. Keep V1 event and hook translation in a V1 adapter.
+4. Preserve deterministic IDs, raw-event envelopes, injection bytes, token
+   budgets, bounded paths, and fallback classifications.
+5. Replace cross-file copies with one source of truth; wrappers remain re-exports.
+6. Keep SDK imports out of the shared runtime.
+7. Verify that `pnpm run release:version` still resolves both managed pins after
+   extraction, and update the matcher and tests if generated output changes
+   their path or line shape.
+
+### Expected file shape
+
+The spike decides exact extensions and build output, but the logical split is:
+
+```text
+packages/opencode-plugin/
+  src/
+    runtime/
+    adapters/v1
+    adapters/v2
+    entrypoint
+```
+
+Generated or compiled artifacts may remain under `.opencode/plugins/` when host
+loading requires that location. Generated files must have a drift test and must
+not be hand-edited.
+
+### Additional files
+
+- `scripts/release-version.mjs`
+- `scripts/release-version.test.mjs`
+- `docs/versioning.md` when managed paths change
+
+### Validation
+
+```fish
+pnpm --filter codemem test:plugin
+pnpm --filter @codemem/opencode-plugin test
+pnpm --filter @codemem/opencode-plugin test:packed-artifact
+pnpm run test:release
+pnpm run tsc
+pnpm run lint
+```
+
+### Exit gate
+
+The full existing V1 plugin suite passes without expected-output changes, the
+shared runtime has no OpenCode SDK import, and release-version rewriting still
+finds and updates every managed backend pin.
+
+## PR 5: Add the dual package entrypoint
+
+**Bead:** `codemem-5v7c.5`
+
+The fifth PR changes the package export shape in isolation before V2 behavior is
+added.
+
+### Tasks
+
+1. Add the typed V2 definition with a no-behavior `setup()` shell proven by the
+   spike.
+2. Default-export one documented object containing V1 `server()` and V2
+   `id`/`setup()`.
+3. Preserve named compatibility exports where useful.
+4. Update packed-artifact assertions from a function default to the dual object.
+5. Prove V1 calls only `server()` and V2 calls only `setup()` from the installed
+   tarball.
+6. Cover duplicate loading through configured and checkout-local sources.
+
+### Main files
+
+- `packages/opencode-plugin/index.js` or its spike-selected replacement
+- `packages/opencode-plugin/package.json`
+- `packages/opencode-plugin/scripts/packed-artifact-smoke.mjs`
+- Focused V1 and V2 package-loading fixtures
+
+### Validation
+
+```fish
+pnpm --filter @codemem/opencode-plugin test
+pnpm --filter @codemem/opencode-plugin test:packed-artifact
+pnpm --filter codemem test:plugin
+pnpm run tsc
+pnpm run lint
+```
+
+### Exit gate
+
+Both installed hosts select only their intended entrypoint, and reverting this
+PR restores the old export shape without reverting runtime extraction.
+
+## PR 6: Add OpenCode 2 capture and lifecycle
+
+**Bead:** `codemem-5v7c.6`
+
+The sixth PR enables durable V2 capture before automatic recall is enabled.
+
+### Tasks
+
+1. Implement the V2 `setup(ctx)` adapter, map `ctx.location` to shared project
+   identity, and resolve the active worktree through the source proved by the
+   spike.
+2. Subscribe to `ctx.event.subscribe()` with an abortable task.
+3. Normalize V2 session, user-message, assistant-message, usage, and lifecycle
+   events into the existing raw-event envelope.
+4. Register `ctx.tool.hook("execute.after")` and normalize completed and failed
+   executions, including safe repository-relative working-set paths.
+5. Start, monitor, stop, and restart the viewer through the shared runtime.
+6. Dispose subscriptions, hook registrations, timers, health checks, and
+   duplicate-registration ownership on unload or partial setup failure.
+7. Keep capture failures non-blocking and bounded under the current spool and CLI
+   fallback rules.
+
+### Validation
+
+```fish
+pnpm --filter @codemem/opencode-plugin test
+pnpm --filter @codemem/opencode-plugin test:packed-artifact
+pnpm --filter codemem test:plugin
+pnpm run tsc
+pnpm run lint
+```
+
+### Exit gate
+
+A packed plugin run produces equivalent normalized event rows for one V1 and one
+V2 session across prompt, successful tool, failed tool, assistant completion,
+idle or terminal boundary, and unload flows.
+
+## PR 7: Add OpenCode 2 recall and memory tools
+
+**Bead:** `codemem-5v7c.7`
+
+The seventh PR enables V2's user-visible memory behavior only after capture and
+lifecycle cleanup are stable.
+
+### Tasks
+
+1. Register `ctx.session.hook("context")` through the V2 adapter.
+2. Build the retrieval query from the same first prompt, latest eligible prompt,
+   project, and working-set inputs as V1.
+3. Skip transient and compaction requests according to the proved V2
+   discriminator; confirm the documented absence of the context hook for title
+   requests in the pinned host smoke test.
+4. Preserve one fresh retrieval per eligible turn and stable replay across tool
+   continuations.
+5. Preserve retained-context limits, duplicate filtering, delivery-ledger
+   transitions, measurements, and empty-pack behavior.
+6. Confirm that injected context affects only outbound model context and is not
+   persisted as user-authored history.
+7. Register the memory tools with `ctx.tool.transform()`. Keep V1's hyphenated
+   names stable and use the V2 effective IDs proved by the spike, expected to be
+   `mem_status`, `mem_recent`, and `mem_stats`.
+8. Keep retrieval and optional diagnostics fail-open without swallowing host
+   contract defects in tests.
+
+### Validation
+
+```fish
+pnpm --filter @codemem/opencode-plugin test
+pnpm --filter codemem test:plugin
+pnpm --filter @codemem/opencode-plugin test:packed-artifact
+pnpm run tsc
+pnpm run lint
+```
+
+Run a packed V2 flow covering prompt, recall injection, tool continuation,
+second prompt, compaction, plugin reload, and session deletion.
+
+### Exit gate
+
+The V2 flow matches V1's selected memories, injection budget, duplicate handling,
+and delivery-ledger outcome without injecting during compaction or duplicating
+context on continuation.
+
+## PR 8: Ship dual-host setup, CI, and documentation
+
+**Bead:** `codemem-5v7c.8`
+
+The eighth and final PR turns the verified adapter into a supported 0.45 feature
+and keeps the user migration reversible.
+
+### Tasks
+
+1. Keep `codemem setup --opencode-only` writing configuration accepted by both
+   hosts; do not force native V2 config while V1 remains supported.
+2. Add setup tests for existing V1 config, V2-translated config, duplicate specs,
+   pinned package specs, and repeat runs.
+3. Add required CI jobs for the minimum V1 release and pinned V2 beta.
+4. Add a scheduled or manually triggered compatibility job against the moving V2
+   beta; keep it advisory so upstream beta publication does not randomly block
+   Codemem changes.
+5. Update `README.md`, `docs/plugin-reference.md`, `docs/architecture.md`, and
+   `docs/versioning.md` with installation, support status, host minimums,
+   effective V2 memory-tool names, troubleshooting, and rollback.
+6. State that OpenCode 2 support is beta while the host API is beta.
+7. Run the full release gate and review the complete stack.
+
+### Validation
+
+```fish
+pnpm --filter @codemem/opencode-plugin test
+pnpm --filter @codemem/opencode-plugin test:packed-artifact
+pnpm --filter codemem test:plugin
+pnpm run build
+pnpm run test:release
+pnpm run check
+```
+
+### Exit gate
+
+The installed package passes both host smoke tests, setup remains idempotent for
+existing users, the published `files` set contains the new artifact layout, all
+user-facing docs identify the beta pin and V1 minimum, and the full repository
+gate passes.
+
+## Review gates
+
+Review depth increases at the adapter boundaries because a silent capture or
+injection regression would corrupt user expectations without necessarily
+crashing the host.
+
+- Run CodeReviewer after every behavioral or packaging PR and the full stack.
+- Add adversarial review for compaction, duplicate registration, retry/spool
+  state, partial setup failure, and unload races.
+- Run the pragmatic quality reviewer after shared-runtime extraction to prevent
+  the adapter split from becoming a framework inside the plugin.
+- Confirm documentation impact in every PR that changes host-visible behavior.
+
+## Release and rollback
+
+The 0.45 release will pin one verified OpenCode 2 beta and retain OpenCode 1.18.29+
+support from the same package.
+
+If upstream V2 changes before 0.45 ships, update the pin in an isolated PR and
+rerun the V2 contract and packed-host suites. If parity cannot be restored, ship
+0.45 without the V2 support claim rather than weakening compaction or replay
+guarantees. V1 support and backend storage require no rollback migration.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -114,6 +114,25 @@ This check enforces a minimum supported CLI version. It does not query the npm r
 the latest available release, and its existing policy and update behavior are unchanged by release
 discovery.
 
+## OpenCode host compatibility
+
+Codemem 0.45 raises the minimum supported OpenCode 1 host to 1.18.29. The
+`@codemem/opencode-plugin` package records this floor through
+`engines.opencode`, which OpenCode checks when loading npm plugins, and CI runs
+the V1 plugin suite against that exact release.
+This is a breaking host-compatibility change from Codemem 0.44; upgrade OpenCode
+before installing the 0.45 plugin.
+
+Dependabot continues to propose SDK updates, but accepting one requires updating
+all checked-in runtime pins together. CI keeps the minimum host gate fixed at
+1.18.29 until the documented compatibility floor changes. The ignored
+`.opencode/package.json` is only a local contributor runtime and is not a release
+pin. Refresh it when testing the minimum host locally:
+
+```fish
+npm install --prefix .opencode --save-exact @opencode-ai/plugin@1.18.29
+```
+
 Override for testing:
 
 ```bash

--- a/packages/cli/.opencode/package.json
+++ b/packages/cli/.opencode/package.json
@@ -1,6 +1,6 @@
 {
 	"type": "module",
 	"dependencies": {
-		"@opencode-ai/plugin": "1.2.27"
+		"@opencode-ai/plugin": "1.18.29"
 	}
 }

--- a/packages/opencode-plugin/.opencode/package.json
+++ b/packages/opencode-plugin/.opencode/package.json
@@ -1,6 +1,6 @@
 {
 	"type": "module",
 	"dependencies": {
-		"@opencode-ai/plugin": "1.2.27"
+		"@opencode-ai/plugin": "1.18.29"
 	}
 }

--- a/packages/opencode-plugin/README.md
+++ b/packages/opencode-plugin/README.md
@@ -2,6 +2,8 @@
 
 Persistent memory plugin for [OpenCode](https://opencode.ai).
 
+Requires OpenCode 1.18.29 or newer.
+
 ## Install
 
 Recommended:

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -18,13 +18,15 @@
 		".opencode/lib/"
 	],
 	"scripts": {
+		"test": "pnpm exec vitest run",
 		"test:packed-artifact": "node ./scripts/packed-artifact-smoke.mjs"
 	},
 	"dependencies": {
-		"@opencode-ai/plugin": "1.18.25"
+		"@opencode-ai/plugin": "1.18.29"
 	},
 	"devDependencies": {
-		"@types/node": "^24.12.4"
+		"@types/node": "^24.12.4",
+		"vitest": "catalog:"
 	},
 	"repository": {
 		"type": "git",
@@ -36,7 +38,8 @@
 		"url": "https://github.com/kunickiaj/codemem/issues"
 	},
 	"engines": {
-		"node": ">=24.15.0"
+		"node": ">=24.15.0",
+		"opencode": ">=1.18.29"
 	},
 	"license": "MIT",
 	"publishConfig": {

--- a/packages/opencode-plugin/src/package-entrypoint.test.ts
+++ b/packages/opencode-plugin/src/package-entrypoint.test.ts
@@ -1,0 +1,37 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { expect, it } from "vitest";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "../../..");
+const minimumOpenCodeVersion = "1.18.29";
+
+async function readJson(relativePath: string) {
+	return JSON.parse(await readFile(path.join(repositoryRoot, relativePath), "utf8"));
+}
+
+it("keeps the OpenCode 1 SDK manifests aligned with the supported host floor", async () => {
+	const packageManifest = await readJson("packages/opencode-plugin/package.json");
+	const pluginRuntimeManifest = await readJson("packages/opencode-plugin/.opencode/package.json");
+	const cliRuntimeManifest = await readJson("packages/cli/.opencode/package.json");
+
+	expect(packageManifest.dependencies["@opencode-ai/plugin"]).toBe(minimumOpenCodeVersion);
+	expect(packageManifest.engines.opencode).toBe(`>=${minimumOpenCodeVersion}`);
+	expect(pluginRuntimeManifest.dependencies["@opencode-ai/plugin"]).toBe(minimumOpenCodeVersion);
+	expect(cliRuntimeManifest.dependencies["@opencode-ai/plugin"]).toBe(minimumOpenCodeVersion);
+});
+
+it("loads the repository wrapper from the canonical package implementation", async () => {
+	const packageEntrypointUrl = pathToFileURL(
+		path.join(repositoryRoot, "packages/opencode-plugin/index.js"),
+	).href;
+	const repositoryWrapperUrl = pathToFileURL(
+		path.join(repositoryRoot, ".opencode/plugins/codemem.js"),
+	).href;
+
+	const packageEntrypoint = await import(packageEntrypointUrl);
+	const repositoryWrapper = await import(repositoryWrapperUrl);
+
+	expect(Object.keys(repositoryWrapper)).toEqual(["default"]);
+	expect(repositoryWrapper.default).toBe(packageEntrypoint.default);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,12 +364,15 @@ importers:
   packages/opencode-plugin:
     dependencies:
       '@opencode-ai/plugin':
-        specifier: 1.18.25
-        version: 1.18.25
+        specifier: 1.18.29
+        version: 1.18.29
     devDependencies:
       '@types/node':
         specifier: ^24.12.4
         version: 24.13.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.11(@types/node@24.13.3)(jsdom@30.0.1)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.23.13)(yaml@2.9.0))
 
   packages/ui:
     dependencies:
@@ -1660,8 +1663,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@opencode-ai/plugin@1.18.25':
-    resolution: {integrity: sha512-Kb34zFqYosFNiMd1IuYiZGjX17z+18Srm7tHZMCz+uMVRTYNkEw1FTrfAK2FLbggwYdgzifGwKMNF1slLT8eLw==}
+  '@opencode-ai/plugin@1.18.29':
+    resolution: {integrity: sha512-IhF83EU4I/ASgWwvm0FIh1O3a8ZVuCLqPrCbmSHdSYq7GHxIYe773i6dHqcbrzCzvlG/lP2H+dyTQ+xPAwFpbw==}
     peerDependencies:
       '@opentui/core': '>=0.4.5'
       '@opentui/keymap': '>=0.4.5'
@@ -1674,8 +1677,8 @@ packages:
       '@opentui/solid':
         optional: true
 
-  '@opencode-ai/sdk@1.18.25':
-    resolution: {integrity: sha512-GwgwhW+vE8FWSDw730SjzqNhsWXB0uJjbFOiqFkmM+USFuG13HuTlGe6SR2ixt+WXxoD6FV1hILWqsXyqej9hQ==}
+  '@opencode-ai/sdk@1.18.29':
+    resolution: {integrity: sha512-4CS+FoLPkymTlcga8jxivGDDb2AbWMIIl3b8+myoe2wtv/1ANYCErslgz1xy5hTVHymWE6CtVNKzRuPU0ED57A==}
 
   '@oxc-project/types@0.147.0':
     resolution: {integrity: sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==}
@@ -4863,14 +4866,14 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
     optional: true
 
-  '@opencode-ai/plugin@1.18.25':
+  '@opencode-ai/plugin@1.18.29':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@opencode-ai/sdk': 1.18.25
+      '@opencode-ai/sdk': 1.18.29
       effect: 4.0.0-beta.83
       zod: 4.1.8
 
-  '@opencode-ai/sdk@1.18.25':
+  '@opencode-ai/sdk@1.18.29':
     dependencies:
       cross-spawn: 7.0.6
 

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -91,6 +91,20 @@ describe("normal CI workflow source contract", () => {
 		);
 	});
 
+	it("tests the minimum OpenCode 1 plugin runtime through both package suites", () => {
+		const pluginJob = getJob(ciWorkflow, "plugin-smoke");
+
+		assert.match(
+			pluginJob,
+			/npm install --prefix packages\/cli\/\.opencode --no-save @opencode-ai\/plugin@1\.18\.29/u,
+		);
+		assert.match(
+			pluginJob,
+			/npm install --prefix packages\/opencode-plugin\/\.opencode --no-save @opencode-ai\/plugin@1\.18\.29/u,
+		);
+		assert.match(pluginJob, /pnpm --filter @codemem\/opencode-plugin test &&/u);
+	});
+
 	it("defines the regular E2E Smoke check without an event condition", () => {
 		const smokeJob = getJob(ciWorkflow, "e2e-smoke");
 


### PR DESCRIPTION
## Description

Starts the Codemem 0.45 OpenCode 2 compatibility stack by creating a tested OpenCode 1 baseline. It raises the supported host floor to 1.18.29, aligns checked-in runtime pins and CI, adds package/root-wrapper coverage, and records the approved eight-PR roadmap.

Tracks codemem-5v7c.1.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated with `pnpm run tsc`, full lint, targeted Biome, 15 package tests, 347 CLI plugin tests, packed-artifact smoke, 11 CI workflow tests, 36 release tests, and `git diff --check`. The full workspace test suite was not run.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced