### PR TITLE
feat(opencode): add v2 capture lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ covers macOS x64/arm64, Linux x64/arm64 (glibc 2.34+ or musl), and Windows x64.
 
 Codemem requires OpenCode 1.18.29 or newer.
 
-The experimental OpenCode 2 beta entrypoint currently loads as an inactive
-compatibility shell. Capture, memory building, and automatic context injection
-remain OpenCode 1 features until the OpenCode 2 adapter is enabled.
+The experimental OpenCode 2 beta entrypoint captures user and assistant messages,
+terminal usage, tool results, and session lifecycle events. It does not yet inject
+automatic recall or expose memory tools; those remain OpenCode 1 features.
 
 1. Install the OpenCode plugin and MCP config:
 
@@ -197,7 +197,7 @@ Codex hook ingestion shares the same raw-event pipeline as Claude and OpenCode t
 
 Adapters hook into runtime event systems (the OpenCode 1 plugin and Claude hooks). They capture tool calls and conversation messages, flush them through an observer pipeline that produces typed memories, and surface retrieval context for future prompts.
 
-> The OpenCode workflow below applies only to OpenCode 1. The OpenCode 2 entrypoint is currently an inactive compatibility shell.
+> The workflow below describes OpenCode 1 recall. OpenCode 2 currently captures activity and manages lifecycle cleanup, but it does not inject automatic recall or expose memory tools.
 
 ```mermaid
 sequenceDiagram

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,7 +60,7 @@ Support tiers describe operational expectations for each adapter path:
 | Adapter | Tier | Notes |
 |---|---|---|
 | OpenCode 1 plugin | Supported | Primary reference adapter for lifecycle events and injection behavior. |
-| OpenCode 2 plugin | Experimental | The beta entrypoint loads as an inactive compatibility shell; capture and injection are not enabled. |
+| OpenCode 2 plugin | Experimental | The beta entrypoint captures conversation, tool, terminal usage, and lifecycle activity with bounded cleanup. Automatic recall and memory tools are not enabled. |
 | Claude hooks/plugin | Supported | Hook-first queue path with CLI/runtime fallback and parity slices tracked in adapter stack PRs. |
 | Codex plugin (hooks + MCP) | Supported | Functional capture pipeline (`plugins/codex/`, `packages/core/src/codex-hooks.ts`) dogfooded end-to-end: edge normalization → `POST /api/raw-events` → observer → memories. Prompt-time injection is present and env-gated but not fully validated on strict models. |
 | Windsurf integration | Experimental | Planned via shared adapter contract after OpenCode/Claude stabilization. |
@@ -185,7 +185,7 @@ flowchart TD
 
 ## Context injection
 
-The OpenCode 1 plugin injects a memory pack automatically on every turn. Volatile recall output is appended beside the latest user message by default so provider prompt caches can keep the stable system/history prefix. The experimental OpenCode 2 beta entrypoint is an inactive compatibility shell and does not inject context.
+The OpenCode 1 plugin injects a memory pack automatically on every turn. Volatile recall output is appended beside the latest user message by default so provider prompt caches can keep the stable system/history prefix. The experimental OpenCode 2 beta entrypoint captures activity and manages lifecycle cleanup, but it does not inject automatic recall or expose memory tools.
 
 ### Packaged Claude and Codex hooks
 

--- a/docs/opencode-retained-recall.md
+++ b/docs/opencode-retained-recall.md
@@ -1,6 +1,6 @@
 # OpenCode Retained Recall
 
-This contract applies to the OpenCode 1 plugin. The experimental OpenCode 2 beta entrypoint is an inactive compatibility shell and does not perform automatic recall.
+This retained-recall contract applies to the OpenCode 1 plugin. The experimental OpenCode 2 beta entrypoint captures activity and manages lifecycle cleanup, but it does not perform automatic recall or expose memory tools.
 
 Automatic message recall must preserve retained bytes and derive allowance from the current transform output, not a lifetime counter.
 

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -8,7 +8,7 @@ This page covers advanced plugin behavior, environment variables, and stream rel
 
 ## Running OpenCode 1 with the plugin
 
-These capture and recall behaviors apply to OpenCode 1. The experimental OpenCode 2 beta entrypoint currently loads as an inactive compatibility shell.
+OpenCode 1 supports the capture and recall behavior below. The experimental OpenCode 2 beta entrypoint captures user and assistant messages, terminal usage, tool results, and session lifecycle events, but it does not yet inject automatic recall or expose memory tools.
 
 1. Start OpenCode inside this repo (or make the plugin global so it globs in everywhere).
 2. Every tooling session creates memory artifacts in SQLite.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -179,7 +179,7 @@ Command/file token caching notes:
 - Low-signal observations are filtered before writing.
 
 ## Automatic context injection
-- The OpenCode 1 plugin injects a memory pack next to the latest user message by default, keeping older prompt prefixes stable for provider prompt caches. The experimental OpenCode 2 beta entrypoint is an inactive compatibility shell and does not inject context.
+- The OpenCode 1 plugin injects a memory pack next to the latest user message by default, keeping older prompt prefixes stable for provider prompt caches. The experimental OpenCode 2 beta entrypoint captures activity and manages lifecycle cleanup, but it does not inject automatic recall or expose memory tools.
 - Controls:
   - `CODEMEM_INJECT_CONTEXT=0` disables injection.
   - `CODEMEM_INJECT_SURFACE=system` uses the legacy OpenCode system-prompt injection surface.

--- a/packages/opencode-plugin/.opencode/lib/host-contract.js
+++ b/packages/opencode-plugin/.opencode/lib/host-contract.js
@@ -30,6 +30,7 @@
 
 /**
  * @typedef {object} CodememToolResult
+ * @property {string | null} [id] Stable host tool-call identity; OpenCode V1 omits it.
  * @property {string | null} sessionID
  * @property {string} tool
  * @property {object} args
@@ -37,12 +38,14 @@
 
 /**
  * @typedef {object} CodememRuntime
- * @property {() => void} dispose
+ * @property {() => void} deactivate
+ * @property {() => Promise<void>} dispose
  * @property {(context: CodememPromptContext) => Promise<void>} handleCompacting
  * @property {(input: CodememPromptContext, output: object) => Promise<void>} transformMessages
  * @property {(input: CodememPromptContext, output: object) => Promise<void>} transformSystem
  * @property {(event: CodememCapturedEvent) => Promise<void>} handleEvent
  * @property {(input: CodememToolResult, output: object) => Promise<void>} handleToolResult
+ * @property {(code: string) => Promise<void>} reportDiagnostic
  * @property {Record<string, {description: string, args: object, execute: Function}>} tools
  */
 

--- a/packages/opencode-plugin/.opencode/lib/opencode-v2-adapter.js
+++ b/packages/opencode-plugin/.opencode/lib/opencode-v2-adapter.js
@@ -1,0 +1,466 @@
+import { createRuntimeHost, createRuntimeLocation } from "./host-contract.js";
+import { createCodememRuntime } from "./runtime.js";
+
+const DEFAULT_EVENT_TASK_TIMEOUT_MS = 250;
+const FAILED_TOOL_ERROR = Object.freeze({
+  name: "CodememToolCaptureError",
+  message: "OpenCode reported a failed tool without error details",
+});
+
+const asRecord = (value) =>
+  value && typeof value === "object" && !Array.isArray(value) ? value : {};
+
+const canonicalEvent = (event, overrides) => ({
+  type: overrides.type,
+  sessionID: overrides.sessionID,
+  messageInfo: overrides.messageInfo || null,
+  part: overrides.part || null,
+  usage: overrides.usage || null,
+  raw: event,
+});
+
+const tokenCount = (value) =>
+  typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+
+const addTokens = (left = {}, right = {}) => ({
+  input: tokenCount(left.input) + tokenCount(right.input),
+  output: tokenCount(left.output) + tokenCount(right.output),
+  cache: {
+    read: tokenCount(left.cache?.read) + tokenCount(right.cache?.read),
+    write: tokenCount(left.cache?.write) + tokenCount(right.cache?.write),
+  },
+});
+
+const usageKey = (sessionID, messageID) => `${sessionID}:${messageID}`;
+
+export const createV2EventTranslator = () => {
+  const usageByMessage = new Map();
+  const textByMessage = new Map();
+
+  const clearSession = (sessionID) => {
+    for (const key of usageByMessage.keys()) {
+      if (key.startsWith(`${sessionID}:`)) usageByMessage.delete(key);
+    }
+    for (const key of textByMessage.keys()) {
+      if (key.startsWith(`${sessionID}:`)) textByMessage.delete(key);
+    }
+  };
+
+  const translateInbox = (event, data, sessionID) => {
+    if (data.item?.type !== "user") return [];
+    const messageID = data.inboxID;
+    const text = data.item.payload?.text;
+    if (typeof messageID !== "string" || typeof text !== "string") return [];
+    return [
+      canonicalEvent(event, {
+        type: "message.updated",
+        sessionID,
+        messageInfo: { id: messageID, role: "user", sessionID },
+      }),
+      canonicalEvent(event, {
+        type: "message.part.updated",
+        sessionID,
+        part: { id: event.id, messageID, sessionID, type: "text", text },
+      }),
+    ];
+  };
+
+  const translateText = (event, data, sessionID) => {
+    const messageID = data.assistantMessageID;
+    if (!sessionID || typeof messageID !== "string" || typeof data.text !== "string") return [];
+    const key = usageKey(sessionID, messageID);
+    const text = `${textByMessage.get(key) || ""}${data.text}`;
+    textByMessage.set(key, text);
+    return [
+      canonicalEvent(event, {
+        type: "message.part.updated",
+        sessionID,
+        part: { id: event.id, messageID, sessionID, type: "text", text },
+      }),
+    ];
+  };
+
+  const translateStep = (event, data, sessionID) => {
+    const messageID = data.assistantMessageID;
+    if (!sessionID || typeof messageID !== "string") return [];
+    const key = usageKey(sessionID, messageID);
+    const tokens = addTokens(usageByMessage.get(key), asRecord(data.tokens));
+    usageByMessage.set(key, tokens);
+    if (data.finish === "tool-calls") return [];
+    usageByMessage.delete(key);
+    textByMessage.delete(key);
+    return [canonicalEvent(event, {
+      type: "message.updated",
+      sessionID,
+      messageInfo: { id: messageID, role: "assistant", sessionID, finish: true, tokens },
+      usage: tokens,
+    })];
+  };
+
+  const translate = (event) => {
+    const data = asRecord(event?.data);
+    const sessionID = typeof data.sessionID === "string" ? data.sessionID : null;
+    if (event?.type === "session.inbox.enqueued") return translateInbox(event, data, sessionID);
+    if (event?.type === "session.text.ended") return translateText(event, data, sessionID);
+    if (event?.type === "session.step.ended") return translateStep(event, data, sessionID);
+    if (event?.type === "session.created") {
+      return [canonicalEvent(event, { type: "session.created", sessionID })];
+    }
+    if (event?.type === "session.deleted") {
+      if (sessionID) clearSession(sessionID);
+      return [canonicalEvent(event, { type: "session.deleted", sessionID })];
+    }
+    if (event?.type === "session.execution.failed") {
+      if (sessionID) clearSession(sessionID);
+      return [canonicalEvent(event, { type: "session.error", sessionID })];
+    }
+    if (
+      event?.type === "session.execution.succeeded"
+      || event?.type === "session.execution.interrupted"
+    ) {
+      if (sessionID) clearSession(sessionID);
+      return [canonicalEvent(event, { type: "session.idle", sessionID })];
+    }
+    return [];
+  };
+
+  return {
+    clear: () => {
+      usageByMessage.clear();
+      textByMessage.clear();
+    },
+    translate,
+  };
+};
+
+export const translateV2Event = (event) => createV2EventTranslator().translate(event);
+
+export const translateV2ToolResult = (input) => {
+  const failed = input?.status === "error";
+  const result = asRecord(input?.result);
+  let output = null;
+  if (!failed) output = result.output ?? result.content ?? input?.result ?? null;
+  return {
+    input: {
+      id: typeof input?.id === "string" ? input.id : null,
+      sessionID: typeof input?.sessionID === "string" ? input.sessionID : null,
+      tool: typeof input?.tool === "string" ? input.tool : "unknown",
+      args: asRecord(input?.input),
+    },
+    output: {
+      output,
+      error: failed ? input.error || FAILED_TOOL_ERROR : null,
+    },
+  };
+};
+
+const disposeAll = async (registrations) => {
+  let firstError;
+  for (const registration of [...registrations].reverse()) {
+    try {
+      await registration.dispose();
+    } catch (error) {
+      firstError ??= error;
+    }
+  }
+  if (firstError) throw firstError;
+};
+
+const defaultWaitForEventTask = (eventTask, timeoutMs) =>
+  new Promise((resolve) => {
+    let settled = false;
+    const finish = (completed) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(completed);
+    };
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    eventTask.then(() => finish(true), () => finish(true));
+  });
+
+const waitForRegistrationDisposal = async (registrations, waitForTask, timeoutMs) => {
+  let disposalError;
+  const disposalTask = disposeAll(registrations).catch((error) => {
+    disposalError = error;
+  });
+  try {
+    const completed = await waitForTask(disposalTask, timeoutMs);
+    return { completed, error: disposalError };
+  } catch (error) {
+    return { completed: false, error };
+  }
+};
+
+const waitForRuntimeDisposal = (runtime, waitForTask, timeoutMs) =>
+  waitForRegistrationDisposal(
+    [{ dispose: () => runtime.dispose() }],
+    waitForTask,
+    timeoutMs,
+  );
+
+const reportDiagnosticSafely = async (runtime, code) => {
+  try {
+    await runtime.reportDiagnostic?.(code);
+  } catch {
+    // Diagnostics must never alter host behavior.
+  }
+};
+
+const reportDiagnosticWithinTimeout = async (runtime, code, waitForTask, timeoutMs) => {
+  const diagnosticTask = reportDiagnosticSafely(runtime, code);
+  try {
+    await waitForTask(diagnosticTask, timeoutMs);
+  } catch {
+    // Diagnostics must never delay or alter cleanup.
+  }
+};
+
+const createCaptureScheduler = () => {
+  let captureTail = Promise.resolve();
+  return (run) => {
+    const task = captureTail.then(run);
+    captureTail = task.catch(() => {});
+    return task;
+  };
+};
+
+const waitForCaptureOrAbort = (task, signal) => new Promise((resolve) => {
+  let settled = false;
+  const finish = () => {
+    if (settled) return;
+    settled = true;
+    signal.removeEventListener("abort", finish);
+    resolve();
+  };
+  signal.addEventListener("abort", finish, { once: true });
+  task.then(finish, finish);
+  if (signal.aborted) finish();
+});
+
+const captureRuntimeTaskWithinTimeout = async ({
+  runtime,
+  run,
+  scheduleCapture = (capture) => Promise.resolve().then(capture),
+  diagnosticCode,
+  timeoutMs,
+  waitForCaptureTask,
+  waitForDiagnosticTask,
+}) => {
+  let failed = false;
+  const task = scheduleCapture(run).catch(() => {
+    failed = true;
+  });
+  let completed = false;
+  try {
+    completed = await waitForCaptureTask(task, timeoutMs);
+  } catch {
+    failed = true;
+  }
+  if (completed && !failed) return { completed, task };
+  await reportDiagnosticWithinTimeout(
+    runtime,
+    diagnosticCode,
+    waitForDiagnosticTask,
+    timeoutMs,
+  );
+  return { completed, task };
+};
+
+const consumeEvents = async (
+  context,
+  signal,
+  runtime,
+  translator,
+  { eventTaskTimeoutMs, scheduleCapture, waitForCaptureTask, waitForDiagnosticTask },
+) => {
+  try {
+    for await (const event of context.event.subscribe({ signal })) {
+      if (signal.aborted) break;
+      for (const translated of translator.translate(event)) {
+        const capture = await captureRuntimeTaskWithinTimeout({
+          runtime,
+          run: () => runtime.handleEvent(translated),
+          scheduleCapture,
+          diagnosticCode: "v2_event_capture_failed",
+          timeoutMs: eventTaskTimeoutMs,
+          waitForCaptureTask,
+          waitForDiagnosticTask,
+        });
+        if (!capture.completed) {
+          await waitForCaptureOrAbort(capture.task, signal);
+          if (signal.aborted) return;
+        }
+      }
+    }
+    if (!signal.aborted) {
+      await reportDiagnosticWithinTimeout(
+        runtime,
+        "v2_event_stream_ended_unexpectedly",
+        waitForDiagnosticTask,
+        eventTaskTimeoutMs,
+      );
+    }
+  } catch (error) {
+    if (signal.aborted && error instanceof Error && error.name === "AbortError") return;
+    await reportDiagnosticWithinTimeout(
+      runtime,
+      "v2_event_stream_failed",
+      waitForDiagnosticTask,
+      eventTaskTimeoutMs,
+    );
+  }
+};
+
+const cleanupAdapter = async ({
+  abortController,
+  eventTask,
+  eventTaskTimeoutMs,
+  registrations,
+  runtime,
+  translator,
+  waitForDiagnosticTask,
+  waitForEventTask,
+  waitForRegistrationTask,
+  waitForRuntimeDisposalTask,
+}) => {
+  runtime.deactivate?.();
+  abortController.abort();
+  const registrationCleanup = await waitForRegistrationDisposal(
+    registrations,
+    waitForRegistrationTask,
+    eventTaskTimeoutMs,
+  );
+  let firstError = registrationCleanup.error;
+  if (!registrationCleanup.completed) {
+    await reportDiagnosticWithinTimeout(
+      runtime,
+      "v2_registration_cleanup_timeout",
+      waitForDiagnosticTask,
+      eventTaskTimeoutMs,
+    );
+  }
+  let completed = false;
+  try {
+    completed = await waitForEventTask(eventTask, eventTaskTimeoutMs);
+  } catch (error) {
+    firstError ??= error;
+  }
+  translator.clear();
+  if (!completed) {
+    await reportDiagnosticWithinTimeout(
+      runtime,
+      "v2_event_stream_cleanup_timeout",
+      waitForDiagnosticTask,
+      eventTaskTimeoutMs,
+    );
+  }
+  const runtimeCleanup = await waitForRuntimeDisposal(
+    runtime,
+    waitForRuntimeDisposalTask,
+    eventTaskTimeoutMs,
+  );
+  firstError ??= runtimeCleanup.error;
+  if (!runtimeCleanup.completed) {
+    await reportDiagnosticWithinTimeout(
+      runtime,
+      "v2_runtime_cleanup_timeout",
+      waitForDiagnosticTask,
+      eventTaskTimeoutMs,
+    );
+  }
+  if (firstError) throw firstError;
+};
+
+export const createOpenCodeV2Adapter = ({
+  createRuntime = createCodememRuntime,
+  eventTaskTimeoutMs = DEFAULT_EVENT_TASK_TIMEOUT_MS,
+  waitForCaptureTask = defaultWaitForEventTask,
+  waitForDiagnosticTask = defaultWaitForEventTask,
+  waitForEventTask = defaultWaitForEventTask,
+  waitForRegistrationTask = defaultWaitForEventTask,
+  waitForRuntimeDisposalTask = defaultWaitForEventTask,
+} = {}) => async (context) => {
+  const location = context.location;
+  // beta-19296 exposes neither app logging nor toast APIs, so V2 uses local diagnostics only.
+  const runtime = await createRuntime({
+    location: createRuntimeLocation({
+      project: { ...location.project, root: location.project.canonical },
+      directory: location.directory,
+      worktree: location.project.directory,
+    }),
+    host: createRuntimeHost({ log: async () => {}, notify: null }),
+  });
+  if (!runtime) return undefined;
+
+  const abortController = new AbortController();
+  const registrations = [];
+  const translator = createV2EventTranslator();
+  const scheduleCapture = createCaptureScheduler();
+  let active = true;
+  let eventTask;
+  try {
+    registrations.push(await context.tool.hook("execute.after", async (input) => {
+      if (!active) return;
+      const translated = translateV2ToolResult(input);
+      await captureRuntimeTaskWithinTimeout({
+        runtime,
+        run: () => runtime.handleToolResult(translated.input, translated.output),
+        scheduleCapture,
+        diagnosticCode: "v2_tool_capture_failed",
+        timeoutMs: eventTaskTimeoutMs,
+        waitForCaptureTask,
+        waitForDiagnosticTask,
+      });
+    }));
+    eventTask = consumeEvents(context, abortController.signal, runtime, translator, {
+      eventTaskTimeoutMs,
+      scheduleCapture,
+      waitForCaptureTask,
+      waitForDiagnosticTask,
+    });
+  } catch (error) {
+    active = false;
+    runtime.deactivate?.();
+    abortController.abort();
+    translator.clear();
+    await disposeAll(registrations).catch(() => {});
+    const runtimeCleanup = await waitForRuntimeDisposal(
+      runtime,
+      waitForRuntimeDisposalTask,
+      eventTaskTimeoutMs,
+    );
+    if (!runtimeCleanup.completed) {
+      await reportDiagnosticWithinTimeout(
+        runtime,
+        "v2_runtime_cleanup_timeout",
+        waitForDiagnosticTask,
+        eventTaskTimeoutMs,
+      );
+    }
+    // Preserve the setup error that explains why activation failed.
+    throw error;
+  }
+
+  let cleanupTask;
+  return () => {
+    if (!cleanupTask) {
+      active = false;
+      cleanupTask = cleanupAdapter({
+        abortController,
+        eventTask,
+        eventTaskTimeoutMs,
+        registrations,
+        runtime,
+        translator,
+        waitForDiagnosticTask,
+        waitForEventTask,
+        waitForRegistrationTask,
+        waitForRuntimeDisposalTask,
+      });
+    }
+    return cleanupTask;
+  };
+};
+
+export const setupOpenCodeV2 = createOpenCodeV2Adapter();

--- a/packages/opencode-plugin/.opencode/lib/runtime.js
+++ b/packages/opencode-plugin/.opencode/lib/runtime.js
@@ -46,6 +46,15 @@ const CODEMEM_CONTEXT_PREFIX = "[codemem context]\n";
 const DEFAULT_EMBEDDING_MODEL = "Xenova/bge-small-en-v1.5";
 const DEFAULT_EMBEDDING_REVISION = "ea104dacec62c0de699686887e3f920caeb4f3e3";
 const PLUGIN_REGISTRATIONS_KEY = Symbol.for("codemem.opencode-plugin.registrations");
+const ADAPTER_DIAGNOSTIC_CODES = new Set([
+  "v2_event_capture_failed",
+  "v2_event_stream_cleanup_timeout",
+  "v2_event_stream_ended_unexpectedly",
+  "v2_event_stream_failed",
+  "v2_registration_cleanup_timeout",
+  "v2_runtime_cleanup_timeout",
+  "v2_tool_capture_failed",
+]);
 
 let compatCheckCache = null;
 const notifiedReleaseVersions = new Set();
@@ -1691,17 +1700,22 @@ const buildOpencodeAdapterPayload = (event) => {
     if (!text) {
       return null;
     }
-    return { text };
+    return {
+      text,
+      message_id: event?.message_id ? String(event.message_id) : null,
+    };
   }
 
   if (eventType === "tool.execute.after") {
     const toolName = String(event?.tool || "unknown");
+    const toolCallID = event?.tool_call_id ? String(event.tool_call_id) : null;
     return {
       tool_name: toolName,
       status: event?.error ? "error" : "ok",
       tool_input: event?.args || {},
       tool_output: event?.result ?? null,
       error: event?.error ?? null,
+      ...(toolCallID ? { tool_call_id: toolCallID } : {}),
     };
   }
 
@@ -2109,6 +2123,7 @@ export const createCodememRuntime = async ({ location, host }) => {
   const hostLog = typeof host?.log === "function" ? host.log : async () => {};
   const hostNotify = typeof host?.notify === "function" ? host.notify : null;
   const events = [];
+  const flushingBatches = new Set();
   const maxEvents = parsePositiveInt(process.env.CODEMEM_PLUGIN_MAX_EVENTS, 200);
   const maxChars = Number.parseInt(
     process.env.CODEMEM_PLUGIN_MAX_EVENT_CHARS || "8000",
@@ -2234,13 +2249,16 @@ export const createCodememRuntime = async ({ location, host }) => {
   let promptCounter = 0;
   let skippedAttemptCounter = 0;
   let lastPromptText = null;
-  let lastAssistantText = null;
+  const capturedPrompts = new Set();
+  const pendingPrompts = new Map();
+  const capturedAssistantMessages = new Set();
   const assistantUsageCaptured = new Set();
   const failedToolCaptured = new Set();
 
   // Track message roles and accumulated text by messageID
   const messageRoles = new Map();
   const messageTexts = new Map();
+  const promptPartsByMessage = new Map();
   let debugLogCount = 0;
 
   const rawEventsEnabled = envNotDisabled(
@@ -2286,6 +2304,8 @@ export const createCodememRuntime = async ({ location, host }) => {
   let lastStatusCheckAt = 0;
   let lastStatusAvailable = true;
   let promptPackTransportUnavailableUntil = 0;
+  const rawEventAbortController = new AbortController();
+  let runtimeActive = true;
 
   const nextEventId = () => {
     if (typeof crypto !== "undefined" && crypto.randomUUID) {
@@ -2534,6 +2554,9 @@ export const createCodememRuntime = async ({ location, host }) => {
       }
     }
     const { body, serialized } = cachedEnvelope;
+    if (!runtimeActive) {
+      return persistRawEventForRetry({ body, serialized, payload, sessionID });
+    }
     if (now < streamUnavailableUntil) {
       const durable = await persistRawEventForRetry({ body, serialized, payload, sessionID });
       try {
@@ -2579,6 +2602,10 @@ export const createCodememRuntime = async ({ location, host }) => {
       const postResp = await fetch(rawEventsUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        signal: AbortSignal.any([
+          rawEventAbortController.signal,
+          AbortSignal.timeout(RAW_EVENTS_STATUS_TIMEOUT_MS),
+        ]),
         body: JSON.stringify({
           ...body,
           db_path: promptPackDbPath,
@@ -2604,6 +2631,9 @@ export const createCodememRuntime = async ({ location, host }) => {
       }
       return true;
     } catch (err) {
+      if (!runtimeActive) {
+        return persistRawEventForRetry({ body, serialized, payload, sessionID });
+      }
       const category = err?.rawEventFailureCategory || "connection";
       streamUnavailableUntil = Date.now() + Math.max(1000, rawEventsBackoffMs);
       await logLine(`raw_events.error category=${category}`);
@@ -2670,7 +2700,75 @@ export const createCodememRuntime = async ({ location, host }) => {
 
   const updateActivity = () => {};
 
-  const extractPromptText = (event) => {
+  const promptMessageKey = (sessionID, messageID) =>
+    `${sessionID || activeSessionID || "unknown"}:${String(messageID)}`;
+
+  const accumulatePromptPart = (part) => {
+    const key = promptMessageKey(part.sessionID, part.messageID);
+    const parts = promptPartsByMessage.get(key) || new Map();
+    parts.set(String(part.id || "text"), part.text);
+    promptPartsByMessage.set(key, parts);
+    return [...parts.values()].join("").trim();
+  };
+
+  const promptIdentityForEvent = (event) => {
+    const info = event?.messageInfo;
+    if (event?.type === "message.updated" && info?.role === "user" && info.id) {
+      return promptMessageKey(info.sessionID || event.sessionID, info.id);
+    }
+    const part = event?.part;
+    if (
+      event?.type === "message.part.updated"
+      && part?.messageID
+      && messageRoles.get(part.messageID) === "user"
+    ) {
+      return promptMessageKey(part.sessionID || event.sessionID, part.messageID);
+    }
+    return null;
+  };
+
+  const clearPromptPartsForSession = (sessionID) => {
+    const resolvedSessionID = sessionID || activeSessionID;
+    if (!resolvedSessionID) {
+      return;
+    }
+    const prefix = `${resolvedSessionID}:`;
+    for (const key of promptPartsByMessage.keys()) {
+      if (key.startsWith(prefix)) {
+        promptPartsByMessage.delete(key);
+      }
+    }
+  };
+
+  const clearPromptSession = (sessionID) => {
+    if (!sessionID) {
+      return;
+    }
+    const prefix = `${sessionID}:`;
+    for (const key of capturedPrompts) {
+      if (key.startsWith(prefix)) {
+        capturedPrompts.delete(key);
+      }
+    }
+    for (const key of pendingPrompts.keys()) {
+      if (key.startsWith(prefix)) {
+        pendingPrompts.delete(key);
+      }
+    }
+    for (const key of capturedAssistantMessages) {
+      if (key.startsWith(prefix)) {
+        capturedAssistantMessages.delete(key);
+      }
+    }
+    for (const key of assistantUsageCaptured) {
+      if (key.startsWith(prefix)) {
+        assistantUsageCaptured.delete(key);
+      }
+    }
+    clearPromptPartsForSession(sessionID);
+  };
+
+  const extractPrompt = (event) => {
     if (!event) {
       return null;
     }
@@ -2681,9 +2779,12 @@ export const createCodememRuntime = async ({ location, host }) => {
       if (info.id && info.role) {
         messageRoles.set(info.id, info.role);
 
-        // If we have buffered text for this message and it's a user message, return it
-        if (info.role === "user" && messageTexts.has(info.id)) {
-          const text = messageTexts.get(info.id);
+        const promptKey = promptMessageKey(info.sessionID, info.id);
+        const promptParts = promptPartsByMessage.get(promptKey);
+        if (info.role === "user" && (promptParts?.size || messageTexts.has(info.id))) {
+          const text = promptParts?.size
+            ? [...promptParts.values()].join("").trim()
+            : messageTexts.get(info.id).trim();
           messageTexts.delete(info.id); // Clean up
           if (debugExtraction) {
             logLine(
@@ -2692,7 +2793,10 @@ export const createCodememRuntime = async ({ location, host }) => {
               )} len=${text.length}`
             );
           }
-          return text;
+          return { messageID: String(info.id), text };
+        }
+        if (info.role !== "user") {
+          promptPartsByMessage.delete(promptKey);
         }
       }
       return null;
@@ -2707,17 +2811,21 @@ export const createCodememRuntime = async ({ location, host }) => {
 
       const role = messageRoles.get(part.messageID);
       if (role === "user") {
-        // We know it's a user message, return the text immediately
+        const text = accumulatePromptPart(part);
         if (debugExtraction) {
           logLine(
             `user prompt captured immediately id=${part.messageID.slice(
               -8
-            )} len=${part.text.length}`
+            )} len=${text.length}`
           );
         }
-        return part.text.trim() || null;
+        if (!text) {
+          return null;
+        }
+        return { messageID: String(part.messageID), text };
       } else if (!role) {
         // Buffer this text until we know the role
+        accumulatePromptPart(part);
         const existing = messageTexts.get(part.messageID) || "";
         messageTexts.set(part.messageID, existing + part.text);
         if (debugExtraction) {
@@ -2763,7 +2871,10 @@ export const createCodememRuntime = async ({ location, host }) => {
         ) {
           const text = messageTexts.get(info.id);
           messageTexts.delete(info.id); // Clean up
-          return text.trim() || null;
+          const assistantText = text.trim();
+          return assistantText
+            ? { messageID: String(info.id), text: assistantText }
+            : null;
         }
       }
       return null;
@@ -2826,7 +2937,8 @@ export const createCodememRuntime = async ({ location, host }) => {
     if (!info.id || info.role !== "assistant" || (!info.finish && !info.time?.completed)) {
       return null;
     }
-    if (assistantUsageCaptured.has(info.id)) {
+    const usageIdentity = promptMessageKey(info.sessionID || event.sessionID, info.id);
+    if (assistantUsageCaptured.has(usageIdentity)) {
       return null;
     }
     const usage = normalizeUsage(
@@ -2835,7 +2947,7 @@ export const createCodememRuntime = async ({ location, host }) => {
     if (!usage) {
       return null;
     }
-    assistantUsageCaptured.add(info.id);
+    assistantUsageCaptured.add(usageIdentity);
     return { usage, id: info.id };
   };
 
@@ -4118,14 +4230,78 @@ export const createCodememRuntime = async ({ location, host }) => {
       _raw_session_id: resolvedSessionID,
     };
     recordEvent(queuedEvent);
-    void emitRawEvent({
+    const deliveryTask = emitRawEvent({
       sessionID: resolvedSessionID,
       type: queuedEvent?.type || "unknown",
       payload: queuedEvent,
     });
+    void deliveryTask.catch(() => {});
+    return deliveryTask;
+  };
+
+  const capturePendingPrompts = async ({
+    exceptIdentity = null,
+    skipFlush = false,
+    awaitDurability = false,
+  } = {}) => {
+    let durabilityFailed = false;
+    for (const [promptIdentity, prompt] of pendingPrompts) {
+      if (!runtimeActive && !skipFlush) return true;
+      if (promptIdentity === exceptIdentity) {
+        continue;
+      }
+      if (capturedPrompts.has(promptIdentity)) {
+        pendingPrompts.delete(promptIdentity);
+        continue;
+      }
+
+      pendingPrompts.delete(promptIdentity);
+      capturedPrompts.add(promptIdentity);
+
+      if (!skipFlush && (prompt.text.trim() === "/new" || prompt.text.trim().startsWith("/new "))) {
+        await logLine("detected /new command, flushing events");
+        await flushEvents();
+      }
+
+      promptCounter += 1;
+      updateActivity();
+
+      if (!sessionContext.firstPrompt) {
+        sessionContext.firstPrompt = prompt.text;
+        sessionContext.startTime = Date.now();
+      }
+      sessionContext.promptCount++;
+
+      const promptEvent = {
+        type: "user_prompt",
+        prompt_number: promptCounter,
+        prompt_text: prompt.text,
+        timestamp: new Date().toISOString(),
+      };
+      if (awaitDurability) {
+        try {
+          const durable = await captureCodememEvent(prompt.sessionID, promptEvent);
+          durabilityFailed ||= !durable;
+        } catch {
+          durabilityFailed = true;
+        }
+      } else {
+        captureCodememEvent(prompt.sessionID, promptEvent);
+      }
+      await logLine(
+        `user_prompt captured #${promptCounter}: ${prompt.text.substring(0, 50)}`
+      );
+
+      if (!skipFlush && shouldForceFlush()) {
+        await logLine(`force flush triggered: tools=${sessionContext.toolCount}, prompts=${sessionContext.promptCount}, duration=${Math.round((Date.now() - (sessionContext.startTime || Date.now())) / 1000)}s`);
+        await flushEvents();
+      }
+    }
+    return !durabilityFailed;
   };
 
   const flushEvents = async () => {
+    if (!runtimeActive) return;
     if (!events.length) {
       await drainRawEventSpool();
       await logLine("flush.skip empty");
@@ -4137,6 +4313,7 @@ export const createCodememRuntime = async ({ location, host }) => {
       await logLine("flush.skip empty");
       return;
     }
+    flushingBatches.add(batch);
 
     const failed = [];
     for (const queuedEvent of batch) {
@@ -4157,9 +4334,14 @@ export const createCodememRuntime = async ({ location, host }) => {
       }
     }
     if (failed.length) {
+      flushingBatches.delete(batch);
       events.unshift(...failed);
       await logLine(`flush.retry_deferred count=${failed.length}`);
       await drainRawEventSpool();
+      return;
+    }
+    if (!runtimeActive) {
+      flushingBatches.delete(batch);
       return;
     }
 
@@ -4171,6 +4353,7 @@ export const createCodememRuntime = async ({ location, host }) => {
       `flush.stream_only finalize count=${batch.length} tools=${sessionContext.toolCount} prompts=${sessionContext.promptCount} duration=${Math.round(durationMs / 1000)}s`
     );
     await logLine(`flush.ok count=${batch.length} dropped=0`);
+    flushingBatches.delete(batch);
     sessionStartedAt = null;
     resetSessionContext();
     await drainRawEventSpool();
@@ -4178,12 +4361,65 @@ export const createCodememRuntime = async ({ location, host }) => {
 
   void drainRawEventSpool();
 
+  const deactivateRuntime = () => {
+    if (!runtimeActive) return;
+    runtimeActive = false;
+    clearTimeout(updateCheckTimer);
+    stopHealthCheck();
+    rawEventAbortController.abort();
+    releasePluginRegistration();
+  };
+
+  const ensureQueuedEventsDurable = async () => {
+    let durable = true;
+    const queuedEvents = new Set(events);
+    for (const batch of flushingBatches) {
+      for (const queuedEvent of batch) {
+        queuedEvents.add(queuedEvent);
+      }
+    }
+    for (const queuedEvent of queuedEvents) {
+      if (queuedEvent?._raw_enqueued || queuedEvent?._raw_spooled) {
+        continue;
+      }
+      const queuedSessionID = queuedEvent?._raw_session_id || null;
+      const persisted = await emitRawEvent({
+        sessionID: queuedSessionID,
+        type: queuedEvent?.type || "unknown",
+        payload: queuedEvent,
+      });
+      durable &&= persisted;
+    }
+    return durable;
+  };
+
   return {
-    dispose: () => {
-      clearTimeout(updateCheckTimer);
-      stopHealthCheck();
-      releasePluginRegistration();
+    deactivate: deactivateRuntime,
+    dispose: async () => {
+      deactivateRuntime();
+      const promptsDurable = await capturePendingPrompts({
+        skipFlush: true,
+        awaitDurability: true,
+      });
+      const deliveriesDurable = await ensureQueuedEventsDurable();
+      if (!promptsDurable || !deliveriesDurable) {
+        await errorLogLine("raw_events.dispose_durability_failed category=persistence");
+      }
     },
+    reportDiagnostic: async (code) => {
+      const safeCode = ADAPTER_DIAGNOSTIC_CODES.has(code)
+        ? code
+        : "unknown_adapter_diagnostic";
+      await errorLogLine(`adapter.diagnostic code=${safeCode}`);
+    },
+    // Test-only state inspection; adapters must not depend on this method.
+    inspectBufferedPromptPartCount: () => [...promptPartsByMessage.values()]
+      .reduce((count, parts) => count + parts.size, 0),
+    inspectQueuedPrompts: () => events
+      .filter((event) => event.type === "user_prompt")
+      .map((event) => ({ number: event.prompt_number, text: event.prompt_text })),
+    inspectQueuedEventTypes: () => events.map((event) => event.type),
+    inspectCapturedPromptCount: () => capturedPrompts.size,
     handleCompacting: async ({ sessionID: requestedSessionID } = {}) => {
       const sessionID = requestedSessionID || activeSessionID;
       markCompactionInjectionSkip(compactionInjectionSkips, sessionID);
@@ -4311,9 +4547,12 @@ export const createCodememRuntime = async ({ location, host }) => {
       }
     },
     handleEvent: async (event) => {
+      if (!runtimeActive) return;
       const eventType = event?.type || "unknown";
       const sessionID = event?.sessionID || null;
       const rawEvent = event?.raw;
+      await capturePendingPrompts({ exceptIdentity: promptIdentityForEvent(event) });
+      if (!runtimeActive) return;
 
       // Always log session-related events for debugging /new
       if (eventType.startsWith("session.")) {
@@ -4380,65 +4619,36 @@ export const createCodememRuntime = async ({ location, host }) => {
           "message.part.updated",
         ].includes(eventType)
       ) {
-        const promptText = extractPromptText(event);
-        if (promptText) {
-          // Update activity tracking
-          updateActivity();
-
-          // Track session context
-          if (!sessionContext.firstPrompt) {
-            sessionContext.firstPrompt = promptText;
-            sessionContext.startTime = Date.now();
-          }
-          sessionContext.promptCount++;
-
-          // Check for /new command and flush before session reset
-          if (
-            promptText.trim() === "/new" ||
-            promptText.trim().startsWith("/new ")
-          ) {
-            await logLine("detected /new command, flushing events");
-            await flushEvents();
-          }
-
-          if (promptText !== lastPromptText) {
-            promptCounter += 1;
-          // promptCount incremented when capturing user_prompt
-
-            lastPromptText = promptText;
-            captureCodememEvent(sessionID, {
-              type: "user_prompt",
-              prompt_number: promptCounter,
-              prompt_text: promptText,
-              timestamp: new Date().toISOString(),
-            });
-            await logLine(
-              `user_prompt captured #${promptCounter}: ${promptText.substring(
-                0,
-                50
-              )}`
-            );
-
-            // Check if we should force flush due to threshold
-            if (shouldForceFlush()) {
-              await logLine(`force flush triggered: tools=${sessionContext.toolCount}, prompts=${sessionContext.promptCount}, duration=${Math.round((Date.now() - (sessionContext.startTime || Date.now())) / 1000)}s`);
-              await flushEvents();
-            }
+        const prompt = extractPrompt(event);
+        if (prompt) {
+          const promptText = prompt.text;
+          const promptIdentity = promptIdentityForEvent(event)
+            || promptMessageKey(sessionID, prompt.messageID);
+          const promptSessionID = event?.messageInfo?.sessionID
+            || event?.part?.sessionID
+            || sessionID;
+          lastPromptText = promptText;
+          if (!capturedPrompts.has(promptIdentity)) {
+            pendingPrompts.set(promptIdentity, { sessionID: promptSessionID, text: promptText });
           }
         }
 
-        const assistantText = extractAssistantText(event);
-        if (assistantText && assistantText !== lastAssistantText) {
-          updateActivity();
-          lastAssistantText = assistantText;
-          captureCodememEvent(sessionID, {
-            type: "assistant_message",
-            assistant_text: assistantText,
-            timestamp: new Date().toISOString(),
-          });
-          await logLine(
-            `assistant_message captured: ${assistantText.substring(0, 50)}`
-          );
+        const assistant = extractAssistantText(event);
+        if (assistant) {
+          const assistantIdentity = promptMessageKey(sessionID, assistant.messageID);
+          if (!capturedAssistantMessages.has(assistantIdentity)) {
+            capturedAssistantMessages.add(assistantIdentity);
+            updateActivity();
+            captureCodememEvent(sessionID, {
+              type: "assistant_message",
+              message_id: assistant.messageID,
+              assistant_text: assistant.text,
+              timestamp: new Date().toISOString(),
+            });
+            await logLine(
+              `assistant_message captured: ${assistant.text.substring(0, 50)}`
+            );
+          }
         }
 
         const assistantUsage = extractAssistantUsage(event);
@@ -4488,11 +4698,13 @@ export const createCodememRuntime = async ({ location, host }) => {
       //
       // REMOVED: session.compacted, session.compacting (too frequent)
       if (eventType === "session.error") {
+        clearPromptPartsForSession(sessionID);
         await logLine("session.error detected, flushing immediately");
         await flushEvents();
       }
 
       if (eventType === "session.idle") {
+        clearPromptPartsForSession(sessionID);
         await logLine(
           `session.idle detected, flushing immediately (tools=${sessionContext.toolCount}, prompts=${sessionContext.promptCount})`
         );
@@ -4511,7 +4723,7 @@ export const createCodememRuntime = async ({ location, host }) => {
         disabledInjectionRecorded.delete("message:unknown");
         disabledInjectionRecorded.delete("system:unknown");
         lastPromptText = null;
-        lastAssistantText = null;
+        clearPromptSession(sessionID);
         resetSessionContext();
         startViewer();
       }
@@ -4535,15 +4747,21 @@ export const createCodememRuntime = async ({ location, host }) => {
               failedToolCaptured.delete(key);
             }
           }
+          clearPromptSession(sessionID);
         }
         await stopViewer();
       }
     },
-    // OpenCode invokes this hook after successful tools; failures arrive as errored ToolPart events.
+    // V1 sends successes here and failures as ToolPart events; V2 sends both variants here.
     handleToolResult: async (input, output) => {
+      if (!runtimeActive) return;
+      await capturePendingPrompts();
+      if (!runtimeActive) return;
       const args = input.args ?? {};
       const result = output.output;
+      const error = output.error ?? null;
       const toolName = input.tool;
+      const toolCallID = input.id ?? null;
 
       // Update activity and session context
       updateActivity();
@@ -4570,8 +4788,9 @@ export const createCodememRuntime = async ({ location, host }) => {
         type: "tool.execute.after",
         tool: toolName,
         args,
-        result: truncate(safeStringify(result)),
-        error: null,
+        result: error ? null : truncate(safeStringify(result)),
+        error: error ? truncate(safeStringify(error)) : null,
+        ...(toolCallID ? { tool_call_id: String(toolCallID) } : {}),
         timestamp: new Date().toISOString(),
       });
       await logLine(`tool.execute.after ${toolName} queued=${events.length} tools=${sessionContext.toolCount}`);

--- a/packages/opencode-plugin/README.md
+++ b/packages/opencode-plugin/README.md
@@ -27,8 +27,9 @@ OpenCode installs npm plugins automatically with Bun at startup.
 
 The package default export is one dual-host object. OpenCode 1 calls its
 `server()` function, while OpenCode 2 calls its `setup()` function. The OpenCode 2
-setup is an intentionally inactive compatibility shell until the V2 adapter is
-enabled.
+setup captures conversation, tool, usage, and lifecycle activity and disposes its
+host registrations on unload. It does not yet inject automatic recall or expose
+memory tools.
 
 `CodememPlugin` remains the canonical named OpenCode 1 function export.
 `OpencodeMemPlugin` remains available as a deprecated, reference-identical alias

--- a/packages/opencode-plugin/index.js
+++ b/packages/opencode-plugin/index.js
@@ -2,11 +2,12 @@ import {
 	CodememPlugin,
 	OpencodeMemPlugin,
 } from "./.opencode/plugins/codemem.js";
+import { setupOpenCodeV2 } from "./.opencode/lib/opencode-v2-adapter.js";
 
 const CodememDualPlugin = {
 	id: "codemem",
 	server: CodememPlugin,
-	setup() {},
+	setup: setupOpenCodeV2,
 };
 
 export default CodememDualPlugin;

--- a/packages/opencode-plugin/scripts/packed-artifact-smoke.mjs
+++ b/packages/opencode-plugin/scripts/packed-artifact-smoke.mjs
@@ -122,6 +122,10 @@ try {
 		"Packed artifact is missing .opencode/lib/runtime.js",
 	);
 	assert(
+		tarListing.includes("package/.opencode/lib/opencode-v2-adapter.js"),
+		"Packed artifact is missing .opencode/lib/opencode-v2-adapter.js",
+	);
+	assert(
 		tarListing.includes("package/.opencode/lib/host-contract.js"),
 		"Packed artifact is missing .opencode/lib/host-contract.js",
 	);
@@ -155,6 +159,10 @@ try {
 	assert(
 		existsSync(join(installedPackageRoot, ".opencode", "lib", "runtime.js")),
 		"Installed artifact is missing .opencode/lib/runtime.js",
+	);
+	assert(
+		existsSync(join(installedPackageRoot, ".opencode", "lib", "opencode-v2-adapter.js")),
+		"Installed artifact is missing .opencode/lib/opencode-v2-adapter.js",
 	);
 	assert(
 		existsSync(join(installedPackageRoot, ".opencode", "lib", "host-contract.js")),
@@ -191,11 +199,28 @@ try {
 		typeConsumer,
 	]);
 
-	run(process.execPath, [
-		"--input-type=module",
-		"-e",
-		"const mod = await import('@codemem/opencode-plugin'); if (!mod.default || typeof mod.default !== 'object') throw new Error('default export is not an object'); if (mod.default.id !== 'codemem') throw new Error('default export has the wrong id'); if (typeof mod.default.server !== 'function') throw new Error('default server is not a function'); if (typeof mod.default.setup !== 'function') throw new Error('default setup is not a function'); if (typeof mod.CodememPlugin !== 'function') throw new Error('canonical named V1 export is not a function'); if (mod.default.server !== mod.CodememPlugin) throw new Error('default server is not the canonical V1 export'); if (mod.OpencodeMemPlugin !== mod.CodememPlugin) throw new Error('legacy V1 export is not a compatibility alias'); const result = await mod.default.setup({}); if (result !== undefined) throw new Error('V2 setup shell has behavior');",
-	], installDir);
+	const v2Home = join(tempDir, "v2-home");
+	mkdirSync(v2Home, { recursive: true });
+	const v2Env = {
+		...process.env,
+		HOME: v2Home,
+		CODEMEM_BACKEND_UPDATE_POLICY: "off",
+		CODEMEM_VIEWER: "0",
+	};
+	const installedV2Adapter = pathToFileURL(
+		join(installedPackageRoot, ".opencode", "lib", "opencode-v2-adapter.js"),
+	).href;
+	const packedEntrypoint = pathToFileURL(join(installedPackageRoot, "index.js")).href;
+	run(
+		process.execPath,
+		[
+			join(packageRoot, "scripts", "packed-v2-adapter-probe.mjs"),
+			packedEntrypoint,
+			installedV2Adapter,
+		],
+		installDir,
+		v2Env,
+	);
 
 	const pinnedOpenCodeV1Version = "1.18.30";
 	run("npm", ["install", "--prefix", installDir, `opencode-ai@${pinnedOpenCodeV1Version}`]);

--- a/packages/opencode-plugin/scripts/packed-v2-adapter-probe.mjs
+++ b/packages/opencode-plugin/scripts/packed-v2-adapter-probe.mjs
@@ -1,0 +1,516 @@
+import { createServer } from "node:http";
+
+const V2_SESSION = "packed-session";
+const V1_SESSION = "packed-v1-session";
+const CAPTURE_TYPES = new Set([
+	"user_prompt",
+	"assistant_message",
+	"assistant_usage",
+	"tool.execute.after",
+]);
+
+function assert(condition, message) {
+	if (!condition) throw new Error(message);
+}
+
+async function startReceiver() {
+	const rows = [];
+	const server = createServer(async (request, response) => {
+		if (request.method === "GET" && request.url?.startsWith("/api/raw-events/status")) {
+			response.writeHead(200, { "content-type": "application/json" });
+			response.end(JSON.stringify({ ingest: { available: true } }));
+			return;
+		}
+		if (request.method === "POST" && request.url === "/api/raw-events") {
+			const chunks = [];
+			for await (const chunk of request) chunks.push(chunk);
+			rows.push(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+			response.writeHead(200, { "content-type": "application/json" });
+			response.end(JSON.stringify({ ok: true }));
+			return;
+		}
+		response.writeHead(404).end();
+	});
+	await new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", resolve);
+	});
+	return { rows, server };
+}
+
+function rowsForSession(rows, sessionID) {
+	const uniqueRows = new Map();
+	for (const row of rows) {
+		if (row.session_id !== sessionID || !CAPTURE_TYPES.has(row.event_type)) continue;
+		uniqueRows.set(row.event_id, row);
+	}
+	return [...uniqueRows.values()];
+}
+
+async function waitForRows(rows, sessionID, count) {
+	const deadline = Date.now() + 2_000;
+	while (Date.now() < deadline) {
+		if (rowsForSession(rows, sessionID).length >= count) {
+			await new Promise((resolve) => setTimeout(resolve, 25));
+			return;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+	throw new Error(
+		`Packed capture timed out for ${sessionID}: ${JSON.stringify(rowsForSession(rows, sessionID).map((row) => ({ eventID: row.event_id, toolCallID: row.payload?.tool_call_id, type: row.event_type })))}`,
+	);
+}
+
+async function waitWithTimeout(promise, timeoutMs, message) {
+	let timer;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise((_, reject) => {
+				timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+			}),
+		]);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+function normalizePayload(row) {
+	const payload = row.payload;
+	if (row.event_type === "user_prompt") {
+		return { type: row.event_type, promptNumber: payload.prompt_number, text: payload.prompt_text };
+	}
+	if (row.event_type === "assistant_message") {
+		return {
+			type: row.event_type,
+			messageID: payload.message_id.replace(/^v[12]-/, ""),
+			text: payload.assistant_text,
+		};
+	}
+	if (row.event_type === "assistant_usage") {
+		return { type: row.event_type, usage: payload.usage };
+	}
+	return {
+		type: row.event_type,
+		tool: payload.tool,
+		args: payload.args,
+		result: payload.result,
+		error: payload.error,
+	};
+}
+
+const normalizeRows = (rows, sessionID) =>
+	rowsForSession(rows, sessionID)
+		.map(normalizePayload)
+		.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+
+function assertEntrypoint(mod) {
+	assert(mod.default && typeof mod.default === "object", "default export is not an object");
+	assert(mod.default.id === "codemem", "default export has the wrong id");
+	assert(typeof mod.default.server === "function", "default server is not a function");
+	assert(typeof mod.default.setup === "function", "default setup is not a function");
+	assert(typeof mod.CodememPlugin === "function", "canonical V1 export is not a function");
+	assert(mod.default.server === mod.CodememPlugin, "default server is not canonical V1");
+	assert(mod.OpencodeMemPlugin === mod.CodememPlugin, "legacy V1 export is not an alias");
+}
+
+function assertPackedTranslation(adapter) {
+	const translator = adapter.createV2EventTranslator();
+	translator.translate({
+		type: "session.step.ended",
+		data: {
+			sessionID: "translation-session",
+			assistantMessageID: "translation-message",
+			finish: "tool-calls",
+			tokens: { input: 2, output: 1 },
+		},
+	});
+	const terminal = translator.translate({
+		type: "session.step.ended",
+		data: {
+			sessionID: "translation-session",
+			assistantMessageID: "translation-message",
+			finish: "stop",
+			tokens: { input: 3, output: 4 },
+		},
+	});
+	assert(terminal[0]?.usage?.input === 5, "packed V2 usage was not cumulative");
+	assert(
+		translator.translate({ type: "session.text.delta", data: {} }).length === 0,
+		"packed V2 adapter accepted a non-allowlisted event",
+	);
+	const failed = adapter.translateV2ToolResult({
+		status: "error",
+		sessionID: "translation-session",
+		tool: "read",
+		input: {},
+	});
+	assert(
+		failed.output.error?.name === "CodememToolCaptureError",
+		"packed V2 adapter lost malformed failure status",
+	);
+}
+
+const v2Events = [
+	{ type: "session.created", data: { sessionID: V2_SESSION } },
+	{
+		id: "v2-user-event",
+		type: "session.inbox.enqueued",
+		data: {
+			sessionID: V2_SESSION,
+			inboxID: "v2-user",
+			item: { type: "user", payload: { text: "parity prompt" } },
+		},
+	},
+	{
+		id: "v2-user-event",
+		type: "session.inbox.enqueued",
+		data: {
+			sessionID: V2_SESSION,
+			inboxID: "v2-user",
+			item: { type: "user", payload: { text: "parity prompt" } },
+		},
+	},
+	{
+		id: "v2-user-event-repeat",
+		type: "session.inbox.enqueued",
+		data: {
+			sessionID: V2_SESSION,
+			inboxID: "v2-user-repeat",
+			item: { type: "user", payload: { text: "parity prompt" } },
+		},
+	},
+	{
+		id: "v2-assistant-event",
+		type: "session.text.ended",
+		data: {
+			sessionID: V2_SESSION,
+			assistantMessageID: "v2-assistant",
+			text: "parity ",
+		},
+	},
+	{
+		type: "session.step.ended",
+		data: {
+			sessionID: V2_SESSION,
+			assistantMessageID: "v2-assistant",
+			finish: "tool-calls",
+			tokens: { input: 2, output: 1 },
+		},
+	},
+	{
+		id: "v2-assistant-event-after-tool",
+		type: "session.text.ended",
+		data: {
+			sessionID: V2_SESSION,
+			assistantMessageID: "v2-assistant",
+			text: "response",
+		},
+	},
+	{
+		type: "session.step.ended",
+		data: {
+			sessionID: V2_SESSION,
+			assistantMessageID: "v2-assistant",
+			finish: "stop",
+			tokens: { input: 2, output: 1 },
+		},
+	},
+	{
+		id: "v2-assistant-repeat-event",
+		type: "session.text.ended",
+		data: {
+			sessionID: V2_SESSION,
+			assistantMessageID: "v2-assistant-repeat",
+			text: "parity response",
+		},
+	},
+	{
+		type: "session.step.ended",
+		data: {
+			sessionID: V2_SESSION,
+			assistantMessageID: "v2-assistant-repeat",
+			finish: "stop",
+			tokens: { input: 4, output: 2 },
+		},
+	},
+];
+
+function createV2Subscription(rows, state, toolsHandled, markTerminalHandled) {
+	return async function* subscribe({ signal }) {
+		for (const event of v2Events) yield event;
+		await toolsHandled;
+		await waitForRows(rows, V2_SESSION, 8);
+		yield { type: "session.execution.succeeded", data: { sessionID: V2_SESSION } };
+		markTerminalHandled();
+		await new Promise((resolve, reject) => {
+			const stop = () => {
+				state.aborted = true;
+				reject(new DOMException("aborted", "AbortError"));
+			};
+			if (signal.aborted) stop();
+			else signal.addEventListener("abort", stop, { once: true });
+		});
+	};
+}
+
+function createV2Context(rows) {
+	let hook;
+	const state = { aborted: false, disposed: false };
+	let markTerminalHandled;
+	let markToolsHandled;
+	const terminalHandled = new Promise((resolve) => {
+		markTerminalHandled = resolve;
+	});
+	const toolsHandled = new Promise((resolve) => {
+		markToolsHandled = resolve;
+	});
+	return {
+		context: {
+			location: {
+				directory: process.cwd(),
+				project: { id: "packed-v2", directory: process.cwd(), canonical: process.cwd() },
+			},
+			event: {
+				subscribe: createV2Subscription(rows, state, toolsHandled, markTerminalHandled),
+			},
+			tool: {
+				hook: async (name, callback) => {
+					assert(name === "execute.after", "packed V2 setup registered the wrong hook");
+					hook = callback;
+					return {
+						dispose: async () => {
+							state.disposed = true;
+						},
+					};
+				},
+			},
+		},
+		getHook: () => hook,
+		isAborted: () => state.aborted,
+		isDisposed: () => state.disposed,
+		markToolsHandled,
+		terminalHandled,
+	};
+}
+
+async function driveV2(mod, rows) {
+	const fixture = createV2Context(rows);
+	const cleanup = await mod.default.setup(fixture.context);
+	const hook = fixture.getHook();
+	assert(typeof cleanup === "function", "packed V2 setup did not return cleanup");
+	assert(typeof hook === "function", "packed V2 setup did not register tool capture");
+	await hook({
+		id: "v2-tool-present-1",
+		status: "completed",
+		sessionID: V2_SESSION,
+		tool: "read",
+		input: { path: "present" },
+		result: { output: "read ok" },
+	});
+	await hook({
+		id: "v2-tool-missing",
+		status: "error",
+		sessionID: V2_SESSION,
+		tool: "read",
+		input: { path: "missing" },
+		error: { message: "missing" },
+	});
+	fixture.markToolsHandled();
+	await waitForRows(rows, V2_SESSION, 8);
+	const toolCallIDs = rowsForSession(rows, V2_SESSION)
+		.filter((row) => row.event_type === "tool.execute.after")
+		.map((row) => row.payload.tool_call_id)
+		.sort();
+	assert(
+		JSON.stringify(toolCallIDs) ===
+			JSON.stringify(["v2-tool-missing", "v2-tool-present-1"]),
+		`packed V2 capture lost tool-call identity: ${JSON.stringify(toolCallIDs)}`,
+	);
+	await waitWithTimeout(fixture.terminalHandled, 3_000, "Packed V2 terminal event timed out");
+	await cleanup();
+	assert(fixture.isAborted(), "packed V2 cleanup did not abort event consumption");
+	assert(fixture.isDisposed(), "packed V2 cleanup did not dispose hook registration");
+}
+
+async function emitV1Event(hooks, event) {
+	await hooks.event({ event });
+}
+
+const createV1Context = () => ({
+	project: { name: "packed-v1" },
+	directory: process.cwd(),
+	worktree: process.cwd(),
+	client: { app: { log: async () => {} }, tui: {} },
+});
+
+const v1ConversationEvents = [
+	{ type: "session.created", properties: { info: { id: V1_SESSION } } },
+	{
+		type: "message.updated",
+		properties: { info: { id: "v1-user", role: "user", sessionID: V1_SESSION } },
+	},
+	{
+		type: "message.part.updated",
+		properties: {
+			part: {
+				id: "v1-user-part",
+				messageID: "v1-user",
+				sessionID: V1_SESSION,
+				type: "text",
+				text: "parity prompt",
+			},
+		},
+	},
+	{
+		type: "message.part.updated",
+		properties: {
+			part: {
+				id: "v1-user-part",
+				messageID: "v1-user",
+				sessionID: V1_SESSION,
+				type: "text",
+				text: "parity prompt",
+			},
+		},
+	},
+	{
+		type: "message.updated",
+		properties: { info: { id: "v1-user-repeat", role: "user", sessionID: V1_SESSION } },
+	},
+	{
+		type: "message.part.updated",
+		properties: {
+			part: {
+				id: "v1-user-part-repeat",
+				messageID: "v1-user-repeat",
+				sessionID: V1_SESSION,
+				type: "text",
+				text: "parity prompt",
+			},
+		},
+	},
+	{
+		type: "message.part.updated",
+		properties: {
+			part: {
+				id: "v1-assistant-part",
+				messageID: "v1-assistant",
+				sessionID: V1_SESSION,
+				type: "text",
+				text: "parity response",
+			},
+		},
+	},
+	{
+		type: "message.updated",
+		properties: {
+			info: {
+				id: "v1-assistant",
+				role: "assistant",
+				sessionID: V1_SESSION,
+				finish: true,
+				tokens: { input: 4, output: 2 },
+			},
+		},
+	},
+	{
+		type: "message.part.updated",
+		properties: {
+			part: {
+				id: "v1-assistant-repeat-part",
+				messageID: "v1-assistant-repeat",
+				sessionID: V1_SESSION,
+				type: "text",
+				text: "parity response",
+			},
+		},
+	},
+	{
+		type: "message.updated",
+		properties: {
+			info: {
+				id: "v1-assistant-repeat",
+				role: "assistant",
+				sessionID: V1_SESSION,
+				finish: true,
+				tokens: { input: 4, output: 2 },
+			},
+		},
+	},
+];
+
+const v1FailureEvent = {
+	type: "message.part.updated",
+	properties: {
+		part: {
+			id: "v1-failed",
+			callID: "v1-failed",
+			messageID: "v1-assistant",
+			sessionID: V1_SESSION,
+			type: "tool",
+			tool: "read",
+			state: {
+				status: "error",
+				input: { path: "missing" },
+				error: { message: "missing" },
+			},
+		},
+	},
+};
+
+async function driveV1(mod, rows) {
+	const hooks = await mod.default.server(createV1Context());
+	assert(typeof hooks.event === "function", "packed V1 server did not activate");
+	for (const event of v1ConversationEvents) await emitV1Event(hooks, event);
+	await hooks["tool.execute.after"](
+		{ sessionID: V1_SESSION, tool: "read", args: { path: "present" } },
+		{ output: "read ok" },
+	);
+	await emitV1Event(hooks, v1FailureEvent);
+	await waitForRows(rows, V1_SESSION, 8);
+	await emitV1Event(hooks, { type: "session.idle", properties: { sessionID: V1_SESSION } });
+	await hooks.dispose();
+	const reloaded = await mod.default.server(createV1Context());
+	assert(typeof reloaded.event === "function", "packed V1 dispose did not release ownership");
+	await reloaded.dispose();
+}
+
+const [entrypointURL, adapterURL] = process.argv.slice(2);
+assert(entrypointURL && adapterURL, "Packed V2 probe requires package URLs");
+const receiver = await startReceiver();
+const address = receiver.server.address();
+assert(address && typeof address === "object", "Packed receiver did not bind a port");
+process.env.CODEMEM_RAW_EVENTS = "1";
+process.env.CODEMEM_VIEWER_HOST = "127.0.0.1";
+process.env.CODEMEM_VIEWER_PORT = String(address.port);
+
+try {
+	const mod = await import(entrypointURL);
+	const adapter = await import(adapterURL);
+	assertEntrypoint(mod);
+	assertPackedTranslation(adapter);
+	await driveV2(mod, receiver.rows);
+	await driveV1(mod, receiver.rows);
+	const v2Rows = normalizeRows(receiver.rows, V2_SESSION);
+	const v1Rows = normalizeRows(receiver.rows, V1_SESSION);
+	assert(
+		v2Rows.length === 8,
+		`packed V2 capture had unexpected rows: ${JSON.stringify(v2Rows)}`,
+	);
+	assert(
+		v1Rows.length === 8,
+		`packed V1 capture had unexpected rows: ${JSON.stringify(v1Rows)}`,
+	);
+	assert(
+		JSON.stringify(v2Rows) === JSON.stringify(v1Rows),
+		`packed V1/V2 normalized capture mismatch: ${JSON.stringify({ v1Rows, v2Rows })}`,
+	);
+} finally {
+	await new Promise((resolve, reject) => {
+		receiver.server.close((error) => {
+			if (error) reject(error);
+			else resolve();
+		});
+	});
+}

--- a/packages/opencode-plugin/scripts/packed-v2-host-smoke.mjs
+++ b/packages/opencode-plugin/scripts/packed-v2-host-smoke.mjs
@@ -370,7 +370,7 @@ try {
 				contract: {
 					package: "@opencode/ai/providers/openai-compatible",
 					settings: {
-						apiKey: "contract-token",
+						apiKey: provider.baseURL,
 						baseURL: provider.baseURL,
 						provider: "contract",
 					},
@@ -401,6 +401,9 @@ try {
 		PATH: process.env.PATH ?? "",
 		HOME: homeDir,
 		XDG_CONFIG_HOME: join(homeDir, ".config"),
+		CODEMEM_BACKEND_UPDATE_POLICY: "off",
+		CODEMEM_RAW_EVENTS: "0",
+		CODEMEM_VIEWER: "0",
 		CODEMEM_OPENCODE_V2_CONTRACT_REPORT: reportPath,
 		OPENCODE_DISABLE_AUTOUPDATE: "true",
 		OPENCODE_DISABLE_MODELS_FETCH: "true",
@@ -556,9 +559,9 @@ try {
 		env,
 	});
 	const expectedEventTypes = [
-		"session.inbox.delivered",
-		"session.tool.success",
-		"session.tool.failed",
+		"session.inbox.enqueued",
+		"session.step.ended",
+		"session.execution.succeeded",
 		"session.text.ended",
 	];
 	const eventDeadline = Date.now() + 10_000;
@@ -613,6 +616,59 @@ try {
 	assert(
 		records.some((record) => record.phase === "event.end" && record.aborted === true),
 		"Host event subscription did not end cleanly after abort",
+	);
+	assert(
+		records.some(
+			(record) =>
+				record.phase === "event" &&
+				record.type === "session.inbox.enqueued" &&
+				record.hasInboxID &&
+				record.hasSessionID &&
+				record.hasTextPayload &&
+				record.isUserItem,
+		),
+		"Pinned host inbox event omitted the expected content-free payload shape",
+	);
+	assert(
+		records.some(
+			(record) =>
+				record.phase === "event" &&
+				record.type === "session.step.ended" &&
+				record.hasAssistantMessageID &&
+				record.hasFinish &&
+				record.hasSessionID &&
+				record.hasTokens,
+		),
+		"Pinned host step-ended event omitted the expected content-free payload shape",
+	);
+	const observedFinishReasons = new Set(
+		records
+			.filter((record) => record.phase === "event" && record.type === "session.step.ended")
+			.map((record) => record.finish),
+	);
+	assert(
+		observedFinishReasons.has("tool-calls") && observedFinishReasons.has("stop"),
+		`Pinned host tool continuation omitted terminal finish evidence; observed ${JSON.stringify([...observedFinishReasons])}`,
+	);
+	const eventRecords = records.filter((record) => record.phase === "event");
+	const terminalStepIndex = eventRecords.findIndex(
+		(record) => record.type === "session.step.ended" && record.finish === "stop",
+	);
+	const precedingTextIndex = eventRecords.findLastIndex(
+		(record, index) => index < terminalStepIndex && record.type === "session.text.ended",
+	);
+	assert(
+		precedingTextIndex >= 0 && precedingTextIndex < terminalStepIndex,
+		"Pinned host did not deliver assistant text before its terminal step",
+	);
+	assert(
+		records.some(
+			(record) =>
+				record.phase === "event" &&
+				record.type === "session.execution.succeeded" &&
+				record.hasSessionID,
+		),
+		"Pinned host execution terminal event omitted session identity",
 	);
 	assert(
 		records.some(

--- a/packages/opencode-plugin/src/opencode-v2-adapter.test.ts
+++ b/packages/opencode-plugin/src/opencode-v2-adapter.test.ts
@@ -1,0 +1,794 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import type { Plugin } from "@opencode/plugin";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+
+const adapterUrl = pathToFileURL(
+	path.resolve(import.meta.dirname, "../.opencode/lib/opencode-v2-adapter.js"),
+).href;
+const adapter = await import(adapterUrl);
+const runtimeUrl = pathToFileURL(
+	path.resolve(import.meta.dirname, "../.opencode/lib/runtime.js"),
+).href;
+const runtimeModule = await import(runtimeUrl);
+
+function makeRuntime() {
+	return {
+		deactivate: vi.fn(),
+		dispose: vi.fn(async () => undefined),
+		handleEvent: vi.fn(async () => undefined),
+		handleToolResult: vi.fn(async () => undefined),
+		reportDiagnostic: vi.fn(async () => undefined),
+	};
+}
+
+function makeContext(
+	events: readonly unknown[] = [],
+	options: { eventError?: Error; hookError?: Error; stuck?: boolean; stuckDispose?: boolean } = {},
+) {
+	const aborted = { value: false };
+	const hookDispose = vi.fn(async () => {
+		if (options.stuckDispose) await new Promise(() => {});
+	});
+	let toolHook: ((input: unknown) => Promise<void>) | undefined;
+	const context = {
+		location: {
+			directory: "/repo/worktree/nested",
+			project: { id: "project", directory: "/repo/worktree", canonical: "/repo" },
+		},
+		event: {
+			subscribe: async function* ({ signal }: { signal: AbortSignal }) {
+				for (const event of events) yield event;
+				if (options.eventError) throw options.eventError;
+				if (options.stuck) await new Promise(() => {});
+				await new Promise<void>((_resolve, reject) => {
+					const abort = () => {
+						aborted.value = true;
+						reject(new DOMException("aborted", "AbortError"));
+					};
+					if (signal.aborted) abort();
+					else signal.addEventListener("abort", abort, { once: true });
+				});
+			},
+		},
+		tool: {
+			hook: vi.fn(async (_name: string, callback: (input: unknown) => Promise<void>) => {
+				if (options.hookError) throw options.hookError;
+				toolHook = callback;
+				return { dispose: hookDispose };
+			}),
+		},
+	};
+	return { aborted, context, hookDispose, invokeTool: (input: unknown) => toolHook?.(input) };
+}
+
+type EventStream = Awaited<ReturnType<Plugin.Context["event"]["subscribe"]>>;
+type OpenCodeEvent = EventStream extends AsyncIterable<infer Event> ? Event : never;
+type InboxEvent = Extract<OpenCodeEvent, { type: "session.inbox.enqueued" }>;
+type StepEndedEvent = Extract<OpenCodeEvent, { type: "session.step.ended" }>;
+type ExecutionEvent = Extract<
+	OpenCodeEvent,
+	{ type: `session.execution.${"succeeded" | "failed" | "interrupted"}` }
+>;
+
+function assertToolHookContract(hook: Plugin.Context["tool"]["hook"]) {
+	return hook("execute.after", (input) => {
+		expectTypeOf(input.status).toEqualTypeOf<"completed" | "error">();
+		expectTypeOf(input.sessionID).toBeString();
+		expectTypeOf(input.tool).toBeString();
+		if (input.status === "error") expectTypeOf(input.error).not.toBeNever();
+	});
+}
+
+describe("pinned OpenCode 2 adapter types", () => {
+	it("derives capture event and tool shapes from Plugin.Context", () => {
+		expectTypeOf<InboxEvent["data"]>().toMatchTypeOf<{
+			sessionID: string;
+			inboxID: string;
+			item: { type: string };
+		}>();
+		expectTypeOf<StepEndedEvent["data"]>().toMatchTypeOf<{
+			sessionID: string;
+			assistantMessageID: string;
+			finish: string;
+			tokens: object;
+		}>();
+		expectTypeOf<ExecutionEvent["data"]>().toMatchTypeOf<{ sessionID: string }>();
+		expectTypeOf(assertToolHookContract).toBeFunction();
+	});
+});
+
+describe("OpenCode 2 event translation", () => {
+	it("normalizes user, assistant, usage, and lifecycle events", () => {
+		const user = adapter.translateV2Event({
+			id: "event-user",
+			type: "session.inbox.enqueued",
+			data: {
+				sessionID: "session-1",
+				inboxID: "message-user",
+				item: { type: "user", payload: { text: "Ship it" } },
+			},
+		});
+		const assistant = adapter.translateV2Event({
+			id: "event-text",
+			type: "session.text.ended",
+			data: {
+				sessionID: "session-1",
+				assistantMessageID: "message-assistant",
+				text: "Done",
+			},
+		});
+		const usage = adapter.translateV2Event({
+			type: "session.step.ended",
+			data: {
+				sessionID: "session-1",
+				assistantMessageID: "message-assistant",
+				finish: "stop",
+				tokens: { input: 4, output: 2, cache: { read: 1, write: 0 } },
+			},
+		});
+
+		expect(user.map((event: { type: string }) => event.type)).toEqual([
+			"message.updated",
+			"message.part.updated",
+		]);
+		expect(user[1].part.text).toBe("Ship it");
+		expect(assistant.map((event: { type: string }) => event.type)).toEqual([
+			"message.part.updated",
+		]);
+		expect(assistant[0].part.text).toBe("Done");
+		expect(usage[0].messageInfo).toMatchObject({ role: "assistant", finish: true });
+		expect(usage[0].messageInfo.tokens.output).toBe(2);
+		expect(
+			adapter.translateV2Event({
+				type: "session.execution.succeeded",
+				data: { sessionID: "session-1" },
+			})[0].type,
+		).toBe("session.idle");
+	});
+
+	it("allowlists events and accumulates usage until a terminal step", () => {
+		const translator = adapter.createV2EventTranslator();
+		const first = translator.translate({
+			type: "session.step.ended",
+			data: {
+				sessionID: "session-1",
+				assistantMessageID: "message-assistant",
+				finish: "tool-calls",
+				tokens: { input: 3, output: 2, reasoning: 1, cache: { read: 4, write: 1 } },
+			},
+		});
+		const terminal = translator.translate({
+			type: "session.step.ended",
+			data: {
+				sessionID: "session-1",
+				assistantMessageID: "message-assistant",
+				finish: "stop",
+				tokens: { input: 5, output: 7, reasoning: 2, cache: { read: 6, write: 3 } },
+			},
+		});
+
+		expect(first).toEqual([]);
+		expect(terminal).toHaveLength(1);
+		expect(terminal[0].usage).toEqual({
+			input: 8,
+			output: 9,
+			cache: { read: 10, write: 4 },
+		});
+		expect(translator.translate({ type: "session.text.delta", data: { text: "ignored" } })).toEqual(
+			[],
+		);
+		for (const finish of ["stop", "length", "content-filter", "error", "unknown"]) {
+			const terminalTranslator = adapter.createV2EventTranslator();
+			expect(
+				terminalTranslator.translate({
+					type: "session.step.ended",
+					data: {
+						sessionID: "session-terminal",
+						assistantMessageID: `message-${finish}`,
+						finish,
+						tokens: { input: 1, output: 1 },
+					},
+				}),
+			).toHaveLength(1);
+		}
+	});
+});
+
+describe("OpenCode 2 assistant continuation translation", () => {
+	it("finalizes one cumulative assistant message after a tool continuation", () => {
+		const translator = adapter.createV2EventTranslator();
+		const beforeTool = translator.translate({
+			id: "text-before-tool",
+			type: "session.text.ended",
+			data: {
+				sessionID: "session-1",
+				assistantMessageID: "message-assistant",
+				text: "Checking. ",
+			},
+		});
+		const toolStep = translator.translate({
+			type: "session.step.ended",
+			data: {
+				sessionID: "session-1",
+				assistantMessageID: "message-assistant",
+				finish: "tool-calls",
+				tokens: { input: 1, output: 1 },
+			},
+		});
+		const afterTool = translator.translate({
+			id: "text-after-tool",
+			type: "session.text.ended",
+			data: {
+				sessionID: "session-1",
+				assistantMessageID: "message-assistant",
+				text: "Done.",
+			},
+		});
+		const terminal = translator.translate({
+			type: "session.step.ended",
+			data: {
+				sessionID: "session-1",
+				assistantMessageID: "message-assistant",
+				finish: "stop",
+				tokens: { input: 2, output: 2 },
+			},
+		});
+
+		expect(beforeTool).toHaveLength(1);
+		expect(beforeTool[0].part.text).toBe("Checking. ");
+		expect(toolStep).toEqual([]);
+		expect(afterTool).toHaveLength(1);
+		expect(afterTool[0].part.text).toBe("Checking. Done.");
+		expect(terminal).toHaveLength(1);
+		expect(terminal[0].messageInfo).toMatchObject({
+			id: "message-assistant",
+			role: "assistant",
+			finish: true,
+		});
+	});
+
+	it("clears unfinished assistant text when a session ends", () => {
+		const translator = adapter.createV2EventTranslator();
+		translator.translate({
+			id: "stale-text",
+			type: "session.text.ended",
+			data: {
+				sessionID: "session-1",
+				assistantMessageID: "message-assistant",
+				text: "Stale",
+			},
+		});
+		translator.translate({
+			type: "session.execution.interrupted",
+			data: { sessionID: "session-1" },
+		});
+
+		const fresh = translator.translate({
+			id: "fresh-text",
+			type: "session.text.ended",
+			data: {
+				sessionID: "session-1",
+				assistantMessageID: "message-assistant",
+				text: "Fresh",
+			},
+		});
+
+		expect(fresh[0].part.text).toBe("Fresh");
+	});
+});
+
+describe("OpenCode 2 tool capture", () => {
+	it("uses tool-call identity to distinguish otherwise identical captured events", () => {
+		const createEvent = (toolCallID: string) =>
+			runtimeModule.__testUtils.buildOpencodeAdapterEvent({
+				sessionID: "session-1",
+				event: {
+					type: "tool.execute.after",
+					tool: "read",
+					args: { path: "/repo/file.ts" },
+					result: "ok",
+					error: null,
+					tool_call_id: toolCallID,
+					timestamp: "2026-09-10T12:00:00.000Z",
+				},
+			});
+
+		expect(createEvent("tool-call-1").event_id).not.toBe(createEvent("tool-call-2").event_id);
+	});
+});
+
+describe("OpenCode 2 adapter lifecycle", () => {
+	it("captures completed and failed tools without changing their outcomes", async () => {
+		const runtime = makeRuntime();
+		const fixture = makeContext();
+		const setup = adapter.createOpenCodeV2Adapter({ createRuntime: async () => runtime });
+		const cleanup = await setup(fixture.context);
+
+		await fixture.invokeTool({
+			id: "tool-call-completed",
+			status: "completed",
+			sessionID: "session-1",
+			tool: "read",
+			input: { path: "/repo/worktree/file.ts" },
+			result: { content: "ok" },
+		});
+		await fixture.invokeTool({
+			id: "tool-call-failed",
+			status: "error",
+			sessionID: "session-1",
+			tool: "read",
+			input: { path: "/repo/worktree/missing.ts" },
+			error: { message: "missing" },
+		});
+		await fixture.invokeTool({
+			id: "tool-call-completed-repeat",
+			status: "completed",
+			sessionID: "session-1",
+			tool: "read",
+			input: { path: "/repo/worktree/file.ts" },
+			result: { content: "ok" },
+		});
+
+		expect(runtime.handleToolResult).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({ id: "tool-call-completed", tool: "read" }),
+			{ output: "ok", error: null },
+		);
+		expect(runtime.handleToolResult).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({ id: "tool-call-failed", tool: "read" }),
+			{ output: null, error: { message: "missing" } },
+		);
+		expect(runtime.handleToolResult).toHaveBeenNthCalledWith(
+			3,
+			expect.objectContaining({ id: "tool-call-completed-repeat", tool: "read" }),
+			{ output: "ok", error: null },
+		);
+		await cleanup?.();
+	});
+
+	it("preserves failed status when malformed input omits error details", () => {
+		const translated = adapter.translateV2ToolResult({
+			status: "error",
+			sessionID: "session-1",
+			tool: "read",
+			input: {},
+		});
+
+		expect(translated.output).toEqual({
+			output: null,
+			error: {
+				name: "CodememToolCaptureError",
+				message: "OpenCode reported a failed tool without error details",
+			},
+		});
+	});
+});
+
+describe("OpenCode 2 adapter lifecycle", () => {
+	it("aborts event consumption and makes cleanup idempotent", async () => {
+		const runtime = makeRuntime();
+		const fixture = makeContext([{ type: "session.created", data: { sessionID: "session-1" } }]);
+		const createRuntime = vi.fn(async () => runtime);
+		const setup = adapter.createOpenCodeV2Adapter({ createRuntime });
+		const cleanup = await setup(fixture.context);
+		await vi.waitFor(() => {
+			expect(runtime.handleEvent).toHaveBeenCalledWith(
+				expect.objectContaining({ type: "session.created", sessionID: "session-1" }),
+			);
+		});
+
+		await Promise.all([cleanup?.(), cleanup?.()]);
+
+		expect(fixture.aborted.value).toBe(true);
+		expect(fixture.hookDispose).toHaveBeenCalledTimes(1);
+		expect(runtime.dispose).toHaveBeenCalledTimes(1);
+		expect(createRuntime).toHaveBeenCalledWith(
+			expect.objectContaining({
+				location: {
+					project: {
+						...fixture.context.location.project,
+						root: fixture.context.location.project.canonical,
+					},
+					directory: "/repo/worktree/nested",
+					worktree: "/repo/worktree",
+				},
+			}),
+		);
+	});
+
+	it("contains stream and capture failures with content-free diagnostics", async () => {
+		const runtime = makeRuntime();
+		runtime.handleEvent.mockRejectedValueOnce(new Error("capture failed"));
+		runtime.reportDiagnostic.mockImplementation(async () => new Promise(() => {}));
+		const waitForDiagnosticTask = vi.fn(async () => false);
+		const fixture = makeContext([{ type: "session.created", data: { sessionID: "session-1" } }], {
+			eventError: new Error("stream failed"),
+		});
+		const setup = adapter.createOpenCodeV2Adapter({
+			createRuntime: async () => runtime,
+			waitForDiagnosticTask,
+		});
+		const cleanup = await setup(fixture.context);
+		await vi.waitFor(() => {
+			expect(runtime.reportDiagnostic).toHaveBeenCalledWith("v2_event_stream_failed");
+		});
+
+		await expect(cleanup?.()).resolves.toBeUndefined();
+		expect(waitForDiagnosticTask).toHaveBeenCalledTimes(2);
+		expect(runtime.dispose).toHaveBeenCalledOnce();
+		expect(runtime.reportDiagnostic).toHaveBeenCalledWith("v2_event_capture_failed");
+		expect(runtime.reportDiagnostic).toHaveBeenCalledWith("v2_event_stream_failed");
+	});
+
+	it("reports tool capture failures without changing tool outcomes", async () => {
+		const runtime = makeRuntime();
+		runtime.handleToolResult.mockRejectedValueOnce(new Error("capture failed"));
+		runtime.reportDiagnostic.mockImplementation(async () => new Promise(() => {}));
+		const waitForDiagnosticTask = vi.fn(async () => false);
+		const fixture = makeContext();
+		const setup = adapter.createOpenCodeV2Adapter({
+			createRuntime: async () => runtime,
+			waitForDiagnosticTask,
+		});
+		const cleanup = await setup(fixture.context);
+
+		await expect(
+			fixture.invokeTool({
+				status: "completed",
+				sessionID: "session-1",
+				tool: "read",
+				input: {},
+				result: { output: "ok" },
+			}),
+		).resolves.toBeUndefined();
+		expect(waitForDiagnosticTask).toHaveBeenCalledOnce();
+		expect(runtime.reportDiagnostic).toHaveBeenCalledWith("v2_tool_capture_failed");
+		await cleanup?.();
+	});
+});
+
+describe("OpenCode 2 adapter capture ordering", () => {
+	it("keeps later events behind a capture that exceeded the host timeout", async () => {
+		const runtime = makeRuntime();
+		let releaseFirstCapture: (() => void) | undefined;
+		runtime.handleEvent.mockImplementationOnce(
+			async () =>
+				new Promise<undefined>((resolve) => {
+					releaseFirstCapture = () => resolve(undefined);
+				}),
+		);
+		const fixture = makeContext([
+			{ type: "session.created", data: { sessionID: "session-1" } },
+			{ type: "session.execution.succeeded", data: { sessionID: "session-1" } },
+		]);
+		const setup = adapter.createOpenCodeV2Adapter({
+			createRuntime: async () => runtime,
+			eventTaskTimeoutMs: 5,
+		});
+		const cleanup = await setup(fixture.context);
+		await vi.waitFor(() => expect(runtime.handleEvent).toHaveBeenCalledOnce());
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(runtime.handleEvent).toHaveBeenCalledOnce();
+		expect(runtime.reportDiagnostic).toHaveBeenCalledWith("v2_event_capture_failed");
+
+		releaseFirstCapture?.();
+		await vi.waitFor(() => expect(runtime.handleEvent).toHaveBeenCalledTimes(2));
+		await cleanup?.();
+	});
+
+	it("keeps tool captures behind an event that exceeded the host timeout", async () => {
+		const runtime = makeRuntime();
+		let releaseEventCapture: (() => void) | undefined;
+		runtime.handleEvent.mockImplementationOnce(
+			async () =>
+				new Promise<undefined>((resolve) => {
+					releaseEventCapture = () => resolve(undefined);
+				}),
+		);
+		const fixture = makeContext([{ type: "session.created", data: { sessionID: "session-1" } }]);
+		const setup = adapter.createOpenCodeV2Adapter({
+			createRuntime: async () => runtime,
+			eventTaskTimeoutMs: 5,
+		});
+		const cleanup = await setup(fixture.context);
+		await vi.waitFor(() => expect(runtime.handleEvent).toHaveBeenCalledOnce());
+
+		await fixture.invokeTool({
+			status: "completed",
+			sessionID: "session-1",
+			tool: "read",
+			input: {},
+			result: { output: "ok" },
+		});
+		expect(runtime.handleToolResult).not.toHaveBeenCalled();
+
+		releaseEventCapture?.();
+		await vi.waitFor(() => expect(runtime.handleToolResult).toHaveBeenCalledOnce());
+		await cleanup?.();
+	});
+
+	it("keeps events behind a tool capture that exceeded the host timeout", async () => {
+		const runtime = makeRuntime();
+		let releaseToolCapture: (() => void) | undefined;
+		let releaseEvent: (() => void) | undefined;
+		runtime.handleToolResult.mockImplementationOnce(
+			async () =>
+				new Promise<undefined>((resolve) => {
+					releaseToolCapture = () => resolve(undefined);
+				}),
+		);
+		const fixture = makeContext();
+		fixture.context.event.subscribe = async function* ({ signal }: { signal: AbortSignal }) {
+			await new Promise<void>((resolve) => {
+				releaseEvent = resolve;
+			});
+			if (signal.aborted) return;
+			yield { type: "session.created", data: { sessionID: "session-1" } };
+		};
+		const setup = adapter.createOpenCodeV2Adapter({
+			createRuntime: async () => runtime,
+			eventTaskTimeoutMs: 5,
+		});
+		const cleanup = await setup(fixture.context);
+
+		await fixture.invokeTool({
+			status: "completed",
+			sessionID: "session-1",
+			tool: "read",
+			input: {},
+			result: { output: "ok" },
+		});
+		releaseEvent?.();
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(runtime.handleEvent).not.toHaveBeenCalled();
+
+		releaseToolCapture?.();
+		await vi.waitFor(() => expect(runtime.handleEvent).toHaveBeenCalledOnce());
+		await cleanup?.();
+	});
+});
+
+describe("OpenCode 2 adapter capture timeout", () => {
+	it("bounds stalled tool capture without holding the host hook", async () => {
+		const runtime = makeRuntime();
+		let releaseCapture: (() => void) | undefined;
+		runtime.handleToolResult.mockImplementation(
+			async () =>
+				new Promise<undefined>((resolve) => {
+					releaseCapture = () => resolve(undefined);
+				}),
+		);
+		const waitForCaptureTask = vi.fn(async () => false);
+		const fixture = makeContext();
+		const setup = adapter.createOpenCodeV2Adapter({
+			createRuntime: async () => runtime,
+			waitForCaptureTask,
+		});
+		const cleanup = await setup(fixture.context);
+
+		await expect(
+			fixture.invokeTool({
+				status: "completed",
+				sessionID: "session-1",
+				tool: "read",
+				input: {},
+				result: { output: "ok" },
+			}),
+		).resolves.toBeUndefined();
+
+		expect(waitForCaptureTask).toHaveBeenCalledOnce();
+		expect(runtime.reportDiagnostic).toHaveBeenCalledWith("v2_tool_capture_failed");
+		releaseCapture?.();
+		await cleanup?.();
+	});
+});
+
+describe("OpenCode 2 adapter setup", () => {
+	it("disposes the runtime after partial setup failure", async () => {
+		const runtime = makeRuntime();
+		const fixture = makeContext([], { hookError: new Error("hook unavailable") });
+		const setup = adapter.createOpenCodeV2Adapter({ createRuntime: async () => runtime });
+
+		await expect(setup(fixture.context)).rejects.toThrow("hook unavailable");
+		expect(runtime.dispose).toHaveBeenCalledOnce();
+	});
+
+	it("skips hook registration when the shared runtime rejects activation", async () => {
+		const fixture = makeContext();
+		const setup = adapter.createOpenCodeV2Adapter({ createRuntime: async () => null });
+
+		expect(await setup(fixture.context)).toBeUndefined();
+		expect(fixture.context.tool.hook).not.toHaveBeenCalled();
+	});
+});
+
+describe("OpenCode 2 adapter cleanup timeout", () => {
+	it("deactivates the runtime before disposing around a stalled event handler", async () => {
+		const runtime = makeRuntime();
+		let releaseCapture: (() => void) | undefined;
+		let active = true;
+		runtime.deactivate.mockImplementation(() => {
+			active = false;
+		});
+		runtime.handleEvent.mockImplementation(
+			async () =>
+				new Promise<undefined>((resolve) => {
+					releaseCapture = () => {
+						if (active) throw new Error("stale event handler remained active");
+						resolve(undefined);
+					};
+				}),
+		);
+		const waitForCaptureTask = vi.fn(async () => false);
+		const fixture = makeContext([{ type: "session.created", data: { sessionID: "session-1" } }]);
+		const setup = adapter.createOpenCodeV2Adapter({
+			createRuntime: async () => runtime,
+			waitForCaptureTask,
+		});
+		const cleanup = await setup(fixture.context);
+		await vi.waitFor(() => expect(runtime.handleEvent).toHaveBeenCalledOnce());
+
+		await cleanup?.();
+		releaseCapture?.();
+
+		expect(runtime.deactivate).toHaveBeenCalledOnce();
+		expect(runtime.deactivate.mock.invocationCallOrder[0]).toBeLessThan(
+			runtime.dispose.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+		);
+	});
+
+	it("bounds stalled runtime disposal during cleanup", async () => {
+		const runtime = makeRuntime();
+		runtime.dispose.mockImplementation(async () => new Promise<undefined>(() => {}));
+		const waitForRuntimeDisposalTask = vi.fn(async () => false);
+		const fixture = makeContext();
+		const setup = adapter.createOpenCodeV2Adapter({
+			createRuntime: async () => runtime,
+			waitForRuntimeDisposalTask,
+		});
+		const cleanup = await setup(fixture.context);
+
+		const result = await Promise.race([
+			cleanup?.().then(() => "completed"),
+			new Promise((resolve) => setTimeout(() => resolve("timed-out"), 25)),
+		]);
+
+		expect(result).toBe("completed");
+		expect(waitForRuntimeDisposalTask).toHaveBeenCalledOnce();
+		expect(runtime.reportDiagnostic).toHaveBeenCalledWith("v2_runtime_cleanup_timeout");
+	});
+});
+
+describe("OpenCode 2 registration and stream cleanup timeout", () => {
+	it("releases runtime ownership after bounded cleanup of a stuck registration", async () => {
+		const runtime = makeRuntime();
+		runtime.reportDiagnostic.mockImplementation(async () => new Promise(() => {}));
+		const waitForDiagnosticTask = vi.fn(async () => false);
+		const waitForRegistrationTask = vi.fn(async () => false);
+		const setup = adapter.createOpenCodeV2Adapter({
+			createRuntime: async () => runtime,
+			waitForDiagnosticTask,
+			waitForRegistrationTask,
+		});
+		const fixture = makeContext([], { stuckDispose: true });
+		const cleanup = await setup(fixture.context);
+
+		const result = await Promise.race([
+			cleanup?.().then(() => "completed"),
+			new Promise((resolve) => setTimeout(() => resolve("timed-out"), 25)),
+		]);
+
+		expect(result).toBe("completed");
+		expect(waitForDiagnosticTask).toHaveBeenCalledOnce();
+		expect(waitForRegistrationTask).toHaveBeenCalledOnce();
+		expect(runtime.reportDiagnostic).toHaveBeenCalledWith("v2_registration_cleanup_timeout");
+		expect(runtime.dispose).toHaveBeenCalledOnce();
+		await fixture.invokeTool({
+			status: "completed",
+			sessionID: "session-1",
+			tool: "read",
+			input: {},
+			result: { output: "late" },
+		});
+		expect(runtime.handleToolResult).not.toHaveBeenCalled();
+	});
+
+	it("releases runtime ownership after bounded cleanup of a stuck stream", async () => {
+		const firstRuntime = makeRuntime();
+		firstRuntime.reportDiagnostic.mockImplementation(async () => new Promise(() => {}));
+		const reloadedRuntime = makeRuntime();
+		const runtimes = [firstRuntime, reloadedRuntime];
+		const waitForDiagnosticTask = vi.fn(async () => false);
+		const waitForEventTask = vi.fn(async () => false);
+		const setup = adapter.createOpenCodeV2Adapter({
+			createRuntime: vi.fn(async () => runtimes.shift()),
+			waitForDiagnosticTask,
+			waitForEventTask,
+		});
+		const first = makeContext([], { stuck: true });
+		const cleanup = await setup(first.context);
+
+		await cleanup?.();
+		const reloaded = makeContext();
+		const reloadedCleanup = await setup(reloaded.context);
+		const hookDisposeOrder = first.hookDispose.mock.invocationCallOrder[0];
+		const runtimeDisposeOrder = firstRuntime.dispose.mock.invocationCallOrder[0];
+		if (hookDisposeOrder === undefined || runtimeDisposeOrder === undefined) {
+			throw new Error("Expected hook and runtime disposal calls");
+		}
+
+		expect(hookDisposeOrder).toBeLessThan(runtimeDisposeOrder);
+		expect(waitForDiagnosticTask).toHaveBeenCalledOnce();
+		expect(firstRuntime.reportDiagnostic).toHaveBeenCalledWith("v2_event_stream_cleanup_timeout");
+		expect(reloaded.context.tool.hook).toHaveBeenCalled();
+		await reloadedCleanup?.();
+	});
+
+	it("ignores a terminal step yielded after bounded cleanup completes", async () => {
+		const runtime = makeRuntime();
+		let releaseDelayedEvent: (() => void) | undefined;
+		let markWaiting: (() => void) | undefined;
+		let markDone: (() => void) | undefined;
+		const waiting = new Promise<void>((resolve) => {
+			markWaiting = resolve;
+		});
+		const done = new Promise<void>((resolve) => {
+			markDone = resolve;
+		});
+		const context = {
+			location: {
+				directory: "/repo/worktree",
+				project: { id: "project", directory: "/repo/worktree", canonical: "/repo" },
+			},
+			event: {
+				subscribe: async function* () {
+					try {
+						yield {
+							type: "session.step.ended",
+							data: {
+								sessionID: "session-1",
+								assistantMessageID: "message-1",
+								finish: "tool-calls",
+								tokens: { input: 2, output: 1 },
+							},
+						};
+						await new Promise<void>((resolve) => {
+							releaseDelayedEvent = resolve;
+							markWaiting?.();
+						});
+						yield {
+							type: "session.step.ended",
+							data: {
+								sessionID: "session-1",
+								assistantMessageID: "message-1",
+								finish: "stop",
+								tokens: { input: 3, output: 4 },
+							},
+						};
+					} finally {
+						markDone?.();
+					}
+				},
+			},
+			tool: {
+				hook: vi.fn(async () => ({ dispose: vi.fn(async () => undefined) })),
+			},
+		};
+		const setup = adapter.createOpenCodeV2Adapter({
+			createRuntime: async () => runtime,
+			waitForEventTask: async () => false,
+		});
+		const cleanup = await setup(context);
+		await waiting;
+
+		await cleanup?.();
+		releaseDelayedEvent?.();
+		await done;
+
+		expect(runtime.handleEvent).not.toHaveBeenCalled();
+		expect(runtime.dispose).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/opencode-plugin/src/opencode-v2-contract-fixture.test.ts
+++ b/packages/opencode-plugin/src/opencode-v2-contract-fixture.test.ts
@@ -81,6 +81,26 @@ function makeContext(
 				[
 					{ type: "server.connected" },
 					{ type: "session.created", properties: { id: "redacted" } },
+					{
+						type: "session.inbox.enqueued",
+						data: {
+							sessionID: "session-a",
+							inboxID: "message-a",
+							item: { type: "user", payload: { text: "must-not-be-recorded" } },
+						},
+					},
+					{
+						type: "session.step.ended",
+						data: {
+							sessionID: "session-a",
+							assistantMessageID: "message-b",
+							finish: "stop",
+							tokens: { input: 1, output: 1 },
+						},
+					},
+					{ type: "session.execution.succeeded", data: { sessionID: "session-a" } },
+					{ type: "session.execution.failed", data: { sessionID: "session-a" } },
+					{ type: "session.execution.interrupted", data: { sessionID: "session-a" } },
 					{ type: "message.updated", properties: { content: "must-not-be-recorded" } },
 					{ type: "tool.updated", properties: { result: "must-not-be-recorded" } },
 				],
@@ -243,11 +263,46 @@ async function executeLifecycleContract() {
 	return { contextInput, fixture, records };
 }
 
+function expectCapturedEventShapes(records: ContractRecord[]) {
+	const eventRecords = records.filter((record) => record.phase === "event");
+	expect(eventRecords.map((record) => record.family)).toEqual([
+		"generic",
+		"session",
+		"session",
+		"session",
+		"session",
+		"session",
+		"session",
+		"message",
+		"tool",
+	]);
+	expect(eventRecords).toEqual(
+		expect.arrayContaining([
+			expect.objectContaining({
+				type: "session.inbox.enqueued",
+				hasInboxID: true,
+				hasSessionID: true,
+				hasTextPayload: true,
+				isUserItem: true,
+			}),
+			expect.objectContaining({
+				type: "session.step.ended",
+				finish: "stop",
+				hasAssistantMessageID: true,
+				hasFinish: true,
+				hasSessionID: true,
+				hasTokens: true,
+			}),
+			expect.objectContaining({ type: "session.execution.succeeded", hasSessionID: true }),
+			expect.objectContaining({ type: "session.execution.failed", hasSessionID: true }),
+			expect.objectContaining({ type: "session.execution.interrupted", hasSessionID: true }),
+		]),
+	);
+	expect(JSON.stringify(eventRecords)).not.toContain("must-not-be-recorded");
+}
+
 describe("OpenCode 2 executable fixture", () => {
 	it("observes location, options, storage, events, hooks, tools, and deterministic cleanup", async () => {
-		// Arrange
-		const expectedEventFamilies = ["generic", "session", "message", "tool"];
-
 		// Act
 		const { contextInput, fixture, records } = await executeLifecycleContract();
 
@@ -326,11 +381,11 @@ describe("OpenCode 2 executable fixture", () => {
 		expect(contextInput.providerOptions.codememContract).toBe(true);
 		expect(fixture.aborted.value).toBe(true);
 		expect(fixture.disposals.every((dispose) => dispose.mock.calls.length === 1)).toBe(true);
-		const eventRecords = records.filter((record) => record.phase === "event");
-		expect(eventRecords.map((record) => record.family)).toEqual(expectedEventFamilies);
-		expect(JSON.stringify(eventRecords)).not.toContain("must-not-be-recorded");
+		expectCapturedEventShapes(records);
 	});
+});
 
+describe("OpenCode 2 fixture cleanup", () => {
 	it("disposes completed registrations when setup fails", async () => {
 		// Arrange
 		const fixture = makeContext({ failToolHook: true });

--- a/packages/opencode-plugin/src/opencode-v2-contract-fixture.ts
+++ b/packages/opencode-plugin/src/opencode-v2-contract-fixture.ts
@@ -32,11 +32,37 @@ export function summarizeEvent(event: unknown): ContractRecord {
 	const candidate = event as Record<string, unknown>;
 	const type = typeof candidate.type === "string" ? candidate.type : "unknown";
 	const family = ["session", "message", "tool"].find((prefix) => type.startsWith(`${prefix}.`));
-	return {
+	const summary: ContractRecord = {
 		family: family ?? "generic",
 		type,
 		hasProperties: candidate.properties != null,
 	};
+	const data = candidate.data as Record<string, unknown> | undefined;
+	if (type === "session.inbox.enqueued") {
+		const item = data?.item as Record<string, unknown> | undefined;
+		const payload = item?.payload as Record<string, unknown> | undefined;
+		return {
+			...summary,
+			hasInboxID: typeof data?.inboxID === "string",
+			hasSessionID: typeof data?.sessionID === "string",
+			hasTextPayload: typeof payload?.text === "string",
+			isUserItem: item?.type === "user",
+		};
+	}
+	if (type === "session.step.ended") {
+		return {
+			...summary,
+			finish: typeof data?.finish === "string" ? data.finish : null,
+			hasAssistantMessageID: typeof data?.assistantMessageID === "string",
+			hasFinish: typeof data?.finish === "string",
+			hasSessionID: typeof data?.sessionID === "string",
+			hasTokens: data?.tokens != null && typeof data.tokens === "object",
+		};
+	}
+	if (type.startsWith("session.execution.")) {
+		return { ...summary, hasSessionID: typeof data?.sessionID === "string" };
+	}
+	return summary;
 }
 
 function defaultReporter(record: ContractRecord) {

--- a/packages/opencode-plugin/src/package-entrypoint.test.ts
+++ b/packages/opencode-plugin/src/package-entrypoint.test.ts
@@ -27,7 +27,7 @@ it("exports one typed dual-host object while retaining V1 compatibility names", 
 	expect(entrypoint.id).toBe("codemem");
 	expect(entrypoint.server).toBe(CodememPlugin);
 	expect(OpencodeMemPlugin).toBe(CodememPlugin);
-	expect(await entrypoint.setup({} as OpenCodeV2.Context)).toBeUndefined();
+	expect(entrypoint.setup).toBeTypeOf("function");
 });
 
 it("keeps the OpenCode 1 SDK manifests aligned with the supported host floor", async () => {

--- a/packages/opencode-plugin/src/runtime-boundary.test.ts
+++ b/packages/opencode-plugin/src/runtime-boundary.test.ts
@@ -1,7 +1,8 @@
-import { readdir, readFile } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const packageRoot = path.resolve(import.meta.dirname, "..");
 const pluginRoot = path.join(packageRoot, ".opencode", "plugins");
@@ -9,6 +10,54 @@ const helperRoot = path.join(packageRoot, ".opencode", "lib");
 
 const readPluginFile = (name: string) => readFile(path.join(pluginRoot, name), "utf8");
 const readHelperFile = (name: string) => readFile(path.join(helperRoot, name), "utf8");
+
+async function createRuntimeFixture(options: { rawEvents?: boolean; homeDir?: string } = {}) {
+	vi.stubEnv("CODEMEM_RAW_EVENTS", options.rawEvents ? "1" : "0");
+	if (options.homeDir) vi.stubEnv("HOME", options.homeDir);
+	vi.stubEnv("CODEMEM_VIEWER", "0");
+	vi.stubEnv("CODEMEM_VIEWER_AUTO", "0");
+	vi.stubEnv("CODEMEM_BACKEND_UPDATE_POLICY", "off");
+	vi.stubEnv("CODEMEM_RUNNER", "/usr/bin/true");
+	const runtimeUrl = pathToFileURL(path.join(helperRoot, "runtime.js")).href;
+	const { createCodememRuntime } = await import(runtimeUrl);
+	const runtime = await createCodememRuntime({
+		location: {
+			project: { name: "runtime-boundary", root: packageRoot },
+			directory: packageRoot,
+			worktree: packageRoot,
+		},
+		host: { log: async () => undefined, notify: null },
+	});
+	if (!runtime) throw new Error("Expected runtime fixture to activate");
+	return runtime;
+}
+
+const userMessage = (messageID: string, sessionID = "session-1") => ({
+	type: "message.updated",
+	sessionID,
+	messageInfo: { id: messageID, role: "user", sessionID },
+});
+
+const textPart = (messageID: string, id: string, text: string, sessionID = "session-1") => ({
+	type: "message.part.updated",
+	sessionID,
+	part: { id, messageID, sessionID, type: "text", text },
+});
+
+const assistantBoundary = (messageID: string, sessionID = "session-1") => ({
+	type: "message.updated",
+	sessionID,
+	messageInfo: { id: messageID, role: "assistant", sessionID },
+});
+
+async function addPrompt(
+	runtime: Awaited<ReturnType<typeof createRuntimeFixture>>,
+	messageID: string,
+) {
+	await runtime.handleEvent(userMessage(messageID));
+	await runtime.handleEvent(textPart(messageID, `${messageID}-part-1`, "First"));
+	await runtime.handleEvent(textPart(messageID, `${messageID}-part-2`, " second"));
+}
 
 describe("shared runtime boundary", () => {
 	it("keeps helper modules outside OpenCode's auto-load directory", async () => {
@@ -39,7 +88,234 @@ describe("shared runtime boundary", () => {
 
 		expect(typeof runtime.createCodememRuntime).toBe("function");
 	});
+});
 
+describe("shared runtime prompt capture", () => {
+	it("releases buffered prompt parts at an execution boundary", async () => {
+		const runtime = await createRuntimeFixture();
+
+		try {
+			await addPrompt(runtime, "message-1");
+
+			expect(runtime.inspectBufferedPromptPartCount()).toBe(2);
+			await runtime.handleEvent({ type: "session.idle", sessionID: "session-1" });
+			expect(runtime.inspectBufferedPromptPartCount()).toBe(0);
+			expect(runtime.inspectCapturedPromptCount()).toBe(1);
+		} finally {
+			await runtime.dispose();
+			vi.unstubAllEnvs();
+		}
+	});
+
+	it("captures multipart OpenCode 1 messages once with their complete text", async () => {
+		const runtime = await createRuntimeFixture();
+		const adapterUrl = pathToFileURL(path.join(pluginRoot, "codemem.js")).href;
+		const adapter = await import(adapterUrl);
+
+		try {
+			await runtime.handleEvent(
+				adapter.__v1AdapterTestUtils.translateV1Event({
+					type: "message.updated",
+					properties: { info: userMessage("message-1").messageInfo },
+				}),
+			);
+			for (const [id, text] of [
+				["part-1", "First"],
+				["part-2", " second"],
+			] as const) {
+				await runtime.handleEvent(
+					adapter.__v1AdapterTestUtils.translateV1Event({
+						type: "message.part.updated",
+						properties: { part: textPart("message-1", id, text).part },
+					}),
+				);
+			}
+			await runtime.handleEvent(assistantBoundary("message-2"));
+
+			expect(runtime.inspectQueuedPrompts()).toEqual([{ number: 1, text: "First second" }]);
+		} finally {
+			await runtime.dispose();
+			vi.unstubAllEnvs();
+		}
+	});
+});
+
+describe("shared runtime prompt boundaries", () => {
+	it("captures pending prompts before tool results", async () => {
+		const runtime = await createRuntimeFixture();
+		try {
+			await addPrompt(runtime, "message-1");
+			await runtime.handleToolResult(
+				{ sessionID: "session-1", tool: "read", args: {} },
+				{ output: "ok", error: null },
+			);
+
+			expect(runtime.inspectQueuedEventTypes()).toEqual(["user_prompt", "tool.execute.after"]);
+		} finally {
+			await runtime.dispose();
+			vi.unstubAllEnvs();
+		}
+	});
+
+	it("numbers two multipart prompts once each", async () => {
+		const runtime = await createRuntimeFixture();
+		try {
+			await addPrompt(runtime, "message-1");
+			await runtime.handleEvent(assistantBoundary("assistant-1"));
+			await addPrompt(runtime, "message-2");
+			await runtime.handleEvent(assistantBoundary("assistant-2"));
+
+			expect(runtime.inspectQueuedPrompts()).toEqual([
+				{ number: 1, text: "First second" },
+				{ number: 2, text: "First second" },
+			]);
+		} finally {
+			await runtime.dispose();
+			vi.unstubAllEnvs();
+		}
+	});
+
+	it("captures a /new prompt once across concurrent V1 boundaries", async () => {
+		const runtime = await createRuntimeFixture();
+		try {
+			await runtime.handleEvent(userMessage("message-1"));
+			await runtime.handleEvent(textPart("message-1", "part-1", "/new"));
+
+			await Promise.all([
+				runtime.handleEvent(assistantBoundary("assistant-1")),
+				runtime.handleToolResult(
+					{ sessionID: "session-1", tool: "read", args: {} },
+					{ output: "ok", error: null },
+				),
+			]);
+
+			expect(runtime.inspectQueuedPrompts()).toEqual([{ number: 1, text: "/new" }]);
+		} finally {
+			await runtime.dispose();
+			vi.unstubAllEnvs();
+		}
+	});
+
+	it("captures a pending prompt during disposal", async () => {
+		const runtime = await createRuntimeFixture();
+		try {
+			await addPrompt(runtime, "message-1");
+			await runtime.dispose();
+
+			expect(runtime.inspectQueuedPrompts()).toEqual([{ number: 1, text: "First second" }]);
+		} finally {
+			await runtime.dispose();
+			vi.unstubAllEnvs();
+		}
+	});
+});
+
+describe("shared runtime disposal durability", () => {
+	it("durably spools a pending prompt before disposal completes", async () => {
+		const homeDir = await mkdtemp(path.join(tmpdir(), "codemem-runtime-disposal-"));
+		const fetchMock = vi.fn(async () => new Promise<Response>(() => {}));
+		vi.stubGlobal("fetch", fetchMock);
+		const runtime = await createRuntimeFixture({ rawEvents: true, homeDir });
+		const spoolUrl = pathToFileURL(path.join(helperRoot, "raw-event-spool.js")).href;
+		const { loadRawEventSpoolEntries } = await import(spoolUrl);
+
+		try {
+			await addPrompt(runtime, "message-1");
+			await runtime.dispose();
+
+			expect(fetchMock).not.toHaveBeenCalled();
+			const spool = await loadRawEventSpoolEntries({ homeDir });
+			expect(
+				spool.entries.some(
+					(entry: { envelope: { event_type?: string } }) =>
+						entry.envelope.event_type === "user_prompt",
+				),
+			).toBe(true);
+		} finally {
+			await runtime.dispose();
+			vi.unstubAllGlobals();
+			vi.unstubAllEnvs();
+			await rm(homeDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("shared runtime deactivation", () => {
+	it("makes in-flight capture continuations inert after deactivation", async () => {
+		const runtime = await createRuntimeFixture();
+		try {
+			await addPrompt(runtime, "message-1");
+			runtime.deactivate();
+			await runtime.handleEvent(assistantBoundary("assistant-1"));
+			await runtime.handleToolResult(
+				{ sessionID: "session-1", tool: "read", args: {} },
+				{ output: "late", error: null },
+			);
+			await runtime.dispose();
+
+			expect(runtime.inspectQueuedEventTypes()).toEqual(["user_prompt"]);
+		} finally {
+			await runtime.dispose();
+			vi.unstubAllEnvs();
+		}
+	});
+
+	it("spools an in-flight raw-event batch when deactivation aborts transport", async () => {
+		const homeDir = await mkdtemp(path.join(tmpdir(), "codemem-runtime-boundary-"));
+		const postSignals: AbortSignal[] = [];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (_url: string, init?: RequestInit) => {
+				if (init?.method === "GET") {
+					return new Response(JSON.stringify({ ingest: { available: true } }), {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+				const signal = init?.signal;
+				if (!signal) throw new Error("Expected raw-event POST abort signal");
+				postSignals.push(signal);
+				return new Promise<Response>((_resolve, reject) => {
+					signal.addEventListener(
+						"abort",
+						() => reject(new DOMException("aborted", "AbortError")),
+						{ once: true },
+					);
+				});
+			}),
+		);
+		const runtime = await createRuntimeFixture({ rawEvents: true, homeDir });
+		const spoolUrl = pathToFileURL(path.join(helperRoot, "raw-event-spool.js")).href;
+		const { loadRawEventSpoolEntries } = await import(spoolUrl);
+
+		try {
+			await addPrompt(runtime, "message-1");
+			const idleTask = runtime.handleEvent({ type: "session.idle", sessionID: "session-1" });
+			await vi.waitFor(() => expect(postSignals.length).toBeGreaterThan(0));
+
+			runtime.deactivate();
+			await runtime.dispose();
+			await idleTask;
+
+			await vi.waitFor(async () => {
+				const spool = await loadRawEventSpoolEntries({ homeDir });
+				expect(
+					spool.entries.some(
+						(entry: { envelope: { event_type?: string } }) =>
+							entry.envelope.event_type === "user_prompt",
+					),
+				).toBe(true);
+			});
+		} finally {
+			await runtime.dispose();
+			vi.unstubAllGlobals();
+			vi.unstubAllEnvs();
+			await rm(homeDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("shared runtime boundary adapters", () => {
 	it("translates OpenCode 1 events into the runtime contract", async () => {
 		const adapterUrl = pathToFileURL(path.join(pluginRoot, "codemem.js")).href;
 		const adapter = await import(adapterUrl);


### PR DESCRIPTION
## Description

Add OpenCode 2 capture and lifecycle support while preserving the OpenCode 1 adapter. Normalize prompt, assistant, usage, tool, and terminal events through the shared runtime; bound cleanup and diagnostics; and prove packed V1/V2 capture parity.

OpenCode 2 automatic recall and memory tools remain deferred to the next PR.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (pnpm run tsc, pnpm run lint, pnpm run test)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected
- [x] pnpm --filter codemem test:plugin
- [x] pnpm --filter @codemem/opencode-plugin test:packed-artifact
- [x] pnpm --filter @codemem/opencode-plugin test:opencode-v2-contract

## Checklist

- [x] Code follows project style (pnpm run lint passes for touched files)
- [x] Self-review completed
- [x] Documentation updated
- [x] No new warnings introduced