### PR TITLE
feat(opencode): add dual package entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![CI](https://github.com/kunickiaj/codemem/actions/workflows/ci.yml/badge.svg)](https://github.com/kunickiaj/codemem/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/kunickiaj/codemem/branch/main/graph/badge.svg)](https://codecov.io/gh/kunickiaj/codemem) [![Release](https://img.shields.io/github/v/release/kunickiaj/codemem)](https://github.com/kunickiaj/codemem/releases)
 
-Persistent memory for [OpenCode](https://opencode.ai) and [Claude Code](https://claude.ai/code). codemem captures what you work on across sessions, retrieves relevant context using hybrid search, and injects relevant context automatically in OpenCode.
+Persistent memory for [OpenCode](https://opencode.ai) and [Claude Code](https://claude.ai/code). codemem captures what you work on across sessions, retrieves relevant context using hybrid search, and injects relevant context automatically in OpenCode 1.
 
 - **Local-first** — everything lives in SQLite on your machine
 - **Hybrid retrieval** — FTS5 BM25 lexical search + sqlite-vec semantic search, merged and re-ranked
-- **Automatic injection** — the OpenCode plugin injects context into every prompt, no manual steps
+- **Automatic injection for OpenCode 1** — the plugin injects context into every prompt, no manual steps
 - **Claude Code plugin support** — install from the codemem marketplace source
 - **Built-in viewer** — browse memories, sessions, and observer output in a local web UI
 - **Peer-to-peer sync** — replicate memories across machines without a central service
@@ -28,6 +28,10 @@ codemem keeps one minimum Node.js version across published packages and workspac
 
 Codemem requires OpenCode 1.18.29 or newer.
 
+The experimental OpenCode 2 beta entrypoint currently loads as an inactive
+compatibility shell. Capture, memory building, and automatic context injection
+remain OpenCode 1 features until the OpenCode 2 adapter is enabled.
+
 1. Install the OpenCode plugin and MCP config:
 
 ```text
@@ -36,7 +40,7 @@ npx -y codemem setup --opencode-only
 
 2. Restart OpenCode.
 
-The OpenCode plugin manages backend execution automatically — no separate global install is required.
+On OpenCode 1, the plugin manages backend execution automatically — no separate global install is required.
 
 3. Verify:
 
@@ -46,7 +50,7 @@ npx -y codemem stats
 npx -y codemem db raw-events-status
 ```
 
-That's it. The plugin captures activity, builds memories, and injects context from here on.
+That's it. On OpenCode 1, the plugin captures activity, builds memories, and injects context from here on.
 
 If you want `codemem` available directly on your `PATH` for manual commands and semantic retrieval, install the CLI globally. The CLI installs its matching embedding runtime by default. The command differs by platform:
 
@@ -176,11 +180,13 @@ Codex hook ingestion shares the same raw-event pipeline as Claude and OpenCode t
 
 ## How it works
 
-Adapters hook into runtime event systems (OpenCode plugin and Claude hooks). They capture tool calls and conversation messages, flush them through an observer pipeline that produces typed memories, and surface retrieval context for future prompts.
+Adapters hook into runtime event systems (the OpenCode 1 plugin and Claude hooks). They capture tool calls and conversation messages, flush them through an observer pipeline that produces typed memories, and surface retrieval context for future prompts.
+
+> The OpenCode workflow below applies only to OpenCode 1. The OpenCode 2 entrypoint is currently an inactive compatibility shell.
 
 ```mermaid
 sequenceDiagram
-participant OC as OpenCode
+participant OC as OpenCode 1
 participant PL as codemem plugin
 participant VW as viewer HTTP
 participant ST as MemoryStore

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,7 +59,8 @@ Support tiers describe operational expectations for each adapter path:
 
 | Adapter | Tier | Notes |
 |---|---|---|
-| OpenCode plugin | Supported | Primary reference adapter for lifecycle events and injection behavior. |
+| OpenCode 1 plugin | Supported | Primary reference adapter for lifecycle events and injection behavior. |
+| OpenCode 2 plugin | Experimental | The beta entrypoint loads as an inactive compatibility shell; capture and injection are not enabled. |
 | Claude hooks/plugin | Supported | Hook-first queue path with CLI/runtime fallback and parity slices tracked in adapter stack PRs. |
 | Codex plugin (hooks + MCP) | Experimental (early beta) | Functional capture pipeline (`plugins/codex/`, `packages/core/src/codex-hooks.ts`) dogfooded end-to-end: edge normalization → `POST /api/raw-events` → observer → memories. Prompt-time injection present and env-gated but not fully validated on strict models. Not yet promoted to a stable support tier. |
 | Windsurf integration | Experimental | Planned via shared adapter contract after OpenCode/Claude stabilization. |
@@ -184,7 +185,7 @@ flowchart TD
 
 ## Context injection
 
-The plugin injects a memory pack automatically on every turn. In OpenCode, volatile recall output is appended beside the latest user message by default so provider prompt caches can keep the stable system/history prefix.
+The OpenCode 1 plugin injects a memory pack automatically on every turn. Volatile recall output is appended beside the latest user message by default so provider prompt caches can keep the stable system/history prefix. The experimental OpenCode 2 beta entrypoint is an inactive compatibility shell and does not inject context.
 
 ### Packaged Claude and Codex hooks
 
@@ -244,7 +245,7 @@ OpenCode's message surface supports an opt-in retained ceiling, off by default, 
 
 ### Injection hook
 
-The OpenCode plugin uses `experimental.chat.messages.transform` to append the current pack text to the latest user message. Earlier injected message blocks are cached by message ID and replayed byte-for-byte on later turns, preserving the stable prompt prefix for provider prompt caches while only the newest user turn receives volatile recall output. Scope revocation affects newly built packs, but historical injected blocks in the same OpenCode session are not retroactively scrubbed; start a new session after revoking access if prompt history must be clean. Set `CODEMEM_INJECT_SURFACE=system` to use the legacy `experimental.chat.system.transform` system-prompt surface. A toast notification shows injection stats on first inject per session.
+The OpenCode 1 plugin uses `experimental.chat.messages.transform` to append the current pack text to the latest user message. Earlier injected message blocks are cached by message ID and replayed byte-for-byte on later turns, preserving the stable prompt prefix for provider prompt caches while only the newest user turn receives volatile recall output. Scope revocation affects newly built packs, but historical injected blocks in the same OpenCode session are not retroactively scrubbed; start a new session after revoking access if prompt history must be clean. Set `CODEMEM_INJECT_SURFACE=system` to use the legacy `experimental.chat.system.transform` system-prompt surface. A toast notification shows injection stats on first inject per session.
 
 Before each pack build, the plugin derives stable attempt and request identities from safe request components so an exact adapter retry is idempotent. At the tool-event boundary, repository-contained absolute working-set paths are converted to repository-relative `/` paths; outside-repository, traversing, blank, and overlong paths are discarded. The same normalized set feeds pack retrieval and its ledger metadata. Before sending prompt-derived POST data, the plugin performs a payload-free, redirect-disabled handshake that verifies the Codemem viewer marker plus resolved database, identity/config, compression, and embedding targets. The viewer also verifies that its cached store identity still matches current database/config resolution before retrieval or ledger writes. Connection failures, timeouts, unavailable endpoints, unrecognized responses, server failures, unusable success responses, profile-target mismatches, and structured request errors before a compatible handshake use the compatible CLI fallback. Structured request errors become terminal only after compatibility is established. Pack assembly returns its legacy response and trace from the same retrieval pass, then the local evidence ledger stores at most 50 selected exposures and 20 diagnostics. Exposure snapshots contain bounded identity, revision, scope, score, and reason-code fields; working-set evidence is limited to normalized repository-relative paths. Attempt recording, handoff, skipped attempts, and cache reuse use the viewer ledger dispatcher on healthy paths and retain classified CLI fallback. A cache hit for the current request creates and delivers one new attempt without modifying the original, while byte-for-byte reconstruction of historical message parts creates no attempts. Ledger writes are fail-open and do not alter retrieval, rendering, or injection.
 

--- a/docs/opencode-retained-recall.md
+++ b/docs/opencode-retained-recall.md
@@ -1,5 +1,7 @@
 # OpenCode Retained Recall
 
+This contract applies to the OpenCode 1 plugin. The experimental OpenCode 2 beta entrypoint is an inactive compatibility shell and does not perform automatic recall.
+
 Automatic message recall must preserve retained bytes and derive allowance from the current transform output, not a lifetime counter.
 
 ## Lifecycle Contract

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -6,7 +6,9 @@ This page covers advanced plugin behavior, environment variables, and stream rel
 
 <img src="images/codemem-settings.png" alt="codemem observer settings" width="520" />
 
-## Running OpenCode with the plugin
+## Running OpenCode 1 with the plugin
+
+These capture and recall behaviors apply to OpenCode 1. The experimental OpenCode 2 beta entrypoint currently loads as an inactive compatibility shell.
 
 1. Start OpenCode inside this repo (or make the plugin global so it globs in everywhere).
 2. Every tooling session creates memory artifacts in SQLite.
@@ -14,7 +16,7 @@ This page covers advanced plugin behavior, environment variables, and stream rel
 4. Use `codemem stats` and `codemem recent` to confirm ingestion.
 5. Browse the viewer at the printed URL.
 
-OpenCode loads configured npm plugins and project-local `.opencode/plugins/` files as separate sources. If both resolve to Codemem for the same project, the first registration remains active and later registrations skip all hooks with a warning. Remove the configured npm entry when testing checkout-local plugin changes so the local copy initializes first.
+OpenCode 1 loads configured npm plugins and project-local `.opencode/plugins/` files as separate sources. If both resolve to Codemem for the same project, the first registration remains active and later registrations skip all hooks with a warning. Remove the configured npm entry when testing checkout-local plugin changes so the local copy initializes first.
 
 ### Repository-only lint feedback
 
@@ -43,7 +45,7 @@ bodies are not replayed to another endpoint.
 
 ### OpenCode prompt-path benchmark
 
-A 30-run synthetic-fixture benchmark measured the **OpenCode plugin path only**; it does not measure
+A 30-run synthetic-fixture benchmark measured the **OpenCode 1 plugin path only**; it does not measure
 Claude or Codex latency. The privacy-safe report contains no prompt, memory content, IDs, or paths.
 
 | Mode | Median / p95 | Prompt children |
@@ -239,7 +241,7 @@ The plugin now passes that explicit host/port through when it auto-starts, healt
 
 If compatibility toasts appear after restart, follow the runner-specific guidance in Compatibility guidance behavior below.
 
-## Plugin tools exposed to the model
+## OpenCode 1 plugin tools exposed to the model
 
 - `mem-status` - show viewer URL, log path, stats, and recent entries.
 - `mem-stats` - show just the stats block.
@@ -405,7 +407,7 @@ codemem db raw-events-retry <session_stream_id>
 
 ## Hook lifecycle and flush boundaries
 
-The plugin uses OpenCode event hooks and flushes on explicit lifecycle boundaries:
+The OpenCode 1 plugin uses event hooks and flushes on explicit lifecycle boundaries:
 
 - `tool.execute.after`: queue tool event; contributes to force-flush thresholds.
 - `session.idle`: immediate flush attempt.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -154,7 +154,7 @@ Command/file token caching notes:
 - Low-signal observations are filtered before writing.
 
 ## Automatic context injection
-- The OpenCode plugin injects a memory pack next to the latest user message by default, keeping older prompt prefixes stable for provider prompt caches.
+- The OpenCode 1 plugin injects a memory pack next to the latest user message by default, keeping older prompt prefixes stable for provider prompt caches. The experimental OpenCode 2 beta entrypoint is an inactive compatibility shell and does not inject context.
 - Controls:
   - `CODEMEM_INJECT_CONTEXT=0` disables injection.
   - `CODEMEM_INJECT_SURFACE=system` uses the legacy OpenCode system-prompt injection surface.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -101,7 +101,7 @@ change whether the current CLI satisfies the plugin's minimum supported version.
 
 ## Compatibility-floor check
 
-The OpenCode plugin performs a runtime CLI version check and warns if the local CLI is below
+The OpenCode 1 plugin performs a runtime CLI version check and warns if the local CLI is below
 `CODEMEM_MIN_VERSION` (default `0.9.20`).
 
 The compatibility reaction is controlled by `CODEMEM_BACKEND_UPDATE_POLICY`:
@@ -119,7 +119,11 @@ discovery.
 Codemem 0.45 raises the minimum supported OpenCode 1 host to 1.18.29. The
 `@codemem/opencode-plugin` package records this floor through
 `engines.opencode`, which OpenCode checks when loading npm plugins, and CI runs
-the V1 plugin suite against that exact release.
+the V1 plugin suite against that exact SDK release. The packed-artifact smoke
+also installs OpenCode 1.18.30 and requires the dual entrypoint to complete the
+host's non-pure startup path. The package default export changes from a callable
+V1 plugin function to the documented dual-host object; named V1 exports remain
+available for integrations that invoke the function directly.
 This is a breaking host-compatibility change from Codemem 0.44; upgrade OpenCode
 before installing the 0.45 plugin.
 

--- a/packages/opencode-plugin/README.md
+++ b/packages/opencode-plugin/README.md
@@ -25,10 +25,15 @@ OpenCode installs npm plugins automatically with Bun at startup.
 
 ## Exports
 
-`CodememPlugin` is the canonical named export and the package default export.
+The package default export is one dual-host object. OpenCode 1 calls its
+`server()` function, while OpenCode 2 calls its `setup()` function. The OpenCode 2
+setup is an intentionally inactive compatibility shell until the V2 adapter is
+enabled.
+
+`CodememPlugin` remains the canonical named OpenCode 1 function export.
 `OpencodeMemPlugin` remains available as a deprecated, reference-identical alias
-for compatibility with integrations created before the Codemem rename. No removal
-version is currently scheduled.
+for integrations created before the Codemem rename. No removal version is
+currently scheduled.
 
 ## Documentation
 

--- a/packages/opencode-plugin/index.d.ts
+++ b/packages/opencode-plugin/index.d.ts
@@ -1,0 +1,19 @@
+import type { Plugin as OpenCodeV1Plugin } from "@opencode-ai/plugin";
+
+export type CodememV2Setup = (
+	context: unknown,
+) => Promise<(() => Promise<void> | void) | void> | (() => Promise<void> | void) | void;
+
+export type CodememDualPlugin = {
+	readonly id: string;
+	readonly server: OpenCodeV1Plugin;
+	readonly setup: CodememV2Setup;
+};
+
+export declare const CodememPlugin: OpenCodeV1Plugin;
+
+/** @deprecated Use CodememPlugin. */
+export declare const OpencodeMemPlugin: typeof CodememPlugin;
+
+declare const plugin: CodememDualPlugin;
+export default plugin;

--- a/packages/opencode-plugin/index.js
+++ b/packages/opencode-plugin/index.js
@@ -1,5 +1,13 @@
-export {
-	CodememPlugin as default,
+import {
 	CodememPlugin,
 	OpencodeMemPlugin,
 } from "./.opencode/plugins/codemem.js";
+
+const CodememDualPlugin = {
+	id: "codemem",
+	server: CodememPlugin,
+	setup() {},
+};
+
+export default CodememDualPlugin;
+export { CodememPlugin, OpencodeMemPlugin };

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -4,13 +4,16 @@
 	"description": "CodeMem plugin for OpenCode",
 	"type": "module",
 	"main": "./index.js",
+	"types": "./index.d.ts",
 	"exports": {
 		".": {
+			"types": "./index.d.ts",
 			"import": "./index.js"
 		}
 	},
 	"files": [
 		"index.js",
+		"index.d.ts",
 		"src/opencode-v2-contract-fixture.ts",
 		"v2-contract-fixture/",
 		"README.md",

--- a/packages/opencode-plugin/scripts/packed-artifact-smoke.mjs
+++ b/packages/opencode-plugin/scripts/packed-artifact-smoke.mjs
@@ -1,7 +1,18 @@
-import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { once } from "node:events";
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 const packageRoot = process.cwd();
 const tempDir = mkdtempSync(join(tmpdir(), "codemem-opencode-plugin-packed-"));
@@ -10,15 +21,16 @@ function fail(message, result) {
 	if (result) {
 		if (result.stdout) process.stderr.write(result.stdout);
 		if (result.stderr) process.stderr.write(result.stderr);
+		if (result.error) process.stderr.write(`${result.error.stack ?? result.error.message}\n`);
 	}
 	throw new Error(message);
 }
 
-function run(command, args, cwd = packageRoot) {
+function run(command, args, cwd = packageRoot, env = process.env) {
 	const result = spawnSync(command, args, {
 		cwd,
 		encoding: "utf8",
-		env: process.env,
+		env,
 	});
 	if (result.status !== 0) fail(`Command failed: ${command} ${args.join(" ")}`, result);
 	return result;
@@ -26,6 +38,66 @@ function run(command, args, cwd = packageRoot) {
 
 function assert(condition, message) {
 	if (!condition) throw new Error(message);
+}
+
+async function stopHost(child) {
+	if (child.exitCode !== null) return;
+	const closed = once(child, "close");
+	child.kill();
+	const forceKill = setTimeout(() => child.kill("SIGKILL"), 5_000);
+	try {
+		await closed;
+	} finally {
+		clearTimeout(forceKill);
+	}
+}
+
+async function exerciseV1Host(opencode, cwd, env, activationLog) {
+	const child = spawn(opencode, ["serve", "--hostname", "127.0.0.1"], { cwd, env });
+	let output = "";
+	child.stdout.setEncoding("utf8");
+	child.stderr.setEncoding("utf8");
+	child.stdout.on("data", (chunk) => {
+		output += chunk;
+	});
+	child.stderr.on("data", (chunk) => {
+		output += chunk;
+	});
+
+	try {
+		let baseURL;
+		for (let attempt = 0; attempt < 100; attempt += 1) {
+			if (child.exitCode !== null) break;
+			baseURL = output.match(/server listening on (http:\/\/\S+)/)?.[1];
+			if (baseURL) break;
+			await new Promise((resolvePromise) => setTimeout(resolvePromise, 50));
+		}
+		if (!baseURL) return { activated: false, output };
+
+		const probePaths = [
+			"/global/health",
+			"/config",
+			"/provider",
+			"/session",
+			"/experimental/tool/ids",
+		];
+		const authorization = `Basic ${Buffer.from(`opencode:${env.OPENCODE_SERVER_PASSWORD}`).toString("base64")}`;
+		for (const path of probePaths) {
+			try {
+				await fetch(`${baseURL}${path}`, { headers: { Authorization: authorization } });
+			} catch {
+				// Continue probing until the server has initialized the plugin runtime.
+			}
+			if (existsSync(activationLog)) break;
+		}
+		const activationDeadline = Date.now() + 15_000;
+		while (!existsSync(activationLog) && Date.now() < activationDeadline) {
+			await new Promise((resolvePromise) => setTimeout(resolvePromise, 50));
+		}
+		return { activated: existsSync(activationLog), output };
+	} finally {
+		await stopHost(child);
+	}
 }
 
 try {
@@ -40,6 +112,7 @@ try {
 
 	const tarListing = run("tar", ["-tf", packedTarball]).stdout;
 	assert(tarListing.includes("package/index.js"), "Packed artifact is missing index.js");
+	assert(tarListing.includes("package/index.d.ts"), "Packed artifact is missing index.d.ts");
 	assert(
 		tarListing.includes("package/.opencode/plugins/codemem.js"),
 		"Packed artifact is missing .opencode/plugins/codemem.js",
@@ -72,6 +145,10 @@ try {
 	assert(existsSync(installedPackageRoot), "Installed artifact is missing @codemem/opencode-plugin");
 	assert(existsSync(join(installedPackageRoot, "index.js")), "Installed artifact is missing index.js");
 	assert(
+		existsSync(join(installedPackageRoot, "index.d.ts")),
+		"Installed artifact is missing index.d.ts",
+	);
+	assert(
 		existsSync(join(installedPackageRoot, ".opencode", "plugins", "codemem.js")),
 		"Installed artifact is missing .opencode/plugins/codemem.js",
 	);
@@ -90,12 +167,107 @@ try {
 
 	const packageJson = JSON.parse(readFileSync(join(installedPackageRoot, "package.json"), "utf8"));
 	assert(packageJson.name === "@codemem/opencode-plugin", "Installed package name mismatch");
+	assert(packageJson.types === "./index.d.ts", "Installed package is missing its type entrypoint");
+	run("npm", ["install", "--prefix", installDir, "--save-dev", "@types/node@24"]);
+	const typeConsumer = join(installDir, "consumer.ts");
+	writeFileSync(
+		typeConsumer,
+		'import plugin from "@codemem/opencode-plugin";\nplugin.setup({ directory: "/tmp" });\nvoid plugin.server;\n',
+	);
+	run("pnpm", [
+		"exec",
+		"tsc",
+		"--ignoreConfig",
+		"--noEmit",
+		"--strict",
+		"--module",
+		"NodeNext",
+		"--moduleResolution",
+		"NodeNext",
+		"--target",
+		"ES2022",
+		"--types",
+		"node",
+		typeConsumer,
+	]);
 
 	run(process.execPath, [
 		"--input-type=module",
 		"-e",
-		"const mod = await import('@codemem/opencode-plugin'); if (typeof mod.default !== 'function') throw new Error('default export is not a function'); if (typeof mod.CodememPlugin !== 'function') throw new Error('canonical named export is not a function'); if (mod.default !== mod.CodememPlugin) throw new Error('default export is not canonical'); if (mod.OpencodeMemPlugin !== mod.CodememPlugin) throw new Error('legacy export is not a compatibility alias');",
+		"const mod = await import('@codemem/opencode-plugin'); if (!mod.default || typeof mod.default !== 'object') throw new Error('default export is not an object'); if (mod.default.id !== 'codemem') throw new Error('default export has the wrong id'); if (typeof mod.default.server !== 'function') throw new Error('default server is not a function'); if (typeof mod.default.setup !== 'function') throw new Error('default setup is not a function'); if (typeof mod.CodememPlugin !== 'function') throw new Error('canonical named V1 export is not a function'); if (mod.default.server !== mod.CodememPlugin) throw new Error('default server is not the canonical V1 export'); if (mod.OpencodeMemPlugin !== mod.CodememPlugin) throw new Error('legacy V1 export is not a compatibility alias'); const result = await mod.default.setup({}); if (result !== undefined) throw new Error('V2 setup shell has behavior');",
 	], installDir);
+
+	const pinnedOpenCodeV1Version = "1.18.30";
+	run("npm", ["install", "--prefix", installDir, `opencode-ai@${pinnedOpenCodeV1Version}`]);
+	run(
+		process.execPath,
+		[join(installDir, "node_modules", "opencode-ai", "postinstall.mjs")],
+		join(installDir, "node_modules", "opencode-ai"),
+	);
+	const v1ConfigPath = join(installDir, "opencode.json");
+	const installedEntrypoint = pathToFileURL(join(installedPackageRoot, "index.js")).href;
+	writeFileSync(v1ConfigPath, `${JSON.stringify({ plugin: [installedEntrypoint] }, null, 2)}\n`);
+	const v1Home = join(tempDir, "v1-home");
+	const v1ActivationLog = join(tempDir, "v1-activation.log");
+	mkdirSync(v1Home, { recursive: true });
+	const opencodeV1 = join(installDir, "node_modules", ".bin", "opencode");
+	const v1Env = {
+		...process.env,
+		HOME: v1Home,
+		XDG_CONFIG_HOME: join(v1Home, ".config"),
+		CODEMEM_VIEWER: "0",
+		CODEMEM_RAW_EVENTS: "0",
+		CODEMEM_PLUGIN_LOG: v1ActivationLog,
+		CODEMEM_BACKEND_UPDATE_POLICY: "off",
+		OPENCODE_SERVER_PASSWORD: randomBytes(32).toString("base64url"),
+	};
+	const v1Version = run(opencodeV1, ["--version"], installDir, v1Env).stdout.trim();
+	assert(v1Version === pinnedOpenCodeV1Version, `Unexpected OpenCode 1 host version: ${v1Version}`);
+	const v1Host = await exerciseV1Host(opencodeV1, installDir, v1Env, v1ActivationLog);
+	assert(
+		v1Host.activated &&
+			readFileSync(v1ActivationLog, "utf8").includes("plugin initialized"),
+		`Pinned OpenCode 1 host did not invoke server() on the installed dual plugin\n${v1Host.output}`,
+	);
+
+	const brokenPluginRoot = join(tempDir, "broken-plugin");
+	cpSync(installedPackageRoot, brokenPluginRoot, { recursive: true });
+	writeFileSync(join(brokenPluginRoot, "index.js"), 'throw new Error("SABOTAGE_PLUGIN_LOAD");\n');
+	writeFileSync(
+		v1ConfigPath,
+		`${JSON.stringify({ plugin: [pathToFileURL(join(brokenPluginRoot, "index.js")).href] }, null, 2)}\n`,
+	);
+	const brokenActivationLog = join(tempDir, "broken-v1-activation.log");
+	const brokenHost = await exerciseV1Host(
+		opencodeV1,
+		installDir,
+		{ ...v1Env, CODEMEM_PLUGIN_LOG: brokenActivationLog },
+		brokenActivationLog,
+	);
+	assert(
+		!brokenHost.activated && !existsSync(brokenActivationLog),
+		"OpenCode 1 activation check did not reject a sabotaged plugin entrypoint",
+	);
+
+	const checkoutPluginUrl = pathToFileURL(join(packageRoot, ".opencode", "plugins", "codemem.js")).href;
+	const duplicateHome = join(tempDir, "duplicate-home");
+	mkdirSync(duplicateHome, { recursive: true });
+	const duplicateEnv = {
+		PATH: process.env.PATH ?? "",
+		HOME: duplicateHome,
+		XDG_CONFIG_HOME: join(duplicateHome, ".config"),
+		CODEMEM_VIEWER: "0",
+		CODEMEM_RAW_EVENTS: "0",
+	};
+	for (const name of ["TMPDIR", "LANG", "LC_ALL", "SYSTEMROOT", "COMSPEC", "PATHEXT"]) {
+		if (process.env[name]) duplicateEnv[name] = process.env[name];
+	}
+	run(process.execPath, [
+		"--input-type=module",
+		"-e",
+		"const checkoutPluginUrl = process.argv[1]; const installed = await import('@codemem/opencode-plugin'); const checkout = await import(checkoutPluginUrl); const firstLogs = []; const secondLogs = []; const context = { project: { name: 'packed-duplicate' }, directory: process.cwd(), worktree: process.cwd() }; const first = await installed.default.server({ ...context, client: { app: { log: async ({ body }) => firstLogs.push(body) }, tui: {} } }); const second = await checkout.default({ ...context, client: { app: { log: async ({ body }) => secondLogs.push(body) }, tui: {} } }); if (typeof first.event !== 'function') throw new Error('configured installed plugin did not activate'); if (Object.keys(second).length !== 0) throw new Error('checkout-local duplicate activated hooks'); if (!secondLogs.some((entry) => entry?.message === 'codemem duplicate plugin registration skipped')) throw new Error('checkout-local duplicate did not report the skip'); await first.dispose?.();",
+		checkoutPluginUrl,
+	], installDir, duplicateEnv);
 } finally {
 	rmSync(tempDir, { recursive: true, force: true });
 }

--- a/packages/opencode-plugin/scripts/packed-v2-host-smoke.mjs
+++ b/packages/opencode-plugin/scripts/packed-v2-host-smoke.mjs
@@ -18,6 +18,7 @@ import { join, resolve } from "node:path";
 const packageRoot = process.cwd();
 const workspaceRoot = resolve(packageRoot, "..", "..");
 const pinnedVersion = "0.0.0-beta-19296";
+const packedPluginTarget = "./node_modules/@codemem/opencode-plugin";
 const packedFixtureTarget = "./node_modules/@codemem/opencode-plugin/v2-contract-fixture";
 const tempDir = mkdtempSync(join(tmpdir(), "codemem-opencode-v2-contract-"));
 let providerServer;
@@ -359,6 +360,7 @@ try {
 		JSON.stringify({
 			model: { providerID: "contract", model: "contract-model" },
 			plugins: [
+				{ package: packedPluginTarget },
 				{
 					package: packedFixtureTarget,
 					options: { contract: true },
@@ -485,7 +487,11 @@ try {
 		env,
 	});
 	assert(
-		configResult.stdout.includes(packedFixtureTarget),
+		configResult.stdout.includes(JSON.stringify(packedPluginTarget)),
+		"Pinned host did not report the installed package plugin target",
+	);
+	assert(
+		configResult.stdout.includes(JSON.stringify(packedFixtureTarget)),
 		"Pinned host did not report the configured project plugin target",
 	);
 	const hostResult = run(opencode2, [
@@ -500,6 +506,24 @@ try {
 		cwd: projectDir,
 		env,
 	});
+	const hostLogLines = `${hostResult.stdout}\n${hostResult.stderr}`.split(/\r?\n/u);
+	const installedPluginPath = "node_modules/@codemem/opencode-plugin";
+	assert(
+		hostLogLines.some(
+			(line) =>
+				line.includes("loading plugin") && line.includes(`${installedPluginPath}/index.js`),
+		),
+		"Pinned host did not attempt to load the installed dual plugin",
+	);
+	assert(
+		!hostLogLines.some(
+			(line) =>
+				line.includes("failed to load plugin") &&
+				line.includes(installedPluginPath) &&
+				!line.includes("v2-contract-fixture"),
+		),
+		"Pinned host rejected the installed dual plugin",
+	);
 	const sessionResult = run(
 		opencode2,
 		[

--- a/packages/opencode-plugin/src/package-entrypoint.test.ts
+++ b/packages/opencode-plugin/src/package-entrypoint.test.ts
@@ -1,14 +1,34 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import type { Plugin as OpenCodeV2 } from "@opencode/plugin";
+import type { Plugin as OpenCodeV1Plugin } from "@opencode-ai/plugin";
 import { expect, it } from "vitest";
+import CodememDualPlugin, { CodememPlugin, OpencodeMemPlugin } from "../index.js";
 
 const repositoryRoot = path.resolve(import.meta.dirname, "../../..");
 const minimumOpenCodeVersion = "1.18.29";
+const pinnedOpenCodeV2Version = "0.0.0-beta-19296";
 
 async function readJson(relativePath: string) {
 	return JSON.parse(await readFile(path.join(repositoryRoot, relativePath), "utf8"));
 }
+
+function assertOpenCodeContracts(
+	entrypoint: OpenCodeV2.Plugin & { readonly server: OpenCodeV1Plugin },
+) {
+	return entrypoint;
+}
+
+it("exports one typed dual-host object while retaining V1 compatibility names", async () => {
+	const entrypoint = assertOpenCodeContracts(CodememDualPlugin);
+
+	expect(Object.keys(entrypoint).sort()).toEqual(["id", "server", "setup"]);
+	expect(entrypoint.id).toBe("codemem");
+	expect(entrypoint.server).toBe(CodememPlugin);
+	expect(OpencodeMemPlugin).toBe(CodememPlugin);
+	expect(await entrypoint.setup({} as OpenCodeV2.Context)).toBeUndefined();
+});
 
 it("keeps the OpenCode 1 SDK manifests aligned with the supported host floor", async () => {
 	const packageManifest = await readJson("packages/opencode-plugin/package.json");
@@ -19,6 +39,8 @@ it("keeps the OpenCode 1 SDK manifests aligned with the supported host floor", a
 	expect(packageManifest.engines.opencode).toBe(`>=${minimumOpenCodeVersion}`);
 	expect(pluginRuntimeManifest.dependencies["@opencode-ai/plugin"]).toBe(minimumOpenCodeVersion);
 	expect(cliRuntimeManifest.dependencies["@opencode-ai/plugin"]).toBe(minimumOpenCodeVersion);
+	expect(packageManifest.dependencies["@opencode/plugin"]).toBeUndefined();
+	expect(packageManifest.devDependencies["@opencode/plugin"]).toBe(pinnedOpenCodeV2Version);
 });
 
 it("loads the repository wrapper from the canonical package implementation", async () => {
@@ -33,5 +55,6 @@ it("loads the repository wrapper from the canonical package implementation", asy
 	const repositoryWrapper = await import(repositoryWrapperUrl);
 
 	expect(Object.keys(repositoryWrapper)).toEqual(["default"]);
-	expect(repositoryWrapper.default).toBe(packageEntrypoint.default);
+	expect(repositoryWrapper.default).toBe(packageEntrypoint.CodememPlugin);
+	expect(packageEntrypoint.default.server).toBe(repositoryWrapper.default);
 });


### PR DESCRIPTION
## Description

Export one typed package object for both supported OpenCode hosts. OpenCode 1 uses `server()`, OpenCode 2 uses the inactive `setup()` shell, and named V1 compatibility exports remain available.

The packed smokes now prove the tarball loads through actual OpenCode 1.18.30 and pinned OpenCode 2 hosts, reject a sabotaged V1 entrypoint, compile a fresh consumer without the V2 SDK in production dependencies, and isolate duplicate-registration state.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [ ] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Validated with:

- `pnpm --filter @codemem/opencode-plugin test`
- `pnpm --filter @codemem/opencode-plugin test:packed-artifact`
- `pnpm --filter @codemem/opencode-plugin test:opencode-v2-contract`
- `pnpm --filter codemem test:plugin`
- `pnpm run tsc`
- `pnpm run lint` (passes with existing repository warnings)

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
