### PR TITLE
fix(ui): simplify memory card details

### DIFF
--- a/packages/ui/src/tabs/feed/components/FeedItemCard.test.tsx
+++ b/packages/ui/src/tabs/feed/components/FeedItemCard.test.tsx
@@ -92,4 +92,35 @@ describe("FeedItemCard", () => {
 		expect(mount.textContent).not.toContain(actorId);
 		expect(mount.textContent).not.toContain(deviceId);
 	});
+
+	it("renders tags only as chips", () => {
+		renderCard({
+			body_text: "A tagged memory body.",
+			tags_text: "searchable-tag second-tag",
+			title: "Tagged memory",
+		});
+
+		expect(mount.querySelector(".feed-meta")).toBeNull();
+		expect(mount.querySelector(".feed-tags")?.textContent).toContain("searchable-tag");
+		expect(mount.querySelectorAll(".tag-chip")).toHaveLength(2);
+	});
+
+	it("applies readable measure to narrative view", () => {
+		renderCard({
+			body_text: "A longer narrative with enough detail to differ from the summary.",
+			metadata_json: {
+				narrative: "A longer narrative with enough detail to differ from the summary.",
+				subtitle: "Short summary.",
+			},
+			title: "Narrative memory",
+		});
+
+		const narrativeButton = Array.from(mount.querySelectorAll("button")).find(
+			(button) => button.textContent === "Narrative",
+		);
+		expect(narrativeButton).toBeDefined();
+		act(() => narrativeButton?.click());
+
+		expect(mount.querySelector(".feed-body")?.classList.contains("narrative")).toBe(true);
+	});
 });

--- a/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
+++ b/packages/ui/src/tabs/feed/components/FeedItemCard.tsx
@@ -8,7 +8,6 @@ import {
 	formatDate,
 	formatFileList,
 	formatRelativeTime,
-	formatTagLabel,
 	parseJsonArray,
 } from "../../../lib/format";
 import { showGlobalNotice } from "../../../lib/notice";
@@ -73,7 +72,6 @@ export function FeedItemCard({
 	const workspaceKind = String(item.workspace_kind || metadata?.workspace_kind || "").trim();
 	const originSource = String(item.origin_source || metadata?.origin_source || "").trim();
 	const trustState = String(item.trust_state || metadata?.trust_state || "").trim();
-	const tagContent = tags.length ? ` · ${tags.map((t) => formatTagLabel(t)).join(", ")}` : "";
 	const fileContent = files.length ? ` · ${formatFileList(files)}` : "";
 	const memoryId = Number(item.id || 0);
 	const memoryIdLabel = memoryId > 0 ? `ID ${memoryId}` : "";
@@ -146,13 +144,12 @@ export function FeedItemCard({
 	]
 		.filter(Boolean)
 		.join(" · ");
-	const metaText = [`${tagContent}${fileContent}`.trim(), provenanceDetails]
-		.filter(Boolean)
-		.join(" · ");
+	const metaText = [fileContent.trim(), provenanceDetails].filter(Boolean).join(" · ");
 
 	const canClamp = Boolean(observationData) && shouldClampBody(activeMode, observationData);
 	const bodyClassName = [
 		activeMode === "facts" ? "feed-body facts" : "feed-body",
+		activeMode === "narrative" ? "narrative" : "",
 		canClamp && !expanded ? clampClass(activeMode).join(" ") : "",
 	]
 		.filter(Boolean)
@@ -359,11 +356,7 @@ export function FeedItemCard({
 						)
 					: null,
 			),
-			h(
-				"div",
-				{ className: "feed-meta" },
-				metaText || "No tags, files, or provenance details attached.",
-			),
+			metaText ? h("div", { className: "feed-meta" }, metaText) : null,
 			bodyContent,
 			h(
 				"div",

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -2213,6 +2213,7 @@
         line-height: 1.55;
         color: var(--text-secondary);
       }
+      .feed-body.narrative { max-width: 88ch; }
       .feed-body.clamp { display: -webkit-box; -webkit-box-orient: vertical; overflow: hidden; }
       .feed-body.clamp-3 { -webkit-line-clamp: 3; }
       .feed-body.clamp-5 { -webkit-line-clamp: 5; }


### PR DESCRIPTION
## Description

Memory cards showed tags twice: once as chips and once as a comma-separated line. This removes the repeated line, hides the details row when it has nothing useful to show, and keeps long narrative text at a more readable width. Summary content is unchanged.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused checks run:
- `pnpm exec vitest run packages/ui/src/tabs/feed/components/FeedItemCard.test.tsx`
- `pnpm --filter @codemem/ui build`
- Targeted Biome check; only existing FeedItemCard complexity warnings remain

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (not needed)
- [x] No new warnings introduced