### PR TITLE
feat(opencode): expose v2 memory tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ covers macOS x64/arm64, Linux x64/arm64 (glibc 2.34+ or musl), and Windows x64.
 Codemem requires OpenCode 1.18.29 or newer.
 
 The experimental OpenCode 2 beta entrypoint captures user and assistant messages,
-terminal usage, tool results, and session lifecycle events. It does not yet inject
-automatic recall or expose memory tools; those remain OpenCode 1 features.
+terminal usage, tool results, and session lifecycle events. It also exposes the
+manual `mem-status`, `mem-recent`, and `mem-stats` tools. Automatic recall remains
+an OpenCode 1 feature because the V2 context hook has no request kind or request ID.
 
 1. Install the OpenCode plugin and MCP config:
 
@@ -197,7 +198,9 @@ Codex hook ingestion shares the same raw-event pipeline as Claude and OpenCode t
 
 Adapters hook into runtime event systems (the OpenCode 1 plugin and Claude hooks). They capture tool calls and conversation messages, flush them through an observer pipeline that produces typed memories, and surface retrieval context for future prompts.
 
-> The workflow below describes OpenCode 1 recall. OpenCode 2 currently captures activity and manages lifecycle cleanup, but it does not inject automatic recall or expose memory tools.
+> The workflow below describes OpenCode 1 recall. OpenCode 2 captures activity,
+> manages lifecycle cleanup, and exposes manual memory tools, but it does not inject
+> automatic recall because its context hook cannot identify the request safely.
 
 ```mermaid
 sequenceDiagram

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,7 +60,7 @@ Support tiers describe operational expectations for each adapter path:
 | Adapter | Tier | Notes |
 |---|---|---|
 | OpenCode 1 plugin | Supported | Primary reference adapter for lifecycle events and injection behavior. |
-| OpenCode 2 plugin | Experimental | The beta entrypoint captures conversation, tool, terminal usage, and lifecycle activity with bounded cleanup. Automatic recall and memory tools are not enabled. |
+| OpenCode 2 plugin | Experimental | The beta entrypoint captures conversation, tool, terminal usage, and lifecycle activity with bounded cleanup. It exposes manual `mem-status`, `mem-recent`, and `mem-stats` tools through `tool.transform` with `codemode: false`; automatic recall remains disabled because the context hook has no request kind or request ID. |
 | Claude hooks/plugin | Supported | Hook-first queue path with CLI/runtime fallback and parity slices tracked in adapter stack PRs. |
 | Codex plugin (hooks + MCP) | Supported | Functional capture pipeline (`plugins/codex/`, `packages/core/src/codex-hooks.ts`) dogfooded end-to-end: edge normalization → `POST /api/raw-events` → observer → memories. Prompt-time injection is present and env-gated but not fully validated on strict models. |
 | Windsurf integration | Experimental | Planned via shared adapter contract after OpenCode/Claude stabilization. |
@@ -185,7 +185,7 @@ flowchart TD
 
 ## Context injection
 
-The OpenCode 1 plugin injects a memory pack automatically on every turn. Volatile recall output is appended beside the latest user message by default so provider prompt caches can keep the stable system/history prefix. The experimental OpenCode 2 beta entrypoint captures activity and manages lifecycle cleanup, but it does not inject automatic recall or expose memory tools.
+The OpenCode 1 plugin injects a memory pack automatically on every turn. Volatile recall output is appended beside the latest user message by default so provider prompt caches can keep the stable system/history prefix. The experimental OpenCode 2 beta entrypoint captures activity, manages lifecycle cleanup, and exposes manual `mem-status`, `mem-recent`, and `mem-stats` tools through `tool.transform` with `codemode: false`. It does not inject automatic recall because the V2 context hook has no request kind or request ID, so compaction and transient safety cannot be guaranteed.
 
 ### Packaged Claude and Codex hooks
 

--- a/docs/opencode-retained-recall.md
+++ b/docs/opencode-retained-recall.md
@@ -1,6 +1,6 @@
 # OpenCode Retained Recall
 
-This retained-recall contract applies to the OpenCode 1 plugin. The experimental OpenCode 2 beta entrypoint captures activity and manages lifecycle cleanup, but it does not perform automatic recall or expose memory tools.
+This retained-recall contract applies to the OpenCode 1 plugin. The experimental OpenCode 2 beta entrypoint captures activity, manages lifecycle cleanup, and exposes manual `mem-status`, `mem-recent`, and `mem-stats` tools. It does not perform automatic recall because its context hook has no request kind or request ID, so compaction and transient safety cannot be guaranteed.
 
 Automatic message recall must preserve retained bytes and derive allowance from the current transform output, not a lifetime counter.
 

--- a/docs/opencode-v2-contract.md
+++ b/docs/opencode-v2-contract.md
@@ -2,9 +2,11 @@
 
 The pinned OpenCode 2 beta can load a TypeScript plugin fixture from Codemem's
 packed npm artifact, but its context-mutation hook cannot identify the request
-kind that caused each call. Codemem must therefore keep automatic recall
-disabled in the V2 adapter until the host exposes an unambiguous request identity
-or adds `kind` to that hook.
+that caused each call. A later development host separates primary context from
+auxiliary generation hooks and preserves IDs on the messages passed to each
+primary context call. Codemem must keep automatic recall disabled against the
+pinned beta, but a supported host with the development contract can correlate
+recall without a new top-level request ID once the correlation tests pass.
 
 ## Pinned test host
 
@@ -26,6 +28,36 @@ spike's published-file allowlist because the smoke must load them from the
 installed Codemem tarball. They are not exported as a supported consumer API.
 The production V2 entrypoint replaces this temporary package content in the
 later adapter PR.
+
+## Development host evaluation
+
+Development build `0.0.0-dev-19439`, produced from upstream commit
+`3edbc8822520e51dca9954b73e2712ecf2884443`, improves hook separation but does
+not replace the exact beta versions pinned by the repository. It is probe-only,
+not a supported production target.
+
+The disposable packed-host probe found:
+
+- `session.context` runs once for each primary model request, including an
+  accepted retry and a tool continuation. Each call receives a fresh mutable
+  request; a system marker added by one call does not appear in later calls.
+- Compaction, generation, and title use their dedicated session hooks rather
+  than `session.context`.
+- The runner intentionally combines overlapping steering prompts into one model
+  continuation. The context transcript retains a stable ID on every user
+  message, including the latest message used to key the turn. Retries and tool
+  continuations repeat that latest ID, which gives Codemem the stable replay key
+  it needs.
+- Setting `input.result` in the compaction and title hooks does not suppress the
+  corresponding model requests in this build. This does not match the documented
+  result short-circuit behavior.
+
+The source and tests confirm that prompt coalescing is intentional rather than a
+lost-identity defect. Codemem can treat the coalesced prompt set as one model
+turn, build new recall for its latest user-message ID, and replay that result
+when the same ID appears on retries or tool continuations. The V2 adapter still
+needs to translate the new message shape and remove assumptions tied to the V1
+prompt counter, but it does not need another host identity field for correctness.
 
 ## Verified surfaces
 
@@ -51,9 +83,10 @@ The fixture and its type-level tests verify these beta-19296 contracts:
   decision but no `kind` or request ID.
 - Tool completion hooks distinguish `completed` results from `error` outcomes
   and carry call, message, session, agent, tool, and input identity.
-- The packed-host smoke verifies that the fixture can declare the hyphenated
-  tool name `mem-status`. The transform API neither accepts an explicit custom
-  ID nor exposes the host-generated effective ID while adding the tool.
+- The packed-host smoke verifies that `tool.transform` with `codemode: false`
+  preserves the hyphenated `mem-status`, `mem-recent`, and `mem-stats` IDs. The
+  transform API neither accepts an explicit custom ID nor exposes the effective
+  ID while adding the tool.
 - The promise-plugin context used by Codemem exposes neither logging nor toast
   methods. The separate TUI plugin API exposes `ui.toast`, but that is not the
   adapter surface under test. The V2 promise adapter must retain local file
@@ -64,14 +97,21 @@ The fixture and its type-level tests verify these beta-19296 contracts:
 
 ## Automatic recall gate
 
-The context hook is Codemem's recall-injection point, but it identifies a request
-with only the tuple of session, agent, and model. Concurrent primary and
-auxiliary requests can share that tuple. The later model-request and HTTP hooks
-carry `kind`, and headers can preserve it downstream, but that cannot
-retroactively classify an earlier context mutation. Retry hooks also omit both
-request kind and request ID. Adjacency or timing cannot resolve the context-hook
-ambiguity without race conditions.
+The context hook is Codemem's recall-injection point, but the pinned beta
+identifies a request with only the tuple of session, agent, and model. Concurrent
+primary and auxiliary requests can share that tuple. The later model-request
+and HTTP hooks carry `kind`, and headers can preserve it downstream, but that
+cannot retroactively classify an earlier context mutation. Retry hooks also omit
+both request kind and request ID. Adjacency or timing cannot resolve the
+context-hook ambiguity without race conditions.
+
+The development host removes the auxiliary-request ambiguity by adding separate
+session hooks. Although `session.context` has no top-level request ID, each
+history-derived user message carries its own ID. That message identity is enough
+to correlate retrieval and replay because overlapping prompts are deliberately
+processed as one model turn.
 
 The V2 adapter may capture events and expose manual memory tools, but it must not
-inject automatic recall until a later pinned host contract passes concurrency,
+inject automatic recall against the current pinned beta. Recall can proceed once
+a supported pinned host exposes the split session hooks and passes concurrency,
 retry, auxiliary-generation, and compaction correlation tests.

--- a/docs/plans/2026-09-08-opencode-2-dual-support-design.md
+++ b/docs/plans/2026-09-08-opencode-2-dual-support-design.md
@@ -202,10 +202,10 @@ implementation spike will choose whether typed TypeScript source can be shipped
 directly to both hosts or must be compiled to JavaScript; the packed artifact,
 not only the workspace copy, decides that outcome.
 
-OpenCode 2 normalizes unsupported characters in tool names to underscores.
-Codemem will keep the V1 names stable and document V2's effective
-`mem_status`, `mem_recent`, and `mem_stats` IDs unless the spike finds a supported
-way to preserve the hyphenated names.
+At approval, the plan expected OpenCode 2 to normalize unsupported tool-name
+characters to underscores. The pinned packed-host result instead verifies that
+`tool.transform` with `codemode: false` preserves Codemem's hyphenated
+`mem-status`, `mem-recent`, and `mem-stats` IDs.
 
 ## Failure handling
 

--- a/docs/plans/2026-09-08-opencode-2-dual-support-implementation.md
+++ b/docs/plans/2026-09-08-opencode-2-dual-support-implementation.md
@@ -356,9 +356,9 @@ lifecycle cleanup are stable.
    transitions, measurements, and empty-pack behavior.
 6. Confirm that injected context affects only outbound model context and is not
    persisted as user-authored history.
-7. Register the memory tools with `ctx.tool.transform()`. Keep V1's hyphenated
-   names stable and use the V2 effective IDs proved by the spike, expected to be
-   `mem_status`, `mem_recent`, and `mem_stats`.
+7. Register the memory tools with `ctx.tool.transform()` using `codemode: false`.
+   The approved plan expected underscore V2 IDs; the pinned packed-host result
+   verifies that `mem-status`, `mem-recent`, and `mem-stats` are preserved.
 8. Keep retrieval and optional diagnostics fail-open without swallowing host
    contract defects in tests.
 

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -8,7 +8,7 @@ This page covers advanced plugin behavior, environment variables, and stream rel
 
 ## Running OpenCode 1 with the plugin
 
-OpenCode 1 supports the capture and recall behavior below. The experimental OpenCode 2 beta entrypoint captures user and assistant messages, terminal usage, tool results, and session lifecycle events, but it does not yet inject automatic recall or expose memory tools.
+OpenCode 1 supports the capture and recall behavior below. The experimental OpenCode 2 beta entrypoint captures user and assistant messages, terminal usage, tool results, and session lifecycle events. It exposes manual `mem-status`, `mem-recent`, and `mem-stats` tools through `tool.transform` with `codemode: false`, but automatic recall remains disabled because the V2 context hook has no request kind or request ID.
 
 1. Start OpenCode inside this repo (or make the plugin global so it globs in everywhere).
 2. Every tooling session creates memory artifacts in SQLite.
@@ -241,14 +241,15 @@ The plugin now passes that explicit host/port through when it auto-starts, healt
 
 If compatibility toasts appear after restart, follow the runner-specific guidance in Compatibility guidance behavior below.
 
-## OpenCode 1 plugin tools exposed to the model
+## OpenCode plugin tools exposed to the model
 
 - `mem-status` - show viewer URL, log path, stats, and recent entries.
 - `mem-stats` - show just the stats block.
 - `mem-recent` - show recent items (defaults to 5).
 
-These are plugin tools callable by the agent/runtime. They are not user-facing
-slash commands in the OpenCode chat input.
+These are plugin tools callable by the agent/runtime, not user-facing slash
+commands. OpenCode 2 registers the same hyphenated IDs through `tool.transform`
+with `codemode: false`; a packed-host smoke test verifies the IDs are preserved.
 
 ## MCP tools exposed to agents
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -179,7 +179,7 @@ Command/file token caching notes:
 - Low-signal observations are filtered before writing.
 
 ## Automatic context injection
-- The OpenCode 1 plugin injects a memory pack next to the latest user message by default, keeping older prompt prefixes stable for provider prompt caches. The experimental OpenCode 2 beta entrypoint captures activity and manages lifecycle cleanup, but it does not inject automatic recall or expose memory tools.
+- The OpenCode 1 plugin injects a memory pack next to the latest user message by default, keeping older prompt prefixes stable for provider prompt caches. The experimental OpenCode 2 beta entrypoint captures activity, manages lifecycle cleanup, and exposes manual `mem-status`, `mem-recent`, and `mem-stats` tools through `tool.transform` with `codemode: false`. It does not inject automatic recall because the V2 context hook has no request kind or request ID, so compaction and transient safety cannot be guaranteed.
 - Controls:
   - `CODEMEM_INJECT_CONTEXT=0` disables injection.
   - `CODEMEM_INJECT_SURFACE=system` uses the legacy OpenCode system-prompt injection surface.

--- a/packages/opencode-plugin/.opencode/lib/opencode-v2-adapter.js
+++ b/packages/opencode-plugin/.opencode/lib/opencode-v2-adapter.js
@@ -154,16 +154,32 @@ export const translateV2ToolResult = (input) => {
   };
 };
 
-const disposeAll = async (registrations) => {
-  let firstError;
-  for (const registration of [...registrations].reverse()) {
-    try {
-      await registration.dispose();
-    } catch (error) {
-      firstError ??= error;
+export const createV2Tool = (name, definition, { isActive = () => true } = {}) => {
+  const properties = {};
+  const required = [];
+  for (const [argumentName, argument] of Object.entries(definition.args)) {
+    if (argument.type !== "number") {
+      throw new Error(`Unsupported OpenCode 2 tool argument: ${argumentName}:${argument.type}`);
     }
+    properties[argumentName] = { type: "number" };
+    if (!argument.optional) required.push(argumentName);
   }
-  if (firstError) throw firstError;
+  const input = {
+    type: "object",
+    properties,
+    additionalProperties: false,
+    ...(required.length > 0 ? { required } : {}),
+  };
+  return {
+    name,
+    description: definition.description,
+    input,
+    options: { codemode: false },
+    execute: async (args) => {
+      if (!isActive()) throw new Error("Codemem tool is unavailable after adapter cleanup");
+      return { content: await definition.execute(asRecord(args)) };
+    },
+  };
 };
 
 const defaultWaitForEventTask = (eventTask, timeoutMs) =>
@@ -180,16 +196,22 @@ const defaultWaitForEventTask = (eventTask, timeoutMs) =>
   });
 
 const waitForRegistrationDisposal = async (registrations, waitForTask, timeoutMs) => {
-  let disposalError;
-  const disposalTask = disposeAll(registrations).catch((error) => {
-    disposalError = error;
-  });
-  try {
-    const completed = await waitForTask(disposalTask, timeoutMs);
-    return { completed, error: disposalError };
-  } catch (error) {
-    return { completed: false, error };
-  }
+  const outcomes = await Promise.all([...registrations].reverse().map(async (registration) => {
+    let disposalError;
+    const disposalTask = Promise.resolve().then(() => registration.dispose()).catch((error) => {
+      disposalError = error;
+    });
+    try {
+      const completed = await waitForTask(disposalTask, timeoutMs);
+      return { completed, error: disposalError };
+    } catch (error) {
+      return { completed: false, error };
+    }
+  }));
+  return {
+    completed: outcomes.every((outcome) => outcome.completed),
+    error: outcomes.find((outcome) => outcome.error)?.error,
+  };
 };
 
 const waitForRuntimeDisposal = (runtime, waitForTask, timeoutMs) =>
@@ -413,6 +435,12 @@ export const createOpenCodeV2Adapter = ({
         waitForDiagnosticTask,
       });
     }));
+    registrations.push(await context.tool.transform((editor) => {
+      if (!active) return;
+      for (const [name, definition] of Object.entries(runtime.tools)) {
+        editor.add(createV2Tool(name, definition, { isActive: () => active }));
+      }
+    }));
     eventTask = consumeEvents(context, abortController.signal, runtime, translator, {
       eventTaskTimeoutMs,
       scheduleCapture,
@@ -424,7 +452,19 @@ export const createOpenCodeV2Adapter = ({
     runtime.deactivate?.();
     abortController.abort();
     translator.clear();
-    await disposeAll(registrations).catch(() => {});
+    const registrationCleanup = await waitForRegistrationDisposal(
+      registrations,
+      waitForRegistrationTask,
+      eventTaskTimeoutMs,
+    );
+    if (!registrationCleanup.completed) {
+      await reportDiagnosticWithinTimeout(
+        runtime,
+        "v2_registration_cleanup_timeout",
+        waitForDiagnosticTask,
+        eventTaskTimeoutMs,
+      );
+    }
     const runtimeCleanup = await waitForRuntimeDisposal(
       runtime,
       waitForRuntimeDisposalTask,

--- a/packages/opencode-plugin/README.md
+++ b/packages/opencode-plugin/README.md
@@ -28,8 +28,9 @@ OpenCode installs npm plugins automatically with Bun at startup.
 The package default export is one dual-host object. OpenCode 1 calls its
 `server()` function, while OpenCode 2 calls its `setup()` function. The OpenCode 2
 setup captures conversation, tool, usage, and lifecycle activity and disposes its
-host registrations on unload. It does not yet inject automatic recall or expose
-memory tools.
+host registrations on unload. It exposes the manual `mem-status`, `mem-recent`,
+and `mem-stats` tools through `tool.transform` with `codemode: false`. It does not
+inject automatic recall because the V2 context hook has no request kind or request ID.
 
 `CodememPlugin` remains the canonical named OpenCode 1 function export.
 `OpencodeMemPlugin` remains available as a deprecated, reference-identical alias

--- a/packages/opencode-plugin/package.json
+++ b/packages/opencode-plugin/package.json
@@ -25,7 +25,7 @@
 	"scripts": {
 		"test": "pnpm exec vitest run",
 		"test:opencode-v2-contract": "node ./scripts/packed-v2-host-smoke.mjs",
-		"test:packed-artifact": "node ./scripts/packed-artifact-smoke.mjs"
+		"test:packed-artifact": "pnpm --filter codemem build && node ./scripts/packed-artifact-smoke.mjs"
 	},
 	"dependencies": {
 		"@opencode-ai/plugin": "1.18.29"

--- a/packages/opencode-plugin/scripts/packed-artifact-smoke.mjs
+++ b/packages/opencode-plugin/scripts/packed-artifact-smoke.mjs
@@ -201,10 +201,15 @@ try {
 
 	const v2Home = join(tempDir, "v2-home");
 	mkdirSync(v2Home, { recursive: true });
+	const builtCli = join(packageRoot, "..", "cli", "dist", "index.js");
+	assert(existsSync(builtCli), `Built local CLI not found: ${builtCli}`);
 	const v2Env = {
 		...process.env,
 		HOME: v2Home,
 		CODEMEM_BACKEND_UPDATE_POLICY: "off",
+		CODEMEM_DB: "",
+		CODEMEM_RUNNER: "node",
+		CODEMEM_RUNNER_FROM: builtCli,
 		CODEMEM_VIEWER: "0",
 	};
 	const installedV2Adapter = pathToFileURL(

--- a/packages/opencode-plugin/scripts/packed-v2-adapter-probe.mjs
+++ b/packages/opencode-plugin/scripts/packed-v2-adapter-probe.mjs
@@ -256,7 +256,8 @@ function createV2Subscription(rows, state, toolsHandled, markTerminalHandled) {
 
 function createV2Context(rows) {
 	let hook;
-	const state = { aborted: false, disposed: false };
+	const memoryTools = [];
+	const state = { aborted: false, hookDisposed: false, transformDisposed: false };
 	let markTerminalHandled;
 	let markToolsHandled;
 	const terminalHandled = new Promise((resolve) => {
@@ -280,15 +281,24 @@ function createV2Context(rows) {
 					hook = callback;
 					return {
 						dispose: async () => {
-							state.disposed = true;
+							state.hookDisposed = true;
+						},
+					};
+				},
+				transform: async (callback) => {
+					callback({ add: (tool) => memoryTools.push(tool) });
+					return {
+						dispose: async () => {
+							state.transformDisposed = true;
 						},
 					};
 				},
 			},
 		},
 		getHook: () => hook,
+		getMemoryTools: () => memoryTools,
 		isAborted: () => state.aborted,
-		isDisposed: () => state.disposed,
+		isDisposed: () => state.hookDisposed && state.transformDisposed,
 		markToolsHandled,
 		terminalHandled,
 	};
@@ -298,8 +308,22 @@ async function driveV2(mod, rows) {
 	const fixture = createV2Context(rows);
 	const cleanup = await mod.default.setup(fixture.context);
 	const hook = fixture.getHook();
+	const memoryTools = fixture.getMemoryTools();
 	assert(typeof cleanup === "function", "packed V2 setup did not return cleanup");
 	assert(typeof hook === "function", "packed V2 setup did not register tool capture");
+	assert(
+		JSON.stringify(memoryTools.map((tool) => tool.name).sort()) ===
+			JSON.stringify(["mem-recent", "mem-stats", "mem-status"]),
+		"packed V2 setup did not register all shared memory tools",
+	);
+	const recentTool = memoryTools.find((tool) => tool.name === "mem-recent");
+	assert(recentTool.input.properties.limit.type === "number", "packed V2 recent limit is not numeric");
+	const recentResult = await recentTool.execute({ limit: 1 });
+	assert(typeof recentResult.content === "string", "packed V2 memory tool returned invalid content");
+	assert(
+		!recentResult.content.startsWith("Failed to fetch recent:"),
+		`packed V2 memory tool failed: ${recentResult.content}`,
+	);
 	await hook({
 		id: "v2-tool-present-1",
 		status: "completed",

--- a/packages/opencode-plugin/scripts/packed-v2-host-smoke.mjs
+++ b/packages/opencode-plugin/scripts/packed-v2-host-smoke.mjs
@@ -123,6 +123,7 @@ async function startProvider(projectDir) {
 					name: tool.function?.name,
 					description: tool.function?.description,
 				})),
+			toolNames: body.tools?.map((tool) => tool.function?.name).filter(Boolean),
 		});
 		attempts += 1;
 		if (request.headers["x-codemem-contract-kind"] === "primary") primaryAttempts += 1;
@@ -674,7 +675,7 @@ try {
 		records.some(
 			(record) =>
 				record.phase === "tool.transform" &&
-				record.declaredName === "mem-status" &&
+				record.declaredName === "contract-probe" &&
 				record.effectiveID === null,
 		),
 		"Host unexpectedly exposed an effective ID while adding the hyphenated tool name",
@@ -763,6 +764,14 @@ try {
 	assert(
 		provider.primaryAttempts() >= 2,
 		`Local provider received ${provider.primaryAttempts()} primary requests across ${provider.attempts()} requests`,
+	);
+	assert(
+		provider.observations().some((observation) =>
+			["mem-status", "mem-recent", "mem-stats"].every((name) =>
+				observation.toolNames?.includes(name),
+			),
+		),
+		`Pinned host did not expose V2 memory-tool IDs; observed ${JSON.stringify(provider.observations().map((observation) => observation.toolNames))}`,
 	);
 	assert(records.some((record) => record.phase === "cleanup"), "Host omitted plugin cleanup on unload");
 } finally {

--- a/packages/opencode-plugin/src/opencode-v2-adapter.test.ts
+++ b/packages/opencode-plugin/src/opencode-v2-adapter.test.ts
@@ -19,18 +19,33 @@ function makeRuntime() {
 		handleEvent: vi.fn(async () => undefined),
 		handleToolResult: vi.fn(async () => undefined),
 		reportDiagnostic: vi.fn(async () => undefined),
+		tools: {},
 	};
 }
 
 function makeContext(
 	events: readonly unknown[] = [],
-	options: { eventError?: Error; hookError?: Error; stuck?: boolean; stuckDispose?: boolean } = {},
+	options: {
+		eventError?: Error;
+		hookError?: Error;
+		stuck?: boolean;
+		stuckDispose?: boolean;
+		stuckTransformDispose?: boolean;
+		transformError?: Error;
+	} = {},
 ) {
 	const aborted = { value: false };
 	const hookDispose = vi.fn(async () => {
 		if (options.stuckDispose) await new Promise(() => {});
 	});
+	const transformDispose = vi.fn(async () => {
+		if (options.stuckTransformDispose) await new Promise(() => {});
+	});
+	const addedTools: Array<Record<string, unknown>> = [];
 	let toolHook: ((input: unknown) => Promise<void>) | undefined;
+	let toolTransform:
+		| ((editor: { add: (tool: Record<string, unknown>) => void }) => void)
+		| undefined;
 	const context = {
 		location: {
 			directory: "/repo/worktree/nested",
@@ -57,9 +72,25 @@ function makeContext(
 				toolHook = callback;
 				return { dispose: hookDispose };
 			}),
+			transform: vi.fn(
+				async (callback: (editor: { add: (tool: Record<string, unknown>) => void }) => void) => {
+					if (options.transformError) throw options.transformError;
+					toolTransform = callback;
+					callback({ add: (tool) => addedTools.push(tool) });
+					return { dispose: transformDispose };
+				},
+			),
 		},
 	};
-	return { aborted, context, hookDispose, invokeTool: (input: unknown) => toolHook?.(input) };
+	return {
+		aborted,
+		addedTools,
+		context,
+		hookDispose,
+		invokeTool: (input: unknown) => toolHook?.(input),
+		invokeTransform: () => toolTransform?.({ add: (tool) => addedTools.push(tool) }),
+		transformDispose,
+	};
 }
 
 type EventStream = Awaited<ReturnType<Plugin.Context["event"]["subscribe"]>>;
@@ -295,6 +326,41 @@ describe("OpenCode 2 tool capture", () => {
 			});
 
 		expect(createEvent("tool-call-1").event_id).not.toBe(createEvent("tool-call-2").event_id);
+	});
+});
+
+describe("OpenCode 2 memory tools", () => {
+	it("registers shared memory tools with V2 schemas and results", async () => {
+		const runtime = makeRuntime();
+		const executeRecent = vi.fn(async ({ limit }: { limit?: number }) => `recent:${limit ?? 5}`);
+		runtime.tools = {
+			"mem-recent": {
+				description: "Show recent codemem entries",
+				args: { limit: { type: "number", optional: true } },
+				execute: executeRecent,
+			},
+		};
+		const fixture = makeContext();
+		const setup = adapter.createOpenCodeV2Adapter({ createRuntime: async () => runtime });
+		const cleanup = await setup(fixture.context);
+		const tool = fixture.addedTools[0] as {
+			execute: (args: unknown) => Promise<unknown>;
+			input: unknown;
+			name: string;
+			options: unknown;
+		};
+
+		expect(tool.name).toBe("mem-recent");
+		expect(tool.input).toEqual({
+			type: "object",
+			properties: { limit: { type: "number" } },
+			additionalProperties: false,
+		});
+		expect(tool.options).toEqual({ codemode: false });
+		await expect(tool.execute({ limit: 3 })).resolves.toEqual({ content: "recent:3" });
+		expect(executeRecent).toHaveBeenCalledWith({ limit: 3 });
+		await cleanup?.();
+		expect(fixture.transformDispose).toHaveBeenCalledOnce();
 	});
 });
 
@@ -596,6 +662,47 @@ describe("OpenCode 2 adapter setup", () => {
 		expect(runtime.dispose).toHaveBeenCalledOnce();
 	});
 
+	it("disposes completed registrations when memory-tool setup fails", async () => {
+		const runtime = makeRuntime();
+		const fixture = makeContext([], { transformError: new Error("transform unavailable") });
+		const setup = adapter.createOpenCodeV2Adapter({ createRuntime: async () => runtime });
+
+		await expect(setup(fixture.context)).rejects.toThrow("transform unavailable");
+		expect(fixture.hookDispose).toHaveBeenCalledOnce();
+		expect(runtime.dispose).toHaveBeenCalledOnce();
+	});
+
+	it("bounds registration disposal when memory-tool setup fails", async () => {
+		const runtime = makeRuntime();
+		runtime.reportDiagnostic.mockImplementation(async () => new Promise(() => {}));
+		const waitForDiagnosticTask = vi.fn(async () => false);
+		const waitForRegistrationTask = vi.fn(async () => false);
+		const fixture = makeContext([], {
+			stuckDispose: true,
+			transformError: new Error("transform unavailable"),
+		});
+		const setup = adapter.createOpenCodeV2Adapter({
+			createRuntime: async () => runtime,
+			waitForDiagnosticTask,
+			waitForRegistrationTask,
+		});
+
+		const result = await Promise.race([
+			setup(fixture.context).then(
+				() => "resolved",
+				(error: Error) => error.message,
+			),
+			new Promise((resolve) => setTimeout(() => resolve("timed-out"), 25)),
+		]);
+
+		expect(result).toBe("transform unavailable");
+		expect(waitForDiagnosticTask).toHaveBeenCalledOnce();
+		expect(waitForRegistrationTask).toHaveBeenCalledOnce();
+		expect(fixture.hookDispose).toHaveBeenCalledOnce();
+		expect(runtime.reportDiagnostic).toHaveBeenCalledWith("v2_registration_cleanup_timeout");
+		expect(runtime.dispose).toHaveBeenCalledOnce();
+	});
+
 	it("skips hook registration when the shared runtime rejects activation", async () => {
 		const fixture = makeContext();
 		const setup = adapter.createOpenCodeV2Adapter({ createRuntime: async () => null });
@@ -683,7 +790,7 @@ describe("OpenCode 2 registration and stream cleanup timeout", () => {
 
 		expect(result).toBe("completed");
 		expect(waitForDiagnosticTask).toHaveBeenCalledOnce();
-		expect(waitForRegistrationTask).toHaveBeenCalledOnce();
+		expect(waitForRegistrationTask).toHaveBeenCalledTimes(2);
 		expect(runtime.reportDiagnostic).toHaveBeenCalledWith("v2_registration_cleanup_timeout");
 		expect(runtime.dispose).toHaveBeenCalledOnce();
 		await fixture.invokeTool({
@@ -696,6 +803,69 @@ describe("OpenCode 2 registration and stream cleanup timeout", () => {
 		expect(runtime.handleToolResult).not.toHaveBeenCalled();
 	});
 
+	it("continues disposing hooks when the transform registration is stuck", async () => {
+		const runtime = makeRuntime();
+		let registrationWaits = 0;
+		const setup = adapter.createOpenCodeV2Adapter({
+			createRuntime: async () => runtime,
+			waitForRegistrationTask: async (task: Promise<void>) => {
+				registrationWaits += 1;
+				if (registrationWaits === 1) return false;
+				await task;
+				return true;
+			},
+		});
+		const fixture = makeContext([], { stuckTransformDispose: true });
+		const cleanup = await setup(fixture.context);
+
+		await cleanup?.();
+
+		expect(fixture.transformDispose).toHaveBeenCalledOnce();
+		expect(fixture.hookDispose).toHaveBeenCalledOnce();
+		expect(runtime.reportDiagnostic).toHaveBeenCalledWith("v2_registration_cleanup_timeout");
+		expect(runtime.dispose).toHaveBeenCalledOnce();
+	});
+
+	it("disables transformed memory tools before bounded cleanup returns", async () => {
+		const runtime = makeRuntime();
+		const executeRecent = vi.fn(async () => "recent");
+		let releaseRegistrationWait: (() => void) | undefined;
+		const registrationWait = new Promise<void>((resolve) => {
+			releaseRegistrationWait = resolve;
+		});
+		runtime.tools = {
+			"mem-recent": {
+				description: "Show recent codemem entries",
+				args: {},
+				execute: executeRecent,
+			},
+		};
+		const setup = adapter.createOpenCodeV2Adapter({
+			createRuntime: async () => runtime,
+			waitForRegistrationTask: async () => {
+				await registrationWait;
+				return false;
+			},
+		});
+		const fixture = makeContext([], { stuckTransformDispose: true });
+		const cleanup = await setup(fixture.context);
+		const tool = fixture.addedTools[0] as { execute: (args: unknown) => Promise<unknown> };
+		await expect(tool.execute({})).resolves.toEqual({ content: "recent" });
+
+		const pendingCleanup = cleanup?.();
+		fixture.invokeTransform();
+
+		await expect(tool.execute({})).rejects.toThrow(
+			"Codemem tool is unavailable after adapter cleanup",
+		);
+		expect(executeRecent).toHaveBeenCalledOnce();
+		expect(fixture.addedTools).toHaveLength(1);
+		releaseRegistrationWait?.();
+		await pendingCleanup;
+	});
+});
+
+describe("OpenCode 2 event stream cleanup timeout", () => {
 	it("releases runtime ownership after bounded cleanup of a stuck stream", async () => {
 		const firstRuntime = makeRuntime();
 		firstRuntime.reportDiagnostic.mockImplementation(async () => new Promise(() => {}));
@@ -775,6 +945,7 @@ describe("OpenCode 2 registration and stream cleanup timeout", () => {
 			},
 			tool: {
 				hook: vi.fn(async () => ({ dispose: vi.fn(async () => undefined) })),
+				transform: vi.fn(async () => ({ dispose: vi.fn(async () => undefined) })),
 			},
 		};
 		const setup = adapter.createOpenCodeV2Adapter({

--- a/packages/opencode-plugin/src/opencode-v2-contract-fixture.test.ts
+++ b/packages/opencode-plugin/src/opencode-v2-contract-fixture.test.ts
@@ -370,7 +370,7 @@ describe("OpenCode 2 executable fixture", () => {
 				}),
 				expect.objectContaining({
 					phase: "tool.transform",
-					declaredName: "mem-status",
+					declaredName: "contract-probe",
 					effectiveID: null,
 				}),
 				expect.objectContaining({ phase: "event.end", aborted: true }),

--- a/packages/opencode-plugin/src/opencode-v2-contract-fixture.ts
+++ b/packages/opencode-plugin/src/opencode-v2-contract-fixture.ts
@@ -202,7 +202,7 @@ async function registerToolContracts(
 	});
 	registrations.push(after);
 	let effectiveID: string | null = null;
-	const declaredName = "mem-status";
+	const declaredName = "contract-probe";
 	const transform = await context.tool.transform((editor) => {
 		editor.add({
 			name: declaredName,


### PR DESCRIPTION
## Description

Expose the shared `mem-status`, `mem-recent`, and `mem-stats` tools through the OpenCode 2 adapter. Map shared argument definitions to JSON Schema, keep codemode disabled, bound registration cleanup independently, and document that automatic recall remains disabled until OpenCode provides concurrency-safe request identity.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Additional packed checks:
- `pnpm --filter @codemem/opencode-plugin test:packed-artifact`
- `pnpm --filter @codemem/opencode-plugin test:opencode-v2-contract`

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced