### PR TITLE
test(opencode): define v2 contract fixture

### DIFF
--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -11,6 +11,8 @@
 	},
 	"files": [
 		"index.js",
+		"src/opencode-v2-contract-fixture.ts",
+		"v2-contract-fixture/",
 		"README.md",
 		"LICENSE",
 		".opencode/package.json",

--- a/packages/opencode-plugin/src/opencode-v2-contract-fixture.test.ts
+++ b/packages/opencode-plugin/src/opencode-v2-contract-fixture.test.ts
@@ -1,0 +1,465 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { Plugin } from "@opencode/plugin";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import {
+	type ContractRecord,
+	defineOpenCodeV2ContractFixture,
+	hasUnambiguousRequestIdentity,
+	OPEN_CODE_V2_CONTRACT_VERSION,
+	summarizeEvent,
+} from "./opencode-v2-contract-fixture.js";
+
+const repositoryRoot = path.resolve(import.meta.dirname, "../../..");
+
+type HookCallback = (input: never) => Promise<void> | void;
+
+function makeRegistration(dispose = vi.fn(async () => undefined)) {
+	return { dispose };
+}
+
+function makeEvents(
+	events: readonly unknown[],
+	aborted: { value: boolean },
+	fixtureOptions: { abortWithError?: boolean; eventError?: Error },
+) {
+	return async function* subscribe(subscriberOptions?: { signal?: AbortSignal }) {
+		for (const event of events) yield event as never;
+		if (fixtureOptions.eventError) throw fixtureOptions.eventError;
+		await new Promise<void>((resolve, reject) => {
+			const finishAbort = () => {
+				aborted.value = true;
+				if (fixtureOptions.abortWithError) {
+					const error = new Error("event stream aborted");
+					error.name = "AbortError";
+					reject(error);
+					return;
+				}
+				resolve();
+			};
+			if (subscriberOptions?.signal?.aborted) {
+				finishAbort();
+				return;
+			}
+			subscriberOptions?.signal?.addEventListener("abort", finishAbort, { once: true });
+		});
+	};
+}
+
+function makeContext(
+	options: { abortWithError?: boolean; eventError?: Error; failToolHook?: boolean } = {},
+) {
+	const sessionHooks = new Map<string, HookCallback>();
+	const toolHooks = new Map<string, HookCallback>();
+	const disposals: Array<ReturnType<typeof vi.fn>> = [];
+	const aborted = { value: false };
+	const storage = new Map<string, unknown>();
+	const effectiveTools: Array<{ id: string; name: string }> = [];
+	const register = async (
+		hooks: Map<string, HookCallback>,
+		name: string,
+		callback: HookCallback,
+	) => {
+		if (options.failToolHook && name === "execute.after") throw new Error("hook unavailable");
+		hooks.set(name, callback);
+		const dispose = vi.fn(async () => undefined);
+		disposals.push(dispose);
+		return makeRegistration(dispose);
+	};
+	const context = {
+		app: { name: "opencode", version: OPEN_CODE_V2_CONTRACT_VERSION, channel: "beta" },
+		location: {
+			directory: "/fixture/project-worktree",
+			workspaceID: "workspace-fixture",
+			project: {
+				id: "project-fixture",
+				directory: "/fixture/project",
+				canonical: "/fixture/project",
+			},
+		},
+		options: { contract: true },
+		event: {
+			subscribe: makeEvents(
+				[
+					{ type: "server.connected" },
+					{ type: "session.created", properties: { id: "redacted" } },
+					{ type: "message.updated", properties: { content: "must-not-be-recorded" } },
+					{ type: "tool.updated", properties: { result: "must-not-be-recorded" } },
+				],
+				aborted,
+				options,
+			),
+		},
+		session: {
+			hook: (name: string, callback: HookCallback) => register(sessionHooks, name, callback),
+		},
+		tool: {
+			hook: (name: string, callback: HookCallback) => register(toolHooks, name, callback),
+			transform: async (callback: (editor: unknown) => void) => {
+				callback({
+					add: (tool: { name: string }) => {
+						effectiveTools.push({ id: "not-exposed-during-transform", name: tool.name });
+					},
+					list: () => [],
+				});
+				const dispose = vi.fn(async () => undefined);
+				disposals.push(dispose);
+				return makeRegistration(dispose);
+			},
+		},
+		storage: {
+			get: async (key: string) => storage.get(key),
+			set: async (key: string, value: unknown) => {
+				storage.set(key, value);
+			},
+			remove: async (key: string) => {
+				storage.delete(key);
+			},
+		},
+	} as unknown as Plugin.Context;
+	return { aborted, context, disposals, effectiveTools, sessionHooks, storage, toolHooks };
+}
+
+async function invoke(hooks: Map<string, HookCallback>, name: string, input: unknown) {
+	const callback = hooks.get(name);
+	expect(callback, `missing ${name} callback`).toBeTypeOf("function");
+	await callback?.(input as never);
+}
+
+async function runCleanup(cleanup: Awaited<ReturnType<Plugin.Plugin["setup"]>>) {
+	expect(cleanup).toBeTypeOf("function");
+	if (cleanup) await cleanup();
+}
+
+describe("pinned OpenCode 2 package contract", () => {
+	it("keeps the CLI and plugin API on the exact matching beta", async () => {
+		// Arrange
+		const manifest = JSON.parse(
+			await readFile(path.join(repositoryRoot, "packages/opencode-plugin/package.json"), "utf8"),
+		);
+
+		// Act
+		const versions = [
+			manifest.devDependencies["@opencode/cli"],
+			manifest.devDependencies["@opencode/plugin"],
+		];
+
+		// Assert
+		expect(versions).toEqual([OPEN_CODE_V2_CONTRACT_VERSION, OPEN_CODE_V2_CONTRACT_VERSION]);
+	});
+
+	it("rejects a moving beta range", () => {
+		// Arrange
+		const invalidPins = ["beta", "^0.0.0-beta-19296"];
+
+		// Act
+		const exact = invalidPins.filter((version) => version === OPEN_CODE_V2_CONTRACT_VERSION);
+
+		// Assert
+		expect(exact).toEqual([]);
+	});
+
+	it("types the public context without undocumented diagnostics or request identity", () => {
+		// Arrange
+		type Context = Plugin.Context;
+
+		// Act
+		type ContextKeys = keyof Context;
+		type AppKeys = keyof Context["app"];
+
+		// Assert
+		expectTypeOf<"location">().toExtend<ContextKeys>();
+		expectTypeOf<"storage">().toExtend<ContextKeys>();
+		expectTypeOf<"log">().not.toExtend<AppKeys>();
+		expectTypeOf<"toast">().not.toExtend<ContextKeys>();
+		expectTypeOf<Context["tool"]["reload"]>().toBeFunction();
+		expectTypeOf<Context["vcs"]["reload"]>().toBeFunction();
+		expectTypeOf<Context["worktree"]["reload"]>().toBeFunction();
+	});
+});
+
+async function executeLifecycleContract() {
+	const records: ContractRecord[] = [];
+	const fixture = makeContext();
+	const plugin = defineOpenCodeV2ContractFixture((record) => {
+		records.push(record);
+	});
+	const contextInput = {
+		sessionID: "session-a",
+		agent: "agent-a",
+		model: { providerID: "provider", modelID: "model" },
+		system: [],
+		messages: [],
+		tools: {},
+		generation: {},
+		providerOptions: {} as Record<string, unknown>,
+	};
+	const cleanup = await plugin.setup(fixture.context);
+	await invoke(fixture.sessionHooks, "prompt", {
+		sessionID: "session-a",
+		messageID: "message-a",
+	});
+	await invoke(fixture.sessionHooks, "context", contextInput);
+	const requestHeaders: Record<string, string> = {};
+	await invoke(fixture.sessionHooks, "model.request", {
+		sessionID: "session-a",
+		agent: "agent-a",
+		model: { providerID: "provider", modelID: "model" },
+		kind: "compaction",
+		headers: requestHeaders,
+	});
+	const request = new Request("https://example.invalid", { headers: requestHeaders });
+	await invoke(fixture.sessionHooks, "http.request", {
+		sessionID: "session-a",
+		agent: "agent-a",
+		model: { providerID: "provider", modelID: "model" },
+		kind: "compaction",
+		request,
+	});
+	await invoke(fixture.sessionHooks, "http.response", {
+		sessionID: "session-a",
+		agent: "agent-a",
+		model: { providerID: "provider", modelID: "model" },
+		kind: "compaction",
+		request,
+		response: new Response(),
+	});
+	await invoke(fixture.sessionHooks, "retry", {
+		sessionID: "session-a",
+		agent: "agent-a",
+		model: { providerID: "provider", modelID: "model" },
+		attempt: 2,
+		decision: { retry: false },
+	});
+	await invoke(fixture.toolHooks, "execute.after", {
+		status: "completed",
+		id: "call-a",
+		messageID: "message-a",
+		sessionID: "session-a",
+		agent: "agent-a",
+		tool: "mem-status",
+		input: {},
+		result: { content: "contract-ok" },
+	});
+	await runCleanup(cleanup);
+	return { contextInput, fixture, records };
+}
+
+describe("OpenCode 2 executable fixture", () => {
+	it("observes location, options, storage, events, hooks, tools, and deterministic cleanup", async () => {
+		// Arrange
+		const expectedEventFamilies = ["generic", "session", "message", "tool"];
+
+		// Act
+		const { contextInput, fixture, records } = await executeLifecycleContract();
+
+		// Assert
+		expect(records).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					phase: "setup",
+					directory: "/fixture/project-worktree",
+					projectCanonical: "/fixture/project",
+					optionKeys: ["contract"],
+					hasLog: false,
+					hasToast: false,
+				}),
+				expect.objectContaining({ phase: "storage", removed: true, valueMatches: true }),
+				expect.objectContaining({ phase: "prompt", hasMessageID: true, hasSessionID: true }),
+				expect.objectContaining({
+					phase: "context",
+					generationMutable: true,
+					hasKind: false,
+					hasMessageID: false,
+					messagesMutable: true,
+					systemMutable: true,
+					toolsMutable: true,
+				}),
+				expect.objectContaining({ phase: "model.request", kind: "compaction" }),
+				expect.objectContaining({
+					phase: "http.request",
+					kind: "compaction",
+					kindHeader: "compaction",
+				}),
+				expect.objectContaining({
+					phase: "http.response",
+					kind: "compaction",
+					kindHeader: "compaction",
+				}),
+				expect.objectContaining({
+					phase: "retry",
+					attempt: 2,
+					retry: false,
+					hasKind: false,
+					hasRequestID: false,
+				}),
+				expect.objectContaining({
+					phase: "tool.execute.after",
+					status: "completed",
+					hasAgent: true,
+					hasCallID: true,
+					hasInput: true,
+					hasMessageID: true,
+					hasSessionID: true,
+					hasTool: true,
+				}),
+				expect.objectContaining({
+					phase: "tool.transform",
+					declaredName: "mem-status",
+					effectiveID: null,
+				}),
+				expect.objectContaining({ phase: "event.end", aborted: true }),
+				expect.objectContaining({ phase: "cleanup", disposed: 8 }),
+			]),
+		);
+		expect(fixture.storage.size).toBe(0);
+		expect(contextInput.providerOptions.codememContract).toBe(true);
+		expect(fixture.aborted.value).toBe(true);
+		expect(fixture.disposals.every((dispose) => dispose.mock.calls.length === 1)).toBe(true);
+		const eventRecords = records.filter((record) => record.phase === "event");
+		expect(eventRecords.map((record) => record.family)).toEqual(expectedEventFamilies);
+		expect(JSON.stringify(eventRecords)).not.toContain("must-not-be-recorded");
+	});
+
+	it("disposes completed registrations when setup fails", async () => {
+		// Arrange
+		const fixture = makeContext({ failToolHook: true });
+		const plugin = defineOpenCodeV2ContractFixture();
+
+		// Act
+		const setup = plugin.setup(fixture.context);
+
+		// Assert
+		await expect(setup).rejects.toThrow("hook unavailable");
+		expect(fixture.disposals).toHaveLength(6);
+		expect(fixture.disposals.every((dispose) => dispose.mock.calls.length === 1)).toBe(true);
+	});
+
+	it("defers event-stream failures to cleanup without skipping disposal", async () => {
+		// Arrange
+		const fixture = makeContext({ eventError: new Error("event stream failed") });
+		const plugin = defineOpenCodeV2ContractFixture();
+
+		// Act
+		const cleanup = await plugin.setup(fixture.context);
+
+		// Assert
+		await expect(runCleanup(cleanup)).rejects.toThrow("event stream failed");
+		expect(fixture.disposals.every((dispose) => dispose.mock.calls.length === 1)).toBe(true);
+	});
+
+	it("reports event-stream completion when cancellation throws AbortError", async () => {
+		// Arrange
+		const records: ContractRecord[] = [];
+		const fixture = makeContext({ abortWithError: true });
+		const plugin = defineOpenCodeV2ContractFixture((record) => {
+			records.push(record);
+		});
+		const cleanup = await plugin.setup(fixture.context);
+
+		// Act
+		await runCleanup(cleanup);
+
+		// Assert
+		expect(records).toContainEqual(expect.objectContaining({ phase: "event.end", aborted: true }));
+	});
+
+	it("records event families without prompt or tool-result content", () => {
+		// Arrange
+		const events = [
+			{ type: "server.connected" },
+			{ type: "session.created", properties: { title: "private" } },
+			{ type: "message.updated", properties: { content: "private" } },
+			{ type: "tool.updated", properties: { result: "private" } },
+		];
+
+		// Act
+		const summaries = events.map(summarizeEvent);
+
+		// Assert
+		expect(summaries.map((summary) => summary.family)).toEqual([
+			"generic",
+			"session",
+			"message",
+			"tool",
+		]);
+		expect(JSON.stringify(summaries)).not.toContain("private");
+	});
+});
+
+describe("OpenCode 2 request and tool contracts", () => {
+	it("distinguishes requests whose public session identities do not overlap", () => {
+		// Arrange
+		const kinds = ["primary", "compaction", "title", "generate"] as const;
+		const requests = kinds.map((kind) => ({
+			sessionID: `session-${kind}`,
+			agent: "agent",
+			model: "model",
+		}));
+
+		// Act
+		const safe = hasUnambiguousRequestIdentity(requests);
+
+		// Assert
+		expect(safe).toBe(true);
+	});
+
+	it("cannot distinguish request kinds that share one public session identity", () => {
+		// Arrange
+		const identity = { sessionID: "session-a", agent: "agent-a", model: "model-a" };
+		const requests = [
+			{ ...identity, kind: "primary" },
+			{ ...identity, kind: "compaction" },
+			{ ...identity, kind: "title" },
+			{ ...identity, kind: "generate" },
+		];
+
+		// Act
+		const safe = hasUnambiguousRequestIdentity(requests);
+
+		// Assert
+		expect(safe).toBe(false);
+	});
+
+	it("rejects correlation for concurrent or retried requests sharing the public identity", () => {
+		// Arrange
+		const identity = { sessionID: "session-a", agent: "agent-a", model: "model-a" };
+		const overlapping = [identity, identity];
+
+		// Act
+		const safe = hasUnambiguousRequestIdentity(overlapping);
+
+		// Assert
+		expect(safe).toBe(false);
+	});
+
+	it("reports both completed and failed tool variants", async () => {
+		// Arrange
+		const records: ContractRecord[] = [];
+		const fixture = makeContext();
+		const plugin = defineOpenCodeV2ContractFixture((record) => {
+			records.push(record);
+		});
+		const cleanup = await plugin.setup(fixture.context);
+
+		// Act
+		await invoke(fixture.toolHooks, "execute.after", {
+			status: "completed",
+			id: "call-success",
+			messageID: "message-success",
+		});
+		await invoke(fixture.toolHooks, "execute.after", {
+			status: "error",
+			id: "call-failure",
+			messageID: "message-failure",
+		});
+		await runCleanup(cleanup);
+
+		// Assert
+		expect(
+			records
+				.filter((record) => record.phase === "tool.execute.after")
+				.map((record) => record.status),
+		).toEqual(["completed", "error"]);
+	});
+});

--- a/packages/opencode-plugin/src/opencode-v2-contract-fixture.ts
+++ b/packages/opencode-plugin/src/opencode-v2-contract-fixture.ts
@@ -1,0 +1,246 @@
+import { appendFile } from "node:fs/promises";
+import { Plugin } from "@opencode/plugin";
+
+export const OPEN_CODE_V2_CONTRACT_VERSION = "0.0.0-beta-19296";
+
+export type ContractRecord = Readonly<Record<string, unknown>>;
+export type ContractReporter = (record: ContractRecord) => Promise<void> | void;
+
+type Disposable = { readonly dispose: () => Promise<void> };
+
+function identity(input: {
+	readonly sessionID: unknown;
+	readonly agent: unknown;
+	readonly model: unknown;
+}) {
+	return JSON.stringify([input.sessionID, input.agent, input.model]);
+}
+
+export function hasUnambiguousRequestIdentity(
+	requests: ReadonlyArray<{
+		readonly sessionID: unknown;
+		readonly agent: unknown;
+		readonly model: unknown;
+	}>,
+) {
+	const identities = requests.map(identity);
+	return new Set(identities).size === identities.length;
+}
+
+export function summarizeEvent(event: unknown): ContractRecord {
+	if (event == null || typeof event !== "object") return { family: "generic", type: "unknown" };
+	const candidate = event as Record<string, unknown>;
+	const type = typeof candidate.type === "string" ? candidate.type : "unknown";
+	const family = ["session", "message", "tool"].find((prefix) => type.startsWith(`${prefix}.`));
+	return {
+		family: family ?? "generic",
+		type,
+		hasProperties: candidate.properties != null,
+	};
+}
+
+function defaultReporter(record: ContractRecord) {
+	const reportPath = process.env.CODEMEM_OPENCODE_V2_CONTRACT_REPORT;
+	if (!reportPath) return;
+	return appendFile(reportPath, `${JSON.stringify(record)}\n`, "utf8");
+}
+
+async function probeStorage(context: Plugin.Context, report: ContractReporter) {
+	const key = "codemem-contract/probe";
+	const expected = { version: OPEN_CODE_V2_CONTRACT_VERSION };
+	await context.storage.set(key, expected);
+	const value = await context.storage.get(key);
+	await context.storage.remove(key);
+	const removed = await context.storage.get(key);
+	await report({
+		phase: "storage",
+		removed: removed == null,
+		valueMatches: JSON.stringify(value) === JSON.stringify(expected),
+	});
+}
+
+async function consumeEvents(
+	context: Plugin.Context,
+	signal: AbortSignal,
+	report: ContractReporter,
+) {
+	try {
+		for await (const event of context.event.subscribe({ signal })) {
+			await report({ phase: "event", ...summarizeEvent(event) });
+		}
+		await report({ phase: "event.end", aborted: signal.aborted });
+	} catch (error) {
+		if (signal.aborted && error instanceof Error && error.name === "AbortError") {
+			await report({ phase: "event.end", aborted: true });
+			return;
+		}
+		throw error;
+	}
+}
+
+async function registerContextHook(context: Plugin.Context, report: ContractReporter) {
+	return context.session.hook("context", async (input) => {
+		input.system = [...input.system];
+		input.messages = [...input.messages];
+		input.tools = { ...input.tools };
+		input.generation = { ...input.generation };
+		input.providerOptions = { ...input.providerOptions, codememContract: true };
+		await report({
+			phase: "context",
+			generationMutable: typeof input.generation === "object",
+			hasKind: "kind" in input,
+			hasMessageID: "messageID" in input,
+			hasSessionID: Boolean(input.sessionID),
+			messagesMutable: Array.isArray(input.messages),
+			systemMutable: Array.isArray(input.system),
+			toolsMutable: typeof input.tools === "object",
+		});
+	});
+}
+
+async function registerSessionHooks(
+	context: Plugin.Context,
+	report: ContractReporter,
+	registrations: Disposable[],
+) {
+	registrations.push(
+		await context.session.hook("prompt", async (input) => {
+			await report({
+				phase: "prompt",
+				hasMessageID: Boolean(input.messageID),
+				hasSessionID: Boolean(input.sessionID),
+			});
+		}),
+	);
+	registrations.push(await registerContextHook(context, report));
+	registrations.push(
+		await context.session.hook("model.request", async (input) => {
+			input.headers["x-codemem-contract-kind"] = input.kind;
+			await report({ phase: "model.request", kind: input.kind, identity: identity(input) });
+		}),
+	);
+	registrations.push(
+		await context.session.hook("http.request", async (input) => {
+			await report({
+				phase: "http.request",
+				kind: input.kind,
+				kindHeader: input.request.headers.get("x-codemem-contract-kind"),
+			});
+		}),
+	);
+	registrations.push(
+		await context.session.hook("http.response", async (input) => {
+			await report({
+				phase: "http.response",
+				kind: input.kind,
+				kindHeader: input.request.headers.get("x-codemem-contract-kind"),
+			});
+		}),
+	);
+	registrations.push(
+		await context.session.hook("retry", async (input) => {
+			await report({
+				phase: "retry",
+				attempt: input.attempt,
+				retry: input.decision.retry,
+				hasKind: "kind" in input,
+				hasRequestID: "requestID" in input,
+			});
+		}),
+	);
+}
+
+async function registerToolContracts(
+	context: Plugin.Context,
+	report: ContractReporter,
+	registrations: Disposable[],
+) {
+	const after = await context.tool.hook("execute.after", async (input) => {
+		await report({
+			phase: "tool.execute.after",
+			hasAgent: Boolean(input.agent),
+			status: input.status,
+			hasCallID: Boolean(input.id),
+			hasInput: input.input != null,
+			hasMessageID: Boolean(input.messageID),
+			hasSessionID: Boolean(input.sessionID),
+			hasTool: Boolean(input.tool),
+		});
+	});
+	registrations.push(after);
+	let effectiveID: string | null = null;
+	const declaredName = "mem-status";
+	const transform = await context.tool.transform((editor) => {
+		editor.add({
+			name: declaredName,
+			description: "OpenCode 2 contract-only tool",
+			input: { type: "object", properties: {}, additionalProperties: false },
+			execute: async () => ({ content: "contract-ok" }),
+		});
+		const added = editor.list().find((tool) => tool.name === declaredName);
+		effectiveID = added?.id ?? null;
+	});
+	registrations.push(transform);
+	await report({ phase: "tool.transform", declaredName, effectiveID });
+}
+
+async function disposeAll(registrations: readonly Disposable[]) {
+	let firstError: unknown;
+	for (const registration of [...registrations].reverse()) {
+		try {
+			await registration.dispose();
+		} catch (error) {
+			firstError ??= error;
+		}
+	}
+	if (firstError) throw firstError;
+}
+
+export function defineOpenCodeV2ContractFixture(report: ContractReporter = defaultReporter) {
+	return Plugin.define({
+		id: "codemem-v2-contract",
+		async setup(context) {
+			const abortController = new AbortController();
+			const registrations: Disposable[] = [];
+			try {
+				await report({
+					phase: "setup",
+					appVersion: context.app.version,
+					directory: context.location.directory,
+					projectDirectory: context.location.project.directory,
+					projectCanonical: context.location.project.canonical,
+					hasWorkspaceID: Boolean(context.location.workspaceID),
+					optionKeys: Object.keys(context.options).sort(),
+					hasLog: "log" in context.app,
+					hasToast: "toast" in context || "tui" in context,
+				});
+				await probeStorage(context, report);
+				await registerSessionHooks(context, report, registrations);
+				await registerToolContracts(context, report, registrations);
+				let eventError: unknown;
+				const eventTask = consumeEvents(context, abortController.signal, report).catch((error) => {
+					eventError = error;
+				});
+				return async () => {
+					abortController.abort();
+					let disposalError: unknown;
+					try {
+						await disposeAll(registrations);
+					} catch (error) {
+						disposalError = error;
+					}
+					await eventTask;
+					await report({ phase: "cleanup", disposed: registrations.length });
+					if (disposalError) throw disposalError;
+					if (eventError) throw eventError;
+				};
+			} catch (error) {
+				abortController.abort();
+				await disposeAll(registrations);
+				throw error;
+			}
+		},
+	});
+}
+
+export default defineOpenCodeV2ContractFixture();

--- a/packages/opencode-plugin/v2-contract-fixture/index.ts
+++ b/packages/opencode-plugin/v2-contract-fixture/index.ts
@@ -1,0 +1,1 @@
+export { default } from "../src/opencode-v2-contract-fixture.ts";

--- a/packages/opencode-plugin/v2-contract-fixture/package.json
+++ b/packages/opencode-plugin/v2-contract-fixture/package.json
@@ -1,0 +1,8 @@
+{
+	"private": true,
+	"type": "module",
+	"main": "./index.ts",
+	"peerDependencies": {
+		"@opencode/plugin": "0.0.0-beta-19296"
+	}
+}


### PR DESCRIPTION
## Description

Adds the typed OpenCode 2 fixture and focused tests for lifecycle, events, storage, request hooks, retry decisions, tool outcomes, tool naming, and deterministic cleanup. The fixture is included in the packed plugin so the next PR can execute it against the pinned host.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [x] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes — 26 package tests pass
- [x] Manually verified changes work as expected

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced