### PR TITLE
fix(opencode): align v1 runtime contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ sources. If both load Codemem for one Project, the first registration wins and l
 their hooks with a warning. Remove the configured npm entry when testing a source checkout so the
 checkout-local plugin loads first; otherwise your edits may appear to do nothing.
 
+Capture follows the OpenCode 1.18.29 runtime contract: completed assistant
+messages use `info.time.completed`, token usage comes from `info.tokens`, and
+successful and failed tool executions are both recorded. OpenCode reports
+successful tools through `tool.execute.after` and failed tools through errored
+tool parts; Codemem normalizes both into the shared raw-event stream without
+double-counting repeated failure updates.
+
 Automatic OpenCode recall carries the host session ID through Viewer or CLI into
 Core assembly. Summary memories are eligible only from the exact mapped session;
 durable facts from other sessions remain eligible. If the mapping is not ready,

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -360,6 +360,16 @@ Stream contract:
 - Event streaming: `POST /api/raw-events`
 - Non-2xx and network failures are treated as stream failures.
 - Raw events are delivered through the viewer ingest API.
+- OpenCode 1.18.29 session IDs are read from each event's SDK-shaped `info` or
+  `part` payload. Assistant messages and usage are captured after either
+  `info.finish` or `info.time.completed`; current `info.tokens` and legacy usage
+  fields are normalized into one token shape.
+- Successful tools arrive through `tool.execute.after` and record
+  `output.output`. Failed tools arrive as errored `ToolPart` updates and are
+  normalized to `tool.execute.after` raw events with a null result and the
+  reported error. Repeated failure updates for the same session and call are
+  captured once, and their deduplication state is cleared when the session is
+  deleted.
 - Raw-event batches accepted by the viewer are retried by the sweeper flush workers.
 - After Viewer delivery fails, OpenCode writes the exact normalized envelope to `~/.codemem/opencode-raw-event-spool` before invoking the direct CLI fallback. A successful fallback removes the entry; missing runtimes, locks, timeouts, version skew, and validation failures remain on disk and retry at bounded startup or session boundaries with the same event ID.
 - Viewer mismatch notices expose only a fixed category and next action: restart Viewer from the same workspace/config for `database`, restart Codemem and OpenCode with the same environment for `identity`, update Codemem on the installed channel and restart OpenCode for `contract`, or check/restart Viewer for `connection`. Payloads, target values, subprocess output, paths, and addresses are omitted.

--- a/packages/cli/.opencode/tests/plugin-transform-hook.test.js
+++ b/packages/cli/.opencode/tests/plugin-transform-hook.test.js
@@ -386,10 +386,12 @@ describe("OpenCode transform-time injection", () => {
 		);
 
 		expect(secondHooks).toEqual({});
-		expect(secondAppLog).toHaveBeenCalledWith(expect.objectContaining({
-			level: "warn",
-			message: "codemem duplicate plugin registration skipped",
-		}));
+		expect(secondAppLog).toHaveBeenCalledWith({
+			body: expect.objectContaining({
+				level: "warn",
+				message: "codemem duplicate plugin registration skipped",
+			}),
+		});
 		const captureLines = readFileSync(process.env.CODEMEM_PLUGIN_LOG, "utf8")
 			.split("\n")
 			.filter((line) => line.includes("tool.execute.after read queued=1"));
@@ -909,9 +911,9 @@ describe("OpenCode transform-time injection", () => {
 
 		// Assert
 		const budgetWarnings = appLog.mock.calls
-			.map(([entry]) => entry)
+			.map(([entry]) => entry.body)
 			.filter(
-				(entry) => entry.message === "codemem context injection skipped: token budget is too small",
+				(entry) => entry?.message === "codemem context injection skipped: token budget is too small",
 			);
 		expect(budgetWarnings).toEqual([
 			expect.objectContaining({
@@ -1261,7 +1263,7 @@ describe("OpenCode transform-time injection", () => {
 		expect(spawnMock).toHaveBeenCalledTimes(1);
 
 		await hooks.event({
-			event: { type: "session.deleted", properties: { sessionID: "sess-disabled" } },
+			event: { type: "session.deleted", properties: { info: { id: "sess-disabled" } } },
 		});
 		await hooks["experimental.chat.messages.transform"]({}, output);
 		expect(spawnMock).toHaveBeenCalledTimes(2);
@@ -1950,13 +1952,13 @@ describe("OpenCode transform-time injection", () => {
 					failure_code: expectedFailureCode,
 				}),
 			);
-			expect(appLog).toHaveBeenCalledWith(
-				expect.objectContaining({
+			expect(appLog).toHaveBeenCalledWith({
+				body: expect.objectContaining({
 					level: "warn",
 					message: "codemem prompt-pack identity repair failed",
 					extra: expect.objectContaining({ reason: expectedReason }),
 				}),
-			);
+			});
 		},
 	);
 
@@ -2119,8 +2121,7 @@ describe("OpenCode transform-time injection", () => {
 			event: {
 				type: "message.updated",
 				properties: {
-					sessionID: "sess-empty-override",
-					info: { id: "user-stale", role: "user" },
+					info: { id: "user-stale", sessionID: "sess-empty-override", role: "user" },
 				},
 			},
 		});
@@ -2128,8 +2129,13 @@ describe("OpenCode transform-time injection", () => {
 			event: {
 				type: "message.part.updated",
 				properties: {
-					sessionID: "sess-empty-override",
-					part: { messageID: "user-stale", type: "text", text: "stale captured prompt" },
+					part: {
+						id: "part-stale",
+						sessionID: "sess-empty-override",
+						messageID: "user-stale",
+						type: "text",
+						text: "stale captured prompt",
+					},
 				},
 			},
 		});
@@ -2157,6 +2163,188 @@ describe("OpenCode transform-time injection", () => {
 		expect(output.messages[0].parts.at(-1).text).toBe(
 			"[codemem context]\n## Summary\n[1] (feature) Empty prompt override respected",
 		);
+	});
+
+	test("captures OpenCode 1.18.29 message and failed-tool event shapes", async () => {
+		process.env.CODEMEM_VIEWER = "1";
+		process.env.CODEMEM_VIEWER_AUTO = "0";
+		process.env.CODEMEM_RAW_EVENTS = "1";
+		const postedBodies = [];
+		vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
+			if (String(url).includes("/api/raw-events/status")) {
+				return jsonResponse(200, { ingest: { available: true } });
+			}
+			if (String(url).endsWith("/api/raw-events") && init?.method === "POST") {
+				postedBodies.push(JSON.parse(String(init.body)));
+				return jsonResponse(200, { ok: true });
+			}
+			return jsonResponse(200, {});
+		});
+
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: { app: { log: vi.fn().mockResolvedValue(undefined) }, tui: {} },
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
+		await hooks.event({
+			event: {
+				type: "message.part.updated",
+				properties: {
+					part: {
+						id: "assistant-text-current",
+						sessionID: "sess-current-sdk",
+						messageID: "assistant-current",
+						type: "text",
+						text: "Current SDK assistant response",
+					},
+				},
+			},
+		});
+		await hooks.event({
+			event: {
+				type: "message.updated",
+				properties: {
+					info: {
+						id: "assistant-current",
+						sessionID: "sess-current-sdk",
+						role: "assistant",
+						time: { created: 1, completed: 2 },
+						parentID: "user-current",
+						modelID: "model-current",
+						providerID: "provider-current",
+						mode: "chat",
+						path: { cwd: "/tmp/greenroom", root: "/tmp/greenroom" },
+						cost: 0,
+						tokens: {
+							input: 10,
+							output: 5,
+							reasoning: 2,
+							cache: { read: 3, write: 4 },
+						},
+					},
+				},
+			},
+		});
+		await hooks.event({
+			event: {
+				type: "message.updated",
+				properties: {
+					info: {
+						id: "assistant-legacy",
+						sessionID: "sess-current-sdk",
+						role: "assistant",
+						finish: "stop",
+						usage: {
+							input_tokens: 7,
+							output_tokens: 6,
+							cache_creation_input_tokens: 5,
+							cache_read_input_tokens: 4,
+						},
+					},
+				},
+			},
+		});
+		const failedToolEvent = {
+			type: "message.part.updated",
+			properties: {
+				part: {
+					id: "tool-current",
+					sessionID: "sess-current-sdk",
+					messageID: "assistant-current",
+					type: "tool",
+					callID: "call-current",
+					tool: "read",
+					state: {
+						status: "error",
+						input: { filePath: "src/current.ts" },
+						error: "permission denied",
+						time: { start: 1, end: 2 },
+					},
+				},
+			},
+		};
+		await hooks.event({ event: failedToolEvent });
+		await hooks.event({ event: failedToolEvent });
+		await hooks["tool.execute.after"](
+			{
+				tool: "write",
+				sessionID: "sess-current-sdk",
+				callID: "call-completed",
+				args: { filePath: "src/completed.ts" },
+			},
+			{ title: "Write src/completed.ts", output: "saved", metadata: {} },
+		);
+
+		await vi.waitFor(() => expect(postedBodies).toHaveLength(5));
+		const assistantEnvelope = postedBodies.find((entry) => entry.event_type === "assistant_message");
+		expect(assistantEnvelope).toMatchObject({
+			session_id: "sess-current-sdk",
+			payload: { assistant_text: "Current SDK assistant response" },
+		});
+		const usageEnvelope = postedBodies.find(
+			(entry) => entry.event_type === "assistant_usage" && entry.payload.message_id === "assistant-current",
+		);
+		expect(usageEnvelope).toMatchObject({
+			session_id: "sess-current-sdk",
+			payload: {
+				usage: {
+					input_tokens: 10,
+					output_tokens: 5,
+					cache_creation_input_tokens: 4,
+					cache_read_input_tokens: 3,
+				},
+			},
+		});
+		const legacyUsageEnvelope = postedBodies.find(
+			(entry) => entry.event_type === "assistant_usage" && entry.payload.message_id === "assistant-legacy",
+		);
+		expect(legacyUsageEnvelope.payload.usage).toEqual({
+			input_tokens: 7,
+			output_tokens: 6,
+			cache_creation_input_tokens: 5,
+			cache_read_input_tokens: 4,
+		});
+		const failedToolEnvelope = postedBodies.find(
+			(entry) => entry.event_type === "tool.execute.after" && entry.payload.tool === "read",
+		);
+		expect(failedToolEnvelope).toMatchObject({
+			session_id: "sess-current-sdk",
+			payload: {
+				tool: "read",
+				args: { filePath: "src/current.ts" },
+				result: null,
+			},
+		});
+		expect(failedToolEnvelope.payload.error).toContain("permission denied");
+		const completedToolEnvelope = postedBodies.find(
+			(entry) => entry.event_type === "tool.execute.after" && entry.payload.tool === "write",
+		);
+		expect(completedToolEnvelope).toMatchObject({
+			session_id: "sess-current-sdk",
+			payload: {
+				args: { filePath: "src/completed.ts" },
+				error: null,
+			},
+		});
+		expect(completedToolEnvelope.payload.result).toContain("saved");
+	});
+
+	test("tolerates null arguments from a successful tool hook", async () => {
+		process.env.CODEMEM_RAW_EVENTS = "0";
+		const { OpencodeMemPlugin } = await import("../plugins/codemem.js");
+		const hooks = await OpencodeMemPlugin({
+			project: { name: "greenroom" },
+			client: { app: { log: vi.fn().mockResolvedValue(undefined) }, tui: {} },
+			directory: "/tmp/greenroom",
+			worktree: "/tmp/greenroom",
+		});
+
+		await expect(hooks["tool.execute.after"](
+			{ tool: "custom", sessionID: "sess-null-args", callID: "call-null", args: null },
+			{ title: "Custom", output: "done", metadata: {} },
+		)).resolves.toBeUndefined();
 	});
 
 	test("passes only normalized repository paths to pack retrieval and ledger recording", async () => {
@@ -2955,10 +3143,12 @@ describe("OpenCode transform-time injection", () => {
 		);
 		await vi.waitFor(() => expect(fallbackBytes).toHaveLength(1));
 		await vi.waitFor(() =>
-			expect(appLog).toHaveBeenCalledWith(expect.objectContaining({
-				message: `codemem raw event was queued via CLI; ${nextAction}`,
-				extra: { category, delivery: "cli" },
-			})),
+			expect(appLog).toHaveBeenCalledWith({
+				body: expect.objectContaining({
+					message: `codemem raw event was queued via CLI; ${nextAction}`,
+					extra: { category, delivery: "cli" },
+				}),
+			}),
 		);
 
 		const httpEnvelope = { ...postedBodies[0] };
@@ -3035,10 +3225,12 @@ describe("OpenCode transform-time injection", () => {
 		);
 		await vi.waitFor(() => expect(enqueueBytes).toHaveLength(initialAttempts));
 		await vi.waitFor(() =>
-			expect(appLog).toHaveBeenCalledWith(expect.objectContaining({
-				message: "codemem raw event was saved for retry; check or restart the viewer",
-				extra: { category: "connection", delivery: "spool" },
-			})),
+			expect(appLog).toHaveBeenCalledWith({
+				body: expect.objectContaining({
+					message: "codemem raw event was saved for retry; check or restart the viewer",
+					extra: { category: "connection", delivery: "spool" },
+				}),
+			}),
 		);
 		await hooks.event({ event: { type: "session.idle", properties: { sessionID } } });
 
@@ -3263,7 +3455,7 @@ describe("OpenCode transform-time injection", () => {
 		await hooks["tool.execute.after"]({ tool: "read", args: {}, sessionID: "sess-latch-first" }, {});
 		await vi.waitFor(() =>
 			expect(appLog.mock.calls.filter(([entry]) =>
-				entry.message === "codemem could not save a raw event for retry; it remains queued in memory",
+				entry.body?.message === "codemem could not save a raw event for retry; it remains queued in memory",
 			)).toHaveLength(1),
 		);
 		rmSync(join(home, ".codemem"), { force: true });
@@ -3277,7 +3469,7 @@ describe("OpenCode transform-time injection", () => {
 
 		await vi.waitFor(() =>
 			expect(appLog.mock.calls.filter(([entry]) =>
-				entry.message === "codemem could not save a raw event for retry; it remains queued in memory",
+				entry.body?.message === "codemem could not save a raw event for retry; it remains queued in memory",
 			)).toHaveLength(2),
 		);
 		expect(showToast.mock.calls.filter(([entry]) =>
@@ -3316,10 +3508,12 @@ describe("OpenCode transform-time injection", () => {
 			{},
 		);
 		await vi.waitFor(() =>
-			expect(appLog).toHaveBeenCalledWith(expect.objectContaining({
-				message: "codemem could not save a raw event for retry; it remains queued in memory",
-				extra: { category: "persistence", reason: "write_failed" },
-			})),
+			expect(appLog).toHaveBeenCalledWith({
+				body: expect.objectContaining({
+					message: "codemem could not save a raw event for retry; it remains queued in memory",
+					extra: { category: "persistence", reason: "write_failed" },
+				}),
+			}),
 		);
 		const notices = JSON.stringify(appLog.mock.calls);
 		expect(notices).not.toContain("sensitive subprocess failure");
@@ -3355,7 +3549,7 @@ describe("OpenCode transform-time injection", () => {
 		);
 
 		await vi.waitFor(() =>
-			expect(appLog.mock.calls.some(([entry]) => entry.extra?.reason === "spool_full")).toBe(true),
+			expect(appLog.mock.calls.some(([entry]) => entry.body?.extra?.reason === "spool_full")).toBe(true),
 		);
 		const notices = [...appLog.mock.calls, ...showToast.mock.calls]
 			.map(([entry]) => JSON.stringify(entry))

--- a/packages/opencode-plugin/.opencode/plugins/codemem.js
+++ b/packages/opencode-plugin/.opencode/plugins/codemem.js
@@ -521,10 +521,12 @@ const createDebugLogger = ({ debug, client, logTimeoutMs, getLogLine, getErrorLo
     }
     try {
       const logPromise = client.app.log({
-        service: "codemem",
-        level,
-        message,
-        extra,
+        body: {
+          service: "codemem",
+          level,
+          message,
+          extra,
+        },
       });
       if (!Number.isFinite(logTimeoutMs) || logTimeoutMs <= 0) {
         await logPromise;
@@ -2240,6 +2242,7 @@ export const CodememPlugin = async ({
   let lastPromptText = null;
   let lastAssistantText = null;
   const assistantUsageCaptured = new Set();
+  const failedToolCaptured = new Set();
 
   // Track message roles and accumulated text by messageID
   const messageRoles = new Map();
@@ -2338,10 +2341,12 @@ export const CodememPlugin = async ({
       : "codemem could not save a raw event for retry; it remains queued in memory";
     try {
       await client.app.log({
-        service: "codemem",
-        level: "error",
-        message,
-        extra: { category: "persistence", reason },
+        body: {
+          service: "codemem",
+          level: "error",
+          message,
+          extra: { category: "persistence", reason },
+        },
       });
     } catch {
       // Best-effort app logging only.
@@ -2407,12 +2412,14 @@ export const CodememPlugin = async ({
     }
     try {
       await client.app.log({
-        service: "codemem",
-        level: delivered ? "warn" : "error",
-        message,
-        extra: {
-          category,
-          delivery,
+        body: {
+          service: "codemem",
+          level: delivered ? "warn" : "error",
+          message,
+          extra: {
+            category,
+            delivery,
+          },
         },
       });
     } catch {
@@ -2448,10 +2455,12 @@ export const CodememPlugin = async ({
         const message = "codemem could not read saved raw events; spool entries were left untouched";
         try {
           await client.app.log({
-            service: "codemem",
-            level: "error",
-            message,
-            extra: { category: "persistence", delivery: "load" },
+            body: {
+              service: "codemem",
+              level: "error",
+              message,
+              extra: { category: "persistence", delivery: "load" },
+            },
           });
         } catch {
           // Best-effort app logging only.
@@ -2641,10 +2650,29 @@ export const CodememPlugin = async ({
   };
 
   const extractSessionID = (event) => {
-    if (!event) {
+    if (!event || typeof event !== "object") {
       return null;
     }
-    return event?.properties?.sessionID || null;
+    const properties = event.properties;
+    if (!properties || typeof properties !== "object") {
+      return null;
+    }
+    if (typeof properties.sessionID === "string") {
+      return properties.sessionID;
+    }
+    if (typeof properties.info?.sessionID === "string") {
+      return properties.info.sessionID;
+    }
+    if (typeof properties.part?.sessionID === "string") {
+      return properties.part.sessionID;
+    }
+    if (
+      ["session.created", "session.updated", "session.deleted"].includes(event.type) &&
+      typeof properties.info?.id === "string"
+    ) {
+      return properties.info.id;
+    }
+    return null;
   };
 
   const extractHookSessionID = (input) => {
@@ -2788,7 +2816,7 @@ export const CodememPlugin = async ({
         // Only return assistant text when message is finished
         if (
           info.role === "assistant" &&
-          info.finish &&
+          (info.finish || info.time?.completed) &&
           messageTexts.has(info.id)
         ) {
           const text = messageTexts.get(info.id);
@@ -2826,10 +2854,16 @@ export const CodememPlugin = async ({
     if (!usage || typeof usage !== "object") {
       return null;
     }
-    const inputTokens = Number(usage.input_tokens || 0);
-    const outputTokens = Number(usage.output_tokens || 0);
-    const cacheCreationTokens = Number(usage.cache_creation_input_tokens || 0);
-    const cacheReadTokens = Number(usage.cache_read_input_tokens || 0);
+    const currentTokens = usage.tokens && typeof usage.tokens === "object" ? usage.tokens : null;
+    const currentCache = currentTokens?.cache && typeof currentTokens.cache === "object"
+      ? currentTokens.cache
+      : null;
+    const inputTokens = Number(currentTokens?.input ?? usage.input_tokens ?? 0);
+    const outputTokens = Number(currentTokens?.output ?? usage.output_tokens ?? 0);
+    const cacheCreationTokens = Number(
+      currentCache?.write ?? usage.cache_creation_input_tokens ?? 0
+    );
+    const cacheReadTokens = Number(currentCache?.read ?? usage.cache_read_input_tokens ?? 0);
     const total = inputTokens + outputTokens + cacheCreationTokens;
     if (!Number.isFinite(total) || total <= 0) {
       return null;
@@ -2847,14 +2881,14 @@ export const CodememPlugin = async ({
       return null;
     }
     const info = event.properties.info;
-    if (!info.id || info.role !== "assistant" || !info.finish) {
+    if (!info.id || info.role !== "assistant" || (!info.finish && !info.time?.completed)) {
       return null;
     }
     if (assistantUsageCaptured.has(info.id)) {
       return null;
     }
     const usage = normalizeUsage(
-      info.usage || event.properties?.usage || event.usage
+      info.tokens ? info : info.usage || event.properties?.usage || event.usage
     );
     if (!usage) {
       return null;
@@ -4496,6 +4530,29 @@ export const CodememPlugin = async ({
             `assistant_usage captured id=${assistantUsage.id.slice(-8)}`
           );
         }
+
+        const toolPart = eventType === "message.part.updated"
+          ? event.properties?.part
+          : null;
+        if (toolPart?.type === "tool" && toolPart.state?.status === "error") {
+          const failedToolKey = `${sessionID || "unknown"}:${toolPart.callID || toolPart.id}`;
+          if (!failedToolCaptured.has(failedToolKey)) {
+            failedToolCaptured.add(failedToolKey);
+            updateActivity();
+            sessionContext.toolCount++;
+            captureEvent(sessionID, {
+              type: "tool.execute.after",
+              tool: toolPart.tool,
+              args: toolPart.state.input,
+              result: null,
+              error: truncate(safeStringify(toolPart.state.error)),
+              timestamp: new Date().toISOString(),
+            });
+            await logLine(
+              `tool.execute.after ${toolPart.tool} failed queued=${events.length} tools=${sessionContext.toolCount}`
+            );
+          }
+        }
       }
 
       // NEW ACCUMULATION STRATEGY
@@ -4549,15 +4606,20 @@ export const CodememPlugin = async ({
           disabledInjectionRecorded.delete(`system:${sessionID}`);
           latestPolicySkips.delete(`message:${sessionID}`);
           latestPolicySkips.delete(`system:${sessionID}`);
+          for (const key of failedToolCaptured) {
+            if (key.startsWith(`${sessionID}:`)) {
+              failedToolCaptured.delete(key);
+            }
+          }
         }
         await stopViewer();
       }
     },
+    // OpenCode invokes this hook after successful tools; failures arrive as errored ToolPart events.
     "tool.execute.after": async (input, output) => {
-      const args = output?.args ?? input?.args ?? {};
-      const result = output?.result ?? output?.output ?? output?.data ?? null;
-      const error = output?.error ?? null;
-      const toolName = input?.tool || output?.tool || "unknown";
+      const args = input.args ?? {};
+      const result = output.output;
+      const toolName = input.tool;
 
       // Update activity and session context
       updateActivity();
@@ -4580,12 +4642,12 @@ export const CodememPlugin = async ({
         }
       }
 
-      captureEvent(input?.sessionID || null, {
+      captureEvent(input.sessionID, {
         type: "tool.execute.after",
         tool: toolName,
         args,
         result: truncate(safeStringify(result)),
-        error: truncate(safeStringify(error)),
+        error: null,
         timestamp: new Date().toISOString(),
       });
       await logLine(`tool.execute.after ${toolName} queued=${events.length} tools=${sessionContext.toolCount}`);


### PR DESCRIPTION
## Description

Align the OpenCode V1 adapter with the installed 1.18.29 SDK contract. This fixes nested application-log requests, current session and token event shapes, successful tool-hook output, and failed tool-part capture with deduplication. Legacy token fields remain covered explicitly.

Stacked on #1666.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] `pnpm --filter codemem test:plugin -- plugin-transform-hook.test.js` (349 tests)
- [x] `pnpm --filter @codemem/opencode-plugin test` (15 tests)
- [x] `pnpm run tsc`
- [x] `pnpm run build`
- [x] `pnpm --filter codemem test:packed-artifact`
- [x] `node --check` for both touched JavaScript files
- [x] Added/updated tests for changes

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Independent code review completed
- [x] Documentation not needed; public behavior and configuration are unchanged
- [x] No new warnings introduced

`pnpm run lint` completes with existing repository warnings; Biome excludes the two touched `.opencode` files.