### PR TITLE
fix(ui): make automatic recall stats readable

### DIFF
--- a/packages/ui/src/tabs/health.test.ts
+++ b/packages/ui/src/tabs/health.test.ts
@@ -1,4 +1,5 @@
-import { render } from "preact";
+import type { ComponentChildren } from "preact";
+import { h, render } from "preact";
 import { act } from "preact/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { UpdateStatus } from "../lib/api";
@@ -9,7 +10,8 @@ import { renderAutomaticRecall } from "./health/components";
 import { loadHealthData } from "./health/lifecycle";
 
 vi.mock("../components/primitives/tooltip", () => ({
-	Tooltip: ({ children }: { children?: unknown }) => children,
+	Tooltip: ({ children, label }: { children?: ComponentChildren; label?: string }) =>
+		h("span", { "data-tooltip": label }, children),
 	TooltipProvider: ({ children }: { children?: unknown }) => children,
 }));
 
@@ -44,6 +46,7 @@ beforeEach(() => {
 	document.body.innerHTML = `
 		<div id="healthUpdateBanner"></div>
 		<div id="healthGrid"></div>
+		<div id="automaticRecallStats"></div>
 		<div id="healthMeta"></div>
 		<div id="healthActions"></div>
 		<div id="healthDot"></div>
@@ -59,7 +62,7 @@ afterEach(() => {
 	vi.restoreAllMocks();
 	state.activeTab = "feed";
 	setUpdateStatus(null);
-	for (const id of ["healthUpdateBanner", "healthGrid", "healthActions"]) {
+	for (const id of ["healthUpdateBanner", "healthGrid", "automaticRecallStats", "healthActions"]) {
 		const element = document.getElementById(id);
 		if (element) act(() => render(null, element));
 	}
@@ -86,20 +89,34 @@ describe("Automatic recall disclosure", () => {
 		unmeasuredAttempts: 2,
 	};
 	function draw(payload: unknown) {
-		const container = document.getElementById("healthGrid");
+		const container = document.getElementById("automaticRecallStats");
 		act(() => renderAutomaticRecall(container, payload));
 		return container as HTMLElement;
 	}
-	it("starts collapsed with native keyboard disclosure and explicit denominator and period", () => {
+	it("shows measured recall outcomes as the existing stat tiles", () => {
 		const container = draw(stats);
 		const details = container.querySelector("details") as HTMLDetailsElement;
 		expect(details.open).toBe(false);
-		expect(details.querySelector("summary")?.textContent).toBe("Automatic recall (advanced)");
+		expect(details.querySelector("summary")?.textContent).toBe("Automatic recall");
 		expect(details.querySelector("section")?.getAttribute("aria-label")).toBe(
 			"Automatic recall measurements",
 		);
-		expect(container.textContent).toContain("1 / 4 fresh evaluations (25.0%)");
-		expect(container.textContent).toContain(stats.periodStart);
+		expect([...container.querySelectorAll(".stat .label")].map((node) => node.textContent)).toEqual(
+			["Recalls with repeats", "Memories skipped", "Repeated tokens removed", "Recalls checked"],
+		);
+		expect([...container.querySelectorAll(".stat .value")].map((node) => node.textContent)).toEqual(
+			["25%", "2", "~40 tokens", "4"],
+		);
+		expect(container.textContent).not.toContain(stats.periodStart);
+		expect(container.textContent).not.toContain("opencode-retained-v1");
+		expect(container.querySelector(`time[datetime="${stats.periodStart}"]`)).not.toBeNull();
+		expect(container.querySelector(`time[datetime="${stats.periodEnd}"]`)).not.toBeNull();
+		expect(container.querySelectorAll("dl")).toHaveLength(0);
+		expect(container.querySelectorAll(".stat[tabindex='0']")).toHaveLength(4);
+		expect(container.querySelector("[data-tooltip*='1 of 4 automatic recalls']")).not.toBeNull();
+		expect(
+			container.querySelector("[data-tooltip*='Some results may be incomplete']"),
+		).not.toBeNull();
 		details.open = true;
 		draw({ ...stats, unmeasuredAttempts: 3 });
 		expect(details.open).toBe(true);
@@ -111,18 +128,51 @@ describe("Automatic recall disclosure", () => {
 				typeof value === "number" && key !== "windowLimit" ? 0 : value,
 			]),
 		);
-		expect(draw({ ...empty, availability: "no_data" }).textContent).toContain(
-			"Savings are unknown, not zero",
-		);
+		const noData = draw({ ...empty, availability: "no_data", unmeasuredAttempts: 404 });
+		expect(noData.textContent).toContain("No recalls were checked, so savings are unknown");
+		expect([...noData.querySelectorAll(".stat .label")].map((node) => node.textContent)).toEqual([
+			"Recalls checked",
+			"Not checked",
+		]);
+		expect([...noData.querySelectorAll(".stat .value")].map((node) => node.textContent)).toEqual([
+			"0",
+			"404",
+		]);
+		const measuredZero = draw({
+			...stats,
+			evaluationsWithDuplicates: 0,
+			duplicatesOmitted: 0,
+			afterTokens: 100,
+			estimatedTokensAvoided: 0,
+		});
 		expect(
-			draw({
-				...stats,
-				evaluationsWithDuplicates: 0,
-				duplicatesOmitted: 0,
-				afterTokens: 100,
-				estimatedTokensAvoided: 0,
-			}).textContent,
-		).toContain("0 / 4 fresh evaluations (0.0%)");
+			[...measuredZero.querySelectorAll(".stat .value")].map((node) => node.textContent),
+		).toEqual(["0%", "0", "~0 tokens", "4"]);
+	});
+	it("keeps a small nonzero reduction distinct from zero", () => {
+		const container = draw({
+			...stats,
+			freshEvaluations: 900,
+			evaluationsWithDuplicates: 2,
+			candidateItems: 900,
+			duplicatesOmitted: 2,
+			missingRetainedMetadata: 0,
+		});
+		expect(container.querySelector(".stat .value")?.textContent).toBe("<1%");
+	});
+	it("keeps a high non-total reduction distinct from 100 percent", () => {
+		const container = draw({
+			...stats,
+			freshEvaluations: 900,
+			evaluationsWithDuplicates: 899,
+			candidateItems: 900,
+			duplicatesOmitted: 899,
+			beforeTokens: 900,
+			afterTokens: 1,
+			estimatedTokensAvoided: 899,
+			missingRetainedMetadata: 0,
+		});
+		expect(container.querySelector(".stat .value")?.textContent).toBe(">99%");
 	});
 	it.each([
 		undefined,
@@ -131,7 +181,7 @@ describe("Automatic recall disclosure", () => {
 		{ ...stats, estimatedTokensAvoided: 999 },
 		{ ...stats, periodStart: "invalid" },
 	])("fails closed for absent or invalid stats", (payload) => {
-		expect(draw(payload).textContent).toContain("Measurements unavailable");
+		expect(draw(payload).textContent).toContain("Automatic recall details aren’t available");
 	});
 });
 
@@ -198,7 +248,9 @@ describe("Health update banner", () => {
 		expect(updateBannerText()).toContain("Verify the current codemem version and try again.");
 		expect(updateBannerText()).not.toMatch(/up to date|latest stable release/i);
 	});
+});
 
+describe("Health update banner channels and guidance", () => {
 	it("identifies an up-to-date rc installation as rc", () => {
 		setUpdateStatus({
 			...availableStatus,

--- a/packages/ui/src/tabs/health/components.ts
+++ b/packages/ui/src/tabs/health/components.ts
@@ -10,6 +10,7 @@ import { Tooltip, TooltipProvider } from "../../components/primitives/tooltip";
 import type { UpdateStatus } from "../../lib/api";
 import { type AutomaticRecallStats, parseAutomaticRecallStats } from "../../lib/api/stats";
 import { copyToClipboard } from "../../lib/dom";
+import { formatTokenCount } from "../../lib/format";
 import type {
 	HealthAction,
 	HealthActionRowProps,
@@ -27,67 +28,111 @@ export function buildHealthCard(input: HealthCardInput): HealthCardInput {
 	return input;
 }
 
-function automaticRecallRows(stats: AutomaticRecallStats) {
-	const rows = [["Unmeasured retrieval attempts", stats.unmeasuredAttempts.toLocaleString()]];
-	if (stats.freshEvaluations > 0) {
-		rows.unshift(
-			[
-				"Duplicate hit rate",
-				`${stats.evaluationsWithDuplicates} / ${stats.freshEvaluations} fresh evaluations (${((100 * stats.evaluationsWithDuplicates) / stats.freshEvaluations).toFixed(1)}%)`,
-			],
-			["Estimated injection tokens avoided", stats.estimatedTokensAvoided.toLocaleString()],
-			[
-				"Estimated tokens before / after filtering",
-				`${stats.beforeTokens.toLocaleString()} / ${stats.afterTokens.toLocaleString()}`,
-			],
-			[
-				"Duplicate items omitted / candidate items",
-				`${stats.duplicatesOmitted} / ${stats.candidateItems}`,
-			],
-			[
-				"Evaluations with missing / invalid retained metadata",
-				`${stats.missingRetainedMetadata} / ${stats.invalidRetainedMetadata}`,
-			],
-			["Evaluations with pack metadata gaps", String(stats.packMetadataGaps)],
-		);
+function formatAutomaticRecallPeriod(stats: AutomaticRecallStats): [string, string] {
+	const start = new Date(stats.periodStart);
+	const end = new Date(stats.periodEnd);
+	const shortDate = new Intl.DateTimeFormat(undefined, {
+		month: "short",
+		day: "numeric",
+	});
+	const datedYear = new Intl.DateTimeFormat(undefined, {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+	});
+	if (start.getFullYear() === end.getFullYear()) {
+		return [shortDate.format(start), datedYear.format(end)];
 	}
-	return rows;
+	return [datedYear.format(start), datedYear.format(end)];
+}
+
+function formatRecallShare(part: number, total: number): string {
+	const rawPercent = (100 * part) / total;
+	const roundedPercent = Math.round(rawPercent);
+	if (rawPercent > 0 && roundedPercent === 0) return "<1%";
+	if (rawPercent < 100 && roundedPercent === 100) return ">99%";
+	return `${roundedPercent}%`;
+}
+
+function automaticRecallItems(stats: AutomaticRecallStats): StatItem[] {
+	if (stats.freshEvaluations === 0) {
+		return [
+			{
+				label: "Recalls checked",
+				value: 0,
+				tooltip: "No automatic recalls were checked for repeated memories in this period.",
+				icon: "activity",
+			},
+			{
+				label: "Not checked",
+				value: stats.unmeasuredAttempts,
+				tooltip: `Codemem could not check ${stats.unmeasuredAttempts.toLocaleString()} automatic recalls for repeated memories, so savings are unknown.`,
+				icon: "circle-help",
+			},
+		];
+	}
+
+	const deduplicatedValue = formatRecallShare(
+		stats.evaluationsWithDuplicates,
+		stats.freshEvaluations,
+	);
+	const hasIncompleteResults =
+		stats.missingRetainedMetadata > 0 ||
+		stats.invalidRetainedMetadata > 0 ||
+		stats.packMetadataGaps > 0;
+	return [
+		{
+			label: "Recalls with repeats",
+			value: deduplicatedValue,
+			tooltip: `Codemem removed repeated memories from ${stats.evaluationsWithDuplicates.toLocaleString()} of ${stats.freshEvaluations.toLocaleString()} automatic recalls.`,
+			icon: "filter",
+		},
+		{
+			label: "Memories skipped",
+			value: stats.duplicatesOmitted,
+			tooltip: `Codemem left out ${stats.duplicatesOmitted.toLocaleString()} memories that were already in your conversation, out of ${stats.candidateItems.toLocaleString()} considered.`,
+			icon: "minus-circle",
+		},
+		{
+			label: "Repeated tokens removed",
+			value: `~${formatTokenCount(stats.estimatedTokensAvoided)}`,
+			tooltip: `About ${stats.estimatedTokensAvoided.toLocaleString()} tokens were left out because they repeated information already in your conversation.`,
+			icon: "trending-down",
+		},
+		{
+			label: "Recalls checked",
+			value: stats.freshEvaluations,
+			tooltip: `Codemem checked ${stats.freshEvaluations.toLocaleString()} automatic recalls for repeated memories. ${stats.unmeasuredAttempts.toLocaleString()} more could not be checked.${hasIncompleteResults ? " Some results may be incomplete." : ""}`,
+			icon: "activity",
+		},
+	];
 }
 
 function automaticRecallDetail(stats: AutomaticRecallStats | null) {
 	if (!stats || stats.availability === "unavailable")
 		return h(
 			"p",
-			null,
-			"Measurements unavailable. Update the local backend and plugin, then refresh Health.",
+			{ class: "section-meta" },
+			"Automatic recall details aren’t available. Update Codemem and refresh this page.",
 		);
+	const [periodStart, periodEnd] = formatAutomaticRecallPeriod(stats);
 	return h(
 		Fragment,
 		null,
 		h(
-			"p",
-			null,
-			`Local OpenCode message recall, all projects. ${stats.periodStart} to ${stats.periodEnd}; at most the newest ${stats.windowLimit} eligible retrieval attempts, filtered to currently visible selected memories.`,
-		),
-		stats.freshEvaluations === 0
-			? h("p", null, "No recorded fresh evaluations in this window. Savings are unknown, not zero.")
-			: null,
-		h(
-			"dl",
-			null,
-			automaticRecallRows(stats).map(([label, value]) =>
-				h(Fragment, { key: label }, h("dt", null, label), h("dd", null, value)),
+			"div",
+			{ class: "grid-2 automatic-recall-grid" },
+			automaticRecallItems(stats).map((item) =>
+				h(StatBlock, { ...item, key: `${item.label}-${item.icon}` }),
 			),
 		),
 		h(
 			"p",
-			null,
-			"Capture: opencode-retained-v1. Older clients and failed recording leave coverage unknown; unmeasured attempts are not zero savings. Retries and replay do not add measured evaluations. Ceiling skips prevent evaluation and are excluded.",
-		),
-		h(
-			"p",
-			null,
-			"Token estimates compare wrapped candidate text before and after duplicate filtering, not provider consumption, money, or answer quality. The retained ceiling is opt-in; per-pack budgeting still applies.",
+			{ class: "automatic-recall-meta" },
+			h("time", { dateTime: stats.periodStart }, periodStart),
+			"–",
+			h("time", { dateTime: stats.periodEnd }, periodEnd),
+			` · Based on up to ${stats.windowLimit.toLocaleString()} recent automatic recalls across all projects.${stats.freshEvaluations === 0 ? " No recalls were checked, so savings are unknown." : ""}`,
 		),
 	);
 }
@@ -96,17 +141,22 @@ export function renderAutomaticRecall(container: HTMLElement | null, payload: un
 	if (!container) return;
 	render(
 		h(
-			"details",
+			TooltipProvider,
 			null,
-			h("summary", null, "Automatic recall (advanced)"),
 			h(
-				"section",
-				{ "aria-label": "Automatic recall measurements", style: "margin-top: var(--sp-3)" },
-				automaticRecallDetail(parseAutomaticRecallStats(payload)),
+				"details",
+				{ class: "automatic-recall" },
+				h("summary", null, "Automatic recall"),
+				h(
+					"section",
+					{ "aria-label": "Automatic recall measurements" },
+					automaticRecallDetail(parseAutomaticRecallStats(payload)),
+				),
 			),
 		),
 		container,
 	);
+	renderIcons();
 }
 
 function updateBannerCopy(status: UpdateStatus) {
@@ -295,6 +345,7 @@ export function StatBlock({ label, value, icon, tooltip }: StatItem) {
 		{
 			class: "stat",
 			style: tooltip ? "cursor: help;" : undefined,
+			tabIndex: tooltip ? 0 : undefined,
 		},
 		h("i", {
 			"data-lucide": icon,

--- a/packages/ui/static/index.html
+++ b/packages/ui/static/index.html
@@ -858,6 +858,30 @@
         text-transform: uppercase;
       }
 
+      .stat[tabindex="0"]:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      .automatic-recall { margin-top: var(--sp-3); }
+      .automatic-recall > summary {
+        min-height: 44px;
+        padding: 10px 0;
+        cursor: pointer;
+        color: var(--text-secondary);
+        font-size: var(--font-size-md);
+        font-weight: var(--font-weight-medium);
+      }
+      .automatic-recall > section { margin-top: var(--sp-2); }
+      .automatic-recall-grid { margin-top: var(--sp-3); }
+      .automatic-recall-meta {
+        max-width: 65ch;
+        margin-top: var(--sp-3);
+        color: var(--text-tertiary);
+        font-size: var(--font-size-sm);
+        line-height: 1.5;
+      }
+
       .health-primary {
         border-width: 2px;
       }
@@ -4529,7 +4553,7 @@
         <div class="card" style="animation-delay: 0.05s">
           <h2>Stats</h2>
           <div class="grid-2" id="statsGrid"></div>
-          <div id="automaticRecallStats" style="margin-top: var(--sp-3)"></div>
+          <div id="automaticRecallStats"></div>
         </div>
         <div class="card" style="animation-delay: 0.1s">
           <h2>Current session</h2>


### PR DESCRIPTION
## Description

Replace the unreadable Automatic recall diagnostics block with the same stat tiles used elsewhere in Health. The tiles use plain-language labels, accessible tooltips, readable local dates, and clear empty or unavailable states while preserving the distinction between zero and unknown savings.

The disclosure remains collapsed by default, keeps its native expand marker, and gives keyboard users visible focus access to stat descriptions.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [ ] Manually verified changes work as expected

Focused checks passed:

- `pnpm exec vitest run packages/ui/src/tabs/health.test.ts` (18 tests)
- `pnpm exec biome check packages/ui/src/tabs/health/components.ts packages/ui/src/tabs/health.test.ts`
- `pnpm --filter @codemem/ui typecheck`
- `pnpm --filter @codemem/ui build`
- `git diff --check`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced