### PR TITLE
test(opencode): prove pinned v2 contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
       - name: Run packed artifact smoke test
         run: |
           pnpm --filter @codemem/opencode-plugin test:packed-artifact
+          pnpm --filter @codemem/opencode-plugin test:opencode-v2-contract
           pnpm --filter codemem test:packed-artifact
 
   windows-embedding-runtime-smoke:

--- a/docs/opencode-v2-contract.md
+++ b/docs/opencode-v2-contract.md
@@ -1,0 +1,77 @@
+# OpenCode 2 beta contract
+
+The pinned OpenCode 2 beta can load a TypeScript plugin fixture from Codemem's
+packed npm artifact, but its context-mutation hook cannot identify the request
+kind that caused each call. Codemem must therefore keep automatic recall
+disabled in the V2 adapter until the host exposes an unambiguous request identity
+or adds `kind` to that hook.
+
+## Pinned test host
+
+The executable contract uses matching exact versions; moving beta tags and
+semver ranges are intentionally unsupported.
+
+- `@opencode/cli@0.0.0-beta-19296`
+- `@opencode/plugin@0.0.0-beta-19296`
+- CLI identity: `opencode2 v0.0.0-beta-19296`
+
+`pnpm --filter @codemem/opencode-plugin test:opencode-v2-contract` packs the
+Codemem plugin, installs that tarball in an isolated project, and asks the pinned
+host to activate the fixture from the installed package directory. OpenCode 2
+requires configured local plugin targets to be directories, so the packed
+fixture has its own package entrypoint under `v2-contract-fixture/`.
+
+Those contract-only TypeScript fixture files are intentionally present in this
+spike's published-file allowlist because the smoke must load them from the
+installed Codemem tarball. They are not exported as a supported consumer API.
+The production V2 entrypoint replaces this temporary package content in the
+later adapter PR.
+
+## Verified surfaces
+
+The fixture and its type-level tests verify these beta-19296 contracts:
+
+- `Plugin.define({ id, setup })` returns a plugin whose cleanup runs on host
+  shutdown.
+- `context.location.directory` identifies the active directory, while
+  `context.location.project` carries canonical project identity. Worktree and
+  VCS operations are separate context domains.
+- `context.options` exposes configured plugin options, and `context.storage`
+  supports set/get/remove round trips.
+- Event subscriptions accept an abort signal and stop during plugin cleanup. All
+  hook and transform registrations are disposed on cleanup. The fixture records
+  only event family and type, never message, prompt, argument, result, or error
+  content.
+- Session context is mutable through `system`, `messages`, `tools`, `generation`,
+  and `providerOptions`. Prompt hooks carry `sessionID` and `messageID`; context
+  hooks carry `sessionID`, agent, and model but no message or request ID.
+- Model-request and HTTP hooks carry `kind` values `primary`, `compaction`,
+  `title`, and `generate`. A model-request hook can stamp the mutable request
+  headers for downstream HTTP hooks. Retry hooks carry an attempt and mutable
+  decision but no `kind` or request ID.
+- Tool completion hooks distinguish `completed` results from `error` outcomes
+  and carry call, message, session, agent, tool, and input identity.
+- The packed-host smoke verifies that the fixture can declare the hyphenated
+  tool name `mem-status`. The transform API neither accepts an explicit custom
+  ID nor exposes the host-generated effective ID while adding the tool.
+- The promise-plugin context used by Codemem exposes neither logging nor toast
+  methods. The separate TUI plugin API exposes `ui.toast`, but that is not the
+  adapter surface under test. The V2 promise adapter must retain local file
+  logging and treat user notifications as unavailable through its context.
+- Tool, VCS, and worktree reload methods are confirmed by the exact package
+  types. Invoking those state-mutating operations is outside this activation
+  smoke; host shutdown exercises unload and cleanup behavior.
+
+## Automatic recall gate
+
+The context hook is Codemem's recall-injection point, but it identifies a request
+with only the tuple of session, agent, and model. Concurrent primary and
+auxiliary requests can share that tuple. The later model-request and HTTP hooks
+carry `kind`, and headers can preserve it downstream, but that cannot
+retroactively classify an earlier context mutation. Retry hooks also omit both
+request kind and request ID. Adjacency or timing cannot resolve the context-hook
+ambiguity without race conditions.
+
+The V2 adapter may capture events and expose manual memory tools, but it must not
+inject automatic recall until a later pinned host contract passes concurrency,
+retry, auxiliary-generation, and compaction correlation tests.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -133,6 +133,17 @@ pin. Refresh it when testing the minimum host locally:
 npm install --prefix .opencode --save-exact @opencode-ai/plugin@1.18.29
 ```
 
+The OpenCode 2 contract spike separately pins matching
+`@opencode/cli@0.0.0-beta-19296` and
+`@opencode/plugin@0.0.0-beta-19296` development dependencies. The workspace
+allows the CLI package's postinstall because it installs the matching platform
+binary used by the packed-host smoke test. For beta-19296, the reviewed
+postinstall copies that platform binary and detects AVX2 support with `sysctl` on
+macOS or PowerShell on Windows. Re-review the postinstall whenever the exact pin
+changes. Update both beta revisions together and rerun the executable checks
+documented in [the OpenCode 2 beta contract](opencode-v2-contract.md); do not
+replace these pins with a moving beta tag or semver range.
+
 Override for testing:
 
 ```bash

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -21,6 +21,7 @@
 	],
 	"scripts": {
 		"test": "pnpm exec vitest run",
+		"test:opencode-v2-contract": "node ./scripts/packed-v2-host-smoke.mjs",
 		"test:packed-artifact": "node ./scripts/packed-artifact-smoke.mjs"
 	},
 	"dependencies": {

--- a/packages/opencode-plugin/scripts/packed-v2-host-smoke.mjs
+++ b/packages/opencode-plugin/scripts/packed-v2-host-smoke.mjs
@@ -1,0 +1,708 @@
+import { spawn, spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { once } from "node:events";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	readdirSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const packageRoot = process.cwd();
+const workspaceRoot = resolve(packageRoot, "..", "..");
+const pinnedVersion = "0.0.0-beta-19296";
+const packedFixtureTarget = "./node_modules/@codemem/opencode-plugin/v2-contract-fixture";
+const tempDir = mkdtempSync(join(tmpdir(), "codemem-opencode-v2-contract-"));
+let providerServer;
+let hostProcess;
+
+function fail(message, result) {
+	if (result?.stdout) process.stderr.write(result.stdout);
+	if (result?.stderr) process.stderr.write(result.stderr);
+	throw new Error(message);
+}
+
+function run(command, args, options = {}) {
+	const result = spawnSync(command, args, {
+		cwd: options.cwd ?? packageRoot,
+		encoding: "utf8",
+		env: options.env ?? process.env,
+		timeout: options.timeoutMs ?? 300_000,
+	});
+	if (result.error) fail(`Command failed: ${command} ${args.join(" ")}`, result);
+	if (result.status !== 0) fail(`Command failed: ${command} ${args.join(" ")}`, result);
+	return result;
+}
+
+function assert(condition, message) {
+	if (!condition) throw new Error(message);
+}
+
+function isExpectedProjectPath(value, expectedPath) {
+	return (
+		typeof value === "string" &&
+		existsSync(value) &&
+		realpathSync(value) === realpathSync(expectedPath)
+	);
+}
+
+function runAsync(command, args, options = {}) {
+	return new Promise((resolvePromise, reject) => {
+		const child = spawn(command, args, {
+			cwd: options.cwd ?? packageRoot,
+			env: options.env ?? process.env,
+		});
+		let stdout = "";
+		let stderr = "";
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk;
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk;
+		});
+		let timedOut = false;
+		const timeoutMs = options.timeoutMs ?? 300_000;
+		let forceKill;
+		const timeout = setTimeout(() => {
+			timedOut = true;
+			child.kill();
+			forceKill = setTimeout(() => child.kill("SIGKILL"), 5_000);
+		}, timeoutMs);
+		child.on("error", (error) => {
+			clearTimeout(timeout);
+			clearTimeout(forceKill);
+			reject(error);
+		});
+		child.on("close", (status) => {
+			clearTimeout(timeout);
+			clearTimeout(forceKill);
+			const result = { status, stdout, stderr };
+			if (timedOut) {
+				reject(new Error(`Command timed out after ${timeoutMs}ms: ${command} ${args.join(" ")}`));
+				return;
+			}
+			if (status !== 0) {
+				reject(new Error(`Command failed: ${command} ${args.join(" ")}\n${stdout}${stderr}`));
+				return;
+			}
+			resolvePromise(result);
+		});
+	});
+}
+
+async function startProvider(projectDir) {
+	let attempts = 0;
+	let primaryAttempts = 0;
+	const observations = [];
+	const server = createServer(async (request, response) => {
+		const chunks = [];
+		for await (const chunk of request) chunks.push(chunk);
+		if (!request.url?.endsWith("/chat/completions")) {
+			response.writeHead(404).end();
+			return;
+		}
+		const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+		observations.push({
+			messages: body.messages?.map((message) => ({
+				role: message.role,
+				mentionsFailure: JSON.stringify(message.content).includes("failure"),
+			})),
+			tools: body.tools
+				?.filter((tool) => tool.function?.name === "read")
+				.map((tool) => ({
+					name: tool.function?.name,
+					description: tool.function?.description,
+				})),
+		});
+		attempts += 1;
+		if (request.headers["x-codemem-contract-kind"] === "primary") primaryAttempts += 1;
+		if (primaryAttempts === 1) {
+			response.writeHead(429, {
+				"content-type": "application/json",
+				"retry-after-ms": "1",
+			});
+			response.end(
+				JSON.stringify({ error: { message: "contract retry", type: "rate_limit_error" } }),
+			);
+			return;
+		}
+		response.writeHead(200, { "content-type": "text/event-stream" });
+		const messages = Array.isArray(body.messages) ? body.messages : [];
+		const latestUserIndex = messages.findLastIndex((message) => message.role === "user");
+		const messagesAfterPrompt = messages.slice(latestUserIndex + 1);
+		const hasToolResult = messagesAfterPrompt.some((message) => message.role === "tool");
+		const requestFailure = JSON.stringify(messages.at(latestUserIndex)).includes("failure");
+		const selectedTool = body.tools?.find((tool) => tool.function?.name === "read")?.function?.name;
+		if (!hasToolResult && selectedTool) {
+			response.write(
+				`data: ${JSON.stringify({
+					id: "chatcmpl-contract-tool",
+					object: "chat.completion.chunk",
+					created: 0,
+					model: "contract-model",
+					choices: [
+						{
+							index: 0,
+							delta: {
+								role: "assistant",
+								tool_calls: [
+									{
+										index: 0,
+										id: requestFailure ? "call-contract-error" : "call-contract-completed",
+										type: "function",
+										function: {
+											name: selectedTool,
+											arguments: JSON.stringify({
+												path: requestFailure
+													? join(projectDir, "missing-contract-file")
+													: join(projectDir, "package.json"),
+											}),
+										},
+									},
+								],
+							},
+							finish_reason: null,
+						},
+					],
+				})}\n\n`,
+			);
+			response.write(
+				`data: ${JSON.stringify({
+					id: "chatcmpl-contract-tool",
+					object: "chat.completion.chunk",
+					created: 0,
+					model: "contract-model",
+					choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+				})}\n\n`,
+			);
+			response.end("data: [DONE]\n\n");
+			return;
+		}
+		response.write(
+			`data: ${JSON.stringify({
+				id: "chatcmpl-contract",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: "contract-model",
+				choices: [
+					{
+						index: 0,
+						delta: { role: "assistant", content: "contract-ok" },
+						finish_reason: null,
+					},
+				],
+			})}\n\n`,
+		);
+		response.write(
+			`data: ${JSON.stringify({
+				id: "chatcmpl-contract",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: "contract-model",
+				choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+			})}\n\n`,
+		);
+		response.end("data: [DONE]\n\n");
+	});
+	await new Promise((resolvePromise, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", resolvePromise);
+	});
+	const address = server.address();
+	assert(address && typeof address === "object", "Local provider did not bind a TCP port");
+	return {
+		attempts: () => attempts,
+		baseURL: `http://127.0.0.1:${address.port}/v1`,
+		observations: () => observations,
+		primaryAttempts: () => primaryAttempts,
+		server,
+	};
+}
+
+function closeServer(server) {
+	return new Promise((resolvePromise, reject) => {
+		server.close((error) => {
+			if (error) reject(error);
+			else resolvePromise();
+		});
+	});
+}
+
+async function startHost(opencode2, projectDir, env) {
+	const child = spawn(opencode2, ["serve", "--hostname", "127.0.0.1"], {
+		cwd: projectDir,
+		env,
+	});
+	hostProcess = child;
+	let output = "";
+	child.stdout.setEncoding("utf8");
+	child.stderr.setEncoding("utf8");
+	child.stdout.on("data", (chunk) => {
+		output += chunk;
+	});
+	child.stderr.on("data", (chunk) => {
+		output += chunk;
+	});
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		if (child.exitCode !== null) throw new Error(`Pinned host exited during startup\n${output}`);
+		const match = output.match(/server listening on (http:\/\/\S+)/);
+		if (!match) {
+			await new Promise((resolvePromise) => setTimeout(resolvePromise, 50));
+			continue;
+		}
+		const baseURL = match[1];
+		try {
+			const response = await fetch(`${baseURL}/api/health`, {
+				headers: {
+					Authorization: `Basic ${Buffer.from(`opencode:${env.OPENCODE_SERVER_PASSWORD}`).toString("base64")}`,
+				},
+			});
+			if (response.ok) return { baseURL, child, output: () => output };
+		} catch {
+			// The server has not bound the port yet.
+		}
+		await new Promise((resolvePromise) => setTimeout(resolvePromise, 50));
+	}
+	try {
+		await stopHost(child);
+	} catch {
+		process.stderr.write("Warning: unable to stop the pinned host after failed startup\n");
+	}
+	throw new Error(`Pinned host did not start\n${output}`);
+}
+
+async function promptHost(opencode2, host, sessionID, text, options) {
+	await runAsync(
+		opencode2,
+		[
+			"api",
+			"--server",
+			host.baseURL,
+			"POST",
+			`/api/session/${sessionID}/prompt`,
+			"--data",
+			JSON.stringify({ text }),
+		],
+		options,
+	);
+	await runAsync(
+		opencode2,
+		["api", "--server", host.baseURL, "POST", `/api/session/${sessionID}/wait`],
+		options,
+	);
+}
+
+async function stopHost(child) {
+	if (child.exitCode !== null) return;
+	const closed = once(child, "close");
+	child.kill();
+	const forceKill = setTimeout(() => child.kill("SIGKILL"), 5_000);
+	let stopTimeoutID;
+	const stopTimeout = new Promise((_, reject) => {
+		stopTimeoutID = setTimeout(() => reject(new Error("Pinned host did not stop")), 10_000);
+	});
+	try {
+		await Promise.race([closed, stopTimeout]);
+	} finally {
+		clearTimeout(forceKill);
+		clearTimeout(stopTimeoutID);
+	}
+}
+
+function readContractRecords(reportPath, hostResult) {
+	if (!existsSync(reportPath)) {
+		fail("Pinned OpenCode 2 host did not activate the contract plugin", hostResult);
+	}
+	return readFileSync(reportPath, "utf8")
+		.split(/\r?\n/u)
+		.filter(Boolean)
+		.map((line) => JSON.parse(line));
+}
+
+try {
+	run("pnpm", ["pack", "--pack-destination", tempDir]);
+	const tarballs = readdirSync(tempDir).filter((name) => name.endsWith(".tgz"));
+	assert(tarballs.length === 1, `pnpm pack produced ${tarballs.length} plugin tarballs`);
+	const tarball = join(tempDir, tarballs[0]);
+
+	const installDir = join(tempDir, "install");
+	mkdirSync(installDir, { recursive: true });
+	writeFileSync(join(installDir, "package.json"), JSON.stringify({ private: true }), "utf8");
+	run("npm", ["install", tarball, `@opencode/plugin@${pinnedVersion}`], { cwd: installDir });
+
+	const installedFixture = join(
+		installDir,
+		"node_modules",
+		"@codemem",
+		"opencode-plugin",
+		"src",
+		"opencode-v2-contract-fixture.ts",
+	);
+	assert(existsSync(installedFixture), "Packed plugin is missing the OpenCode 2 contract fixture");
+
+	const projectDir = installDir;
+	const homeDir = join(tempDir, "home");
+	mkdirSync(homeDir, { recursive: true });
+	const provider = await startProvider(projectDir);
+	providerServer = provider.server;
+	writeFileSync(
+		join(projectDir, "opencode.json"),
+		JSON.stringify({
+			model: { providerID: "contract", model: "contract-model" },
+			plugins: [
+				{
+					package: packedFixtureTarget,
+					options: { contract: true },
+				},
+			],
+			providers: {
+				contract: {
+					package: "@opencode/ai/providers/openai-compatible",
+					settings: {
+						apiKey: "contract-token",
+						baseURL: provider.baseURL,
+						provider: "contract",
+					},
+					models: {
+						"contract-model": {
+							modelID: "contract-model",
+							limit: { context: 200000, output: 8192 },
+						},
+					},
+				},
+			},
+		}),
+		"utf8",
+	);
+
+	const reportPath = join(tempDir, "contract-report.jsonl");
+	const opencode2 = resolve(
+		workspaceRoot,
+		"packages/opencode-plugin/node_modules/@opencode/cli/bin/opencode2.exe",
+	);
+	assert(existsSync(opencode2), "Pinned @opencode/cli did not install the opencode2 binary");
+	const version = run(opencode2, ["--version"], { cwd: projectDir }).stdout.trim();
+	assert(
+		version === `opencode2 v${pinnedVersion}`,
+		`Pinned host reported ${JSON.stringify(version)}, expected opencode2 v${pinnedVersion}`,
+	);
+	const env = {
+		PATH: process.env.PATH ?? "",
+		HOME: homeDir,
+		XDG_CONFIG_HOME: join(homeDir, ".config"),
+		CODEMEM_OPENCODE_V2_CONTRACT_REPORT: reportPath,
+		OPENCODE_DISABLE_AUTOUPDATE: "true",
+		OPENCODE_DISABLE_MODELS_FETCH: "true",
+		OPENCODE_SERVER_PASSWORD: randomBytes(32).toString("base64url"),
+	};
+	for (const name of ["TMPDIR", "LANG", "LC_ALL", "SYSTEMROOT", "COMSPEC", "PATHEXT"]) {
+		if (process.env[name]) env[name] = process.env[name];
+	}
+	const repositoryDir = join(installDir, "repository");
+	const worktreeDir = join(installDir, "worktree");
+	const worktreeActiveDirectory = join(worktreeDir, "nested");
+	mkdirSync(repositoryDir, { recursive: true });
+	const gitEnv = {
+		...process.env,
+		GIT_CONFIG_GLOBAL: process.platform === "win32" ? "NUL" : "/dev/null",
+		GIT_CONFIG_NOSYSTEM: "1",
+	};
+	delete gitEnv.GIT_DIR;
+	delete gitEnv.GIT_WORK_TREE;
+	run("git", ["init", "--initial-branch=main"], { cwd: repositoryDir, env: gitEnv });
+	run("git", ["config", "user.email", "contract@example.invalid"], {
+		cwd: repositoryDir,
+		env: gitEnv,
+	});
+	run("git", ["config", "user.name", "Codemem Contract"], {
+		cwd: repositoryDir,
+		env: gitEnv,
+	});
+	writeFileSync(join(repositoryDir, "package.json"), JSON.stringify({ private: true }), "utf8");
+	writeFileSync(
+		join(repositoryDir, "opencode.json"),
+		JSON.stringify({
+			plugins: [
+				{
+					package: "../node_modules/@codemem/opencode-plugin/v2-contract-fixture",
+					options: { contract: true },
+				},
+			],
+		}),
+		"utf8",
+	);
+	run("git", ["add", "package.json", "opencode.json"], { cwd: repositoryDir, env: gitEnv });
+	run("git", ["commit", "-m", "contract fixture"], { cwd: repositoryDir, env: gitEnv });
+	run("git", ["worktree", "add", "-b", "contract-worktree", worktreeDir], {
+		cwd: repositoryDir,
+		env: gitEnv,
+	});
+	mkdirSync(worktreeActiveDirectory, { recursive: true });
+	const worktreeResult = run(
+		opencode2,
+		[
+			"api",
+			"--standalone",
+			"POST",
+			"/api/plugin/await-activation",
+			"--param",
+			`location=${worktreeActiveDirectory}`,
+			"--print-logs",
+		],
+		{ cwd: worktreeActiveDirectory, env },
+	);
+	const worktreeRecords = readContractRecords(reportPath, worktreeResult);
+	assert(
+		worktreeRecords.some(
+			(record) =>
+				record.phase === "setup" &&
+				isExpectedProjectPath(record.directory, worktreeActiveDirectory) &&
+				isExpectedProjectPath(record.projectDirectory, worktreeDir) &&
+				isExpectedProjectPath(record.projectCanonical, repositoryDir),
+		),
+		"Pinned host collapsed or swapped the active, worktree, and canonical project paths",
+	);
+	writeFileSync(reportPath, "", "utf8");
+	const configResult = run(opencode2, [
+		"api",
+		"--standalone",
+		"GET",
+		"/api/config",
+		"--param",
+		`location=${projectDir}`,
+		"--print-logs",
+	], {
+		cwd: projectDir,
+		env,
+	});
+	assert(
+		configResult.stdout.includes(packedFixtureTarget),
+		"Pinned host did not report the configured project plugin target",
+	);
+	const hostResult = run(opencode2, [
+		"api",
+		"--standalone",
+		"POST",
+		"/api/plugin/await-activation",
+		"--param",
+		`location=${projectDir}`,
+		"--print-logs",
+	], {
+		cwd: projectDir,
+		env,
+	});
+	const sessionResult = run(
+		opencode2,
+		[
+			"api",
+			"--standalone",
+			"POST",
+			"/api/session",
+			"--param",
+			`location=${projectDir}`,
+			"--data",
+			JSON.stringify({
+				agent: "build",
+				model: { providerID: "contract", id: "contract-model" },
+				location: { directory: projectDir },
+			}),
+		],
+		{ cwd: projectDir, env },
+	);
+	const sessionResponse = JSON.parse(sessionResult.stdout);
+	const sessionID = sessionResponse.id ?? sessionResponse.data?.id;
+	assert(typeof sessionID === "string", "Pinned host did not create a contract session");
+	writeFileSync(reportPath, "", "utf8");
+	const host = await startHost(opencode2, projectDir, env);
+	await promptHost(opencode2, host, sessionID, "contract success probe", {
+		cwd: projectDir,
+		env,
+	});
+	await promptHost(opencode2, host, sessionID, "contract failure probe", {
+		cwd: projectDir,
+		env,
+	});
+	const expectedEventTypes = [
+		"session.inbox.delivered",
+		"session.tool.success",
+		"session.tool.failed",
+		"session.text.ended",
+	];
+	const eventDeadline = Date.now() + 10_000;
+	let deliveredEventTypes = new Set();
+	while (Date.now() < eventDeadline) {
+		let currentRecords;
+		try {
+			currentRecords = readContractRecords(reportPath, {
+				stdout: host.output(),
+				stderr: "",
+			});
+		} catch (error) {
+			if (!(error instanceof SyntaxError)) throw error;
+			await new Promise((resolvePromise) => setTimeout(resolvePromise, 50));
+			continue;
+		}
+		deliveredEventTypes = new Set(
+			currentRecords.filter((record) => record.phase === "event").map((record) => record.type),
+		);
+		if (expectedEventTypes.every((eventType) => deliveredEventTypes.has(eventType))) break;
+		await new Promise((resolvePromise) => setTimeout(resolvePromise, 50));
+	}
+	assert(
+		expectedEventTypes.every((eventType) => deliveredEventTypes.has(eventType)),
+		`Pinned host did not deliver expected events before shutdown; observed ${JSON.stringify([...deliveredEventTypes])}`,
+	);
+	await stopHost(hostProcess);
+	hostProcess = undefined;
+
+	const records = readContractRecords(reportPath, { stdout: host.output(), stderr: "" });
+	const observedHooks = records
+		.filter((record) => typeof record.phase === "string")
+		.map((record) => `${record.phase}:${record.kind ?? "none"}`)
+		.join(", ");
+	assert(
+		records.some(
+			(record) =>
+				record.phase === "setup" &&
+				isExpectedProjectPath(record.directory, projectDir) &&
+				isExpectedProjectPath(record.projectDirectory, projectDir) &&
+				isExpectedProjectPath(record.projectCanonical, projectDir) &&
+				JSON.stringify(record.optionKeys) === JSON.stringify(["contract"]),
+		),
+		"Persistent host setup omitted the expected location or plugin options",
+	);
+	assert(
+		records.some(
+			(record) => record.phase === "storage" && record.valueMatches && record.removed,
+		),
+		"Persistent host storage did not preserve the exact value or remove the probe",
+	);
+	assert(
+		records.some((record) => record.phase === "event.end" && record.aborted === true),
+		"Host event subscription did not end cleanly after abort",
+	);
+	assert(
+		records.some(
+			(record) =>
+				record.phase === "tool.transform" &&
+				record.declaredName === "mem-status" &&
+				record.effectiveID === null,
+		),
+		"Host unexpectedly exposed an effective ID while adding the hyphenated tool name",
+	);
+	assert(
+		records.some(
+			(record) =>
+				record.phase === "context" &&
+				record.generationMutable &&
+				record.hasAgent &&
+				record.messagesMutable &&
+				record.hasModel &&
+				record.hasSessionID &&
+				record.systemMutable &&
+				record.toolsMutable &&
+				record.hasKind === false &&
+				record.hasMessageID === false &&
+				record.sessionID === sessionID &&
+				typeof record.agent === "string" &&
+				record.agent.length > 0 &&
+				typeof record.model === "object" &&
+				record.model != null,
+		),
+		"Pinned host context hook did not expose the expected mutable fields or identity limits",
+	);
+	assert(
+		records.some(
+			(record) =>
+				record.phase === "prompt" &&
+				record.sessionID === sessionID &&
+				typeof record.messageID === "string" &&
+				record.messageID.length > 0,
+		),
+		`Pinned host did not dispatch the prompt hook with session and message identity; observed ${observedHooks}`,
+	);
+	assert(
+		records.some((record) => record.phase === "model.request" && record.kind === "primary"),
+		`Pinned host did not dispatch the primary model-request hook; observed ${observedHooks}`,
+	);
+	assert(
+		records.some(
+			(record) =>
+				record.phase === "http.request" &&
+				record.kind === "primary" &&
+				record.kindHeader === "primary",
+		),
+		"Pinned host did not preserve the primary kind header on the HTTP request",
+	);
+	assert(
+		records.some(
+			(record) =>
+				record.phase === "http.response" &&
+				record.kind === "primary" &&
+				record.kindHeader === "primary",
+		),
+		"Pinned host did not preserve the primary kind header on the HTTP response",
+	);
+	assert(
+		records.some(
+			(record) =>
+				record.phase === "retry" &&
+				record.retry === true &&
+				Number.isInteger(record.attempt) &&
+				record.attempt >= 0 &&
+				record.hasKind === false &&
+				record.hasRequestID === false,
+		),
+		`Pinned host did not dispatch an accepted retry; observed ${observedHooks}`,
+	);
+	for (const status of ["completed", "error"]) {
+		assert(
+			records.some(
+				(record) =>
+					record.phase === "tool.execute.after" &&
+					record.status === status &&
+					record.hasAgent &&
+					record.hasCallID &&
+					record.hasInput &&
+					record.hasMessageID &&
+					record.hasSessionID &&
+					record.hasTool,
+			),
+			`Pinned host did not dispatch the ${status} tool hook with full identity; provider observed ${JSON.stringify(provider.observations())}; tool records ${JSON.stringify(records.filter((record) => record.phase === "tool.execute.after"))}`,
+		);
+	}
+	assert(
+		provider.primaryAttempts() >= 2,
+		`Local provider received ${provider.primaryAttempts()} primary requests across ${provider.attempts()} requests`,
+	);
+	assert(records.some((record) => record.phase === "cleanup"), "Host omitted plugin cleanup on unload");
+} finally {
+	if (hostProcess) {
+		try {
+			await stopHost(hostProcess);
+		} catch {
+			process.stderr.write("Warning: unable to stop the pinned OpenCode 2 host\n");
+		}
+	}
+	if (providerServer) {
+		try {
+			await closeServer(providerServer);
+		} catch {
+			process.stderr.write("Warning: unable to stop the OpenCode 2 contract provider\n");
+		}
+	}
+	try {
+		rmSync(tempDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+	} catch {
+		process.stderr.write("Warning: unable to remove the OpenCode 2 smoke-test directory\n");
+	}
+}

--- a/packages/opencode-plugin/src/opencode-v2-contract-fixture.test.ts
+++ b/packages/opencode-plugin/src/opencode-v2-contract-fixture.test.ts
@@ -30,9 +30,7 @@ function makeEvents(
 			const finishAbort = () => {
 				aborted.value = true;
 				if (fixtureOptions.abortWithError) {
-					const error = new Error("event stream aborted");
-					error.name = "AbortError";
-					reject(error);
+					reject(new DOMException("event stream aborted", "AbortError"));
 					return;
 				}
 				resolve();
@@ -265,13 +263,25 @@ describe("OpenCode 2 executable fixture", () => {
 					hasToast: false,
 				}),
 				expect.objectContaining({ phase: "storage", removed: true, valueMatches: true }),
-				expect.objectContaining({ phase: "prompt", hasMessageID: true, hasSessionID: true }),
+				expect.objectContaining({
+					phase: "prompt",
+					hasMessageID: true,
+					hasSessionID: true,
+					messageID: "message-a",
+					sessionID: "session-a",
+				}),
 				expect.objectContaining({
 					phase: "context",
+					agent: "agent-a",
 					generationMutable: true,
+					hasAgent: true,
 					hasKind: false,
 					hasMessageID: false,
+					hasModel: true,
+					hasSessionID: true,
 					messagesMutable: true,
+					model: { providerID: "provider", modelID: "model" },
+					sessionID: "session-a",
 					systemMutable: true,
 					toolsMutable: true,
 				}),
@@ -348,22 +358,6 @@ describe("OpenCode 2 executable fixture", () => {
 		expect(fixture.disposals.every((dispose) => dispose.mock.calls.length === 1)).toBe(true);
 	});
 
-	it("reports event-stream completion when cancellation throws AbortError", async () => {
-		// Arrange
-		const records: ContractRecord[] = [];
-		const fixture = makeContext({ abortWithError: true });
-		const plugin = defineOpenCodeV2ContractFixture((record) => {
-			records.push(record);
-		});
-		const cleanup = await plugin.setup(fixture.context);
-
-		// Act
-		await runCleanup(cleanup);
-
-		// Assert
-		expect(records).toContainEqual(expect.objectContaining({ phase: "event.end", aborted: true }));
-	});
-
 	it("records event families without prompt or tool-result content", () => {
 		// Arrange
 		const events = [
@@ -384,6 +378,24 @@ describe("OpenCode 2 executable fixture", () => {
 			"tool",
 		]);
 		expect(JSON.stringify(summaries)).not.toContain("private");
+	});
+});
+
+describe("OpenCode 2 event stream cancellation", () => {
+	it("reports completion when cancellation throws AbortError", async () => {
+		// Arrange
+		const records: ContractRecord[] = [];
+		const fixture = makeContext({ abortWithError: true });
+		const plugin = defineOpenCodeV2ContractFixture((record) => {
+			records.push(record);
+		});
+		const cleanup = await plugin.setup(fixture.context);
+
+		// Act
+		await runCleanup(cleanup);
+
+		// Assert
+		expect(records).toContainEqual(expect.objectContaining({ phase: "event.end", aborted: true }));
 	});
 });
 

--- a/packages/opencode-plugin/src/opencode-v2-contract-fixture.ts
+++ b/packages/opencode-plugin/src/opencode-v2-contract-fixture.ts
@@ -87,11 +87,16 @@ async function registerContextHook(context: Plugin.Context, report: ContractRepo
 		input.providerOptions = { ...input.providerOptions, codememContract: true };
 		await report({
 			phase: "context",
+			agent: input.agent,
 			generationMutable: typeof input.generation === "object",
+			hasAgent: Boolean(input.agent),
 			hasKind: "kind" in input,
 			hasMessageID: "messageID" in input,
+			hasModel: Boolean(input.model),
 			hasSessionID: Boolean(input.sessionID),
 			messagesMutable: Array.isArray(input.messages),
+			model: input.model,
+			sessionID: input.sessionID,
 			systemMutable: Array.isArray(input.system),
 			toolsMutable: typeof input.tools === "object",
 		});
@@ -109,6 +114,8 @@ async function registerSessionHooks(
 				phase: "prompt",
 				hasMessageID: Boolean(input.messageID),
 				hasSessionID: Boolean(input.sessionID),
+				messageID: input.messageID,
+				sessionID: input.sessionID,
 			});
 		}),
 	);


### PR DESCRIPTION
## Description

Runs the packaged V2 contract fixture through an authenticated pinned-host server and deterministic local provider. The smoke proves real context, primary model-request, HTTP request/response, accepted retry, activation, and cleanup behavior; CI and versioning documentation record the verified contract and the automatic-recall correlation gate.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [x] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected — packed V1 artifact and pinned V2 host smoke tests pass

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced