### PR TITLE
docs(mcp): clarify retrieval routing and memory tool guidance

### DIFF
--- a/packages/mcp-server/src/tool-guidance.test.ts
+++ b/packages/mcp-server/src/tool-guidance.test.ts
@@ -1,0 +1,174 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connect, initTestSchema, MemoryStore } from "@codemem/core";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createCodememMcpServer } from "./index.js";
+
+type ListedTool = Awaited<ReturnType<Client["listTools"]>>["tools"][number];
+
+function requireTool(tools: ListedTool[], name: string): ListedTool {
+	const tool = tools.find((candidate) => candidate.name === name);
+	if (!tool) throw new Error(`MCP tool not listed: ${name}`);
+	return tool;
+}
+
+function parseTextResult(result: Awaited<ReturnType<Client["callTool"]>>): unknown {
+	if (!("content" in result)) throw new Error("memory_learn returned a task result");
+	const content = result.content[0];
+	if (content?.type !== "text") throw new Error("memory_learn returned no text content");
+	return JSON.parse(content.text);
+}
+
+function collectStrings(value: unknown): string[] {
+	if (typeof value === "string") return [value];
+	if (Array.isArray(value)) return value.flatMap(collectStrings);
+	if (!value || typeof value !== "object") return [];
+	return Object.values(value).flatMap(collectStrings);
+}
+
+function extractCalls(text: string): Array<{ name: string; parameters: string[] }> {
+	return Array.from(text.matchAll(/\b(memory_[a-z_]+)\(([^)]*)\)/g), (match) => ({
+		name: match[1] ?? "",
+		parameters: Array.from(
+			(match[2] ?? "").matchAll(/(?:^|,\s*)([a-z_]+)(?:\s*=|\s*(?=,|$))/g),
+			(parameter) => parameter[1] ?? "",
+		),
+	}));
+}
+
+function assertSearchRoutingGuidance(tools: ListedTool[]): void {
+	const search = requireTool(tools, "memory_search");
+	const index = requireTool(tools, "memory_search_index");
+	const pack = requireTool(tools, "memory_pack");
+	const descriptions = {
+		search: search.description ?? "",
+		index: index.description ?? "",
+		pack: pack.description ?? "",
+	};
+
+	expect(descriptions.search).toMatch(/keyword-search.*exact terms or identifiers/i);
+	expect(descriptions.search).toMatch(/full body text/i);
+	expect(descriptions.search).not.toMatch(/semantic search/i);
+	expect(descriptions.index).toMatch(/compact entries.*without bodies/i);
+	expect(descriptions.index).not.toMatch(/full body text/i);
+	expect(descriptions.pack).toMatch(/concept.*keyword and semantic search/i);
+	expect(descriptions.pack).toMatch(/automatic keyword-only fallback/i);
+	expect(descriptions.pack).toMatch(/exact identifiers/i);
+}
+
+function assertLearnGuidance(tools: ListedTool[], guidance: unknown): void {
+	const toolsByName = new Map(tools.map((tool) => [tool.name, tool]));
+	const schemaParameterNames = new Set(
+		tools.flatMap((tool) => Object.keys(tool.inputSchema.properties ?? {})),
+	);
+	const guidanceText = collectStrings(guidance).join("\n");
+	const calls = extractCalls(guidanceText);
+	const callNames = new Set(calls.map((call) => call.name));
+	const referencedNames = [
+		...new Set(
+			(guidanceText.match(/\bmemory_[a-z_]+\b/g) ?? []).filter(
+				(name) => callNames.has(name) || !schemaParameterNames.has(name),
+			),
+		),
+	];
+
+	expect(referencedNames.length).toBeGreaterThan(0);
+	for (const name of referencedNames) {
+		expect(name).toMatch(/^memory_[a-z]+(?:_[a-z]+)*$/);
+		expect(toolsByName.has(name), `${name} should resolve to a listed MCP tool`).toBe(true);
+	}
+	expect(guidanceText).not.toMatch(/\bmemory-[a-z_-]+\b/);
+	expect(guidanceText).not.toMatch(/\bmemory\.[a-z_]+/);
+	for (const call of calls) {
+		const tool = toolsByName.get(call.name);
+		if (!tool) throw new Error(`Guidance call is not registered: ${call.name}`);
+		const schemaParameters = new Set(Object.keys(tool.inputSchema.properties ?? {}));
+		for (const parameter of call.parameters) {
+			expect(
+				schemaParameters.has(parameter),
+				`${call.name} should accept guidance parameter ${parameter}`,
+			).toBe(true);
+		}
+	}
+}
+
+function assertDirectIdGuidance(tools: ListedTool[]): void {
+	const directGet = requireTool(tools, "memory_get");
+	const directMany = requireTool(tools, "memory_get_observations");
+	const forget = requireTool(tools, "memory_forget");
+
+	for (const description of [directGet.description ?? "", directMany.description ?? ""]) {
+		expect(description).toMatch(/exact ID/i);
+		expect(description).toMatch(/does not inherit the default project/i);
+	}
+	expect(forget.description).toMatch(/soft-delete/i);
+	expect(forget.description).toMatch(/not secure erasure/i);
+	expect(forget.description).toMatch(/filters must match.*not_found/i);
+	expect(directMany.description).toMatch(/missing or filtered-out IDs are omitted/i);
+}
+
+describe("registered MCP tool guidance", () => {
+	let client: Client;
+	let server: ReturnType<typeof createCodememMcpServer>;
+	let store: MemoryStore;
+	let tmpDir: string;
+	let previousConfig: string | undefined;
+	let previousEmbeddingDisabled: string | undefined;
+
+	beforeEach(async () => {
+		previousConfig = process.env.CODEMEM_CONFIG;
+		previousEmbeddingDisabled = process.env.CODEMEM_EMBEDDING_DISABLED;
+		tmpDir = mkdtempSync(join(tmpdir(), "codemem-mcp-guidance-"));
+		process.env.CODEMEM_CONFIG = join(tmpDir, "config.json");
+		process.env.CODEMEM_EMBEDDING_DISABLED = "1";
+
+		const dbPath = join(tmpDir, "memory.sqlite");
+		const db = connect(dbPath);
+		initTestSchema(db);
+		db.close();
+		store = new MemoryStore(dbPath);
+		server = createCodememMcpServer(store, {
+			defaultProject: "default-project",
+			captureRetrievalLedger: false,
+		});
+		client = new Client({ name: "tool-guidance-test", version: "1.0.0" });
+		const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+		await server.connect(serverTransport);
+		await client.connect(clientTransport);
+	});
+
+	afterEach(async () => {
+		await client.close();
+		await server.close();
+		store.close();
+		rmSync(tmpDir, { recursive: true, force: true });
+		if (previousConfig === undefined) delete process.env.CODEMEM_CONFIG;
+		else process.env.CODEMEM_CONFIG = previousConfig;
+		if (previousEmbeddingDisabled === undefined) delete process.env.CODEMEM_EMBEDDING_DISABLED;
+		else process.env.CODEMEM_EMBEDDING_DISABLED = previousEmbeddingDisabled;
+	});
+
+	it("distinguishes exact keyword search, compact index results, and conceptual packs", async () => {
+		const { tools } = await client.listTools();
+
+		assertSearchRoutingGuidance(tools);
+	});
+
+	it("memory_learn references only registered underscore names with valid recipe parameters", async () => {
+		const { tools } = await client.listTools();
+		const guidance = parseTextResult(
+			await client.callTool({ name: "memory_learn", arguments: {} }),
+		);
+
+		assertLearnGuidance(tools, guidance);
+	});
+
+	it("documents direct-ID project scope and forget semantics", async () => {
+		const { tools } = await client.listTools();
+
+		assertDirectIdGuidance(tools);
+	});
+});

--- a/packages/mcp-server/src/tools/items.ts
+++ b/packages/mcp-server/src/tools/items.ts
@@ -18,7 +18,7 @@ export function registerItemTools(server: McpServer, context: ToolRegistrationCo
 
 	server.tool(
 		"memory_get",
-		"Fetch a single memory item by ID.",
+		"Fetch one memory by exact ID. Does not inherit the default project; optional filters constrain the lookup, and a mismatch returns not_found.",
 		{
 			memory_id: z.number().int().describe("Memory ID"),
 			...filterSchema,
@@ -50,7 +50,7 @@ export function registerItemTools(server: McpServer, context: ToolRegistrationCo
 
 	server.tool(
 		"memory_get_observations",
-		"Fetch multiple memory items by their IDs.",
+		"Fetch multiple memories by exact IDs. Does not inherit the default project. Missing or filtered-out IDs are omitted from results, not reported as not_found.",
 		{
 			ids: z.array(z.number().int()).max(200).describe("Memory IDs to fetch"),
 			...filterSchema,
@@ -109,7 +109,7 @@ export function registerItemTools(server: McpServer, context: ToolRegistrationCo
 
 	server.tool(
 		"memory_forget",
-		"Soft-delete a memory item. Use for incorrect or sensitive data.",
+		"Soft-delete a memory by exact ID so it no longer appears in normal retrieval; this is not secure erasure. Does not inherit the default project; optional filters must match or the tool returns not_found.",
 		{
 			memory_id: z.number().int().describe("Memory ID to forget"),
 			...filterSchema,

--- a/packages/mcp-server/src/tools/learn.ts
+++ b/packages/mcp-server/src/tools/learn.ts
@@ -1,94 +1,98 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { jsonContent } from "../content.js";
 
+const MEMORY_LEARN_GUIDANCE = {
+	intro: "Use this tool when you're new to codemem or unsure when to recall/persist.",
+	client_hint: "If you are unfamiliar with codemem, call memory_learn first.",
+	recall: {
+		when: [
+			"Start of a task or when the user references prior work.",
+			"When you need background context, decisions, or recent changes.",
+		],
+		how: [
+			"Use memory_search or memory_search_index for exact terms and identifiers; memory_search returns bodies, while memory_search_index returns compact candidates.",
+			"Use memory_pack for conceptually relevant context; it combines keyword and semantic search when embeddings are available and falls back to keyword search when they are not.",
+			"Use memory_timeline to expand around a promising memory.",
+			"Use memory_get or memory_get_observations for full details only when needed.",
+			"Use the project filter unless the user requests cross-project context.",
+			"Project, trust, and ownership filters organize and select memories; they are not authentication or tenant-isolation controls.",
+		],
+		examples: [
+			'memory_search_index(query="billing cache bug", limit=5)',
+			"memory_timeline(memory_id=123)",
+			"memory_get_observations(ids=[123, 456])",
+		],
+	},
+	persistence: {
+		when: [
+			"Milestones (task done, key decision, new facts learned).",
+			"Notable regressions or follow-ups that should be remembered.",
+		],
+		how: [
+			"Use memory_remember with kind decision/discovery/change/exploration.",
+			"Keep titles short and bodies high-signal.",
+			"ALWAYS pass the project parameter if known.",
+		],
+		examples: [
+			'memory_remember(kind="decision", title="Switch to async cache", body="...why...", project="my-service")',
+			'memory_remember(kind="change", title="Fixed retry loop", body="...impact...", project="my-service")',
+		],
+	},
+	forget: {
+		when: [
+			"Obsolete or incorrect items that should no longer surface.",
+			"Items that should be soft-deleted; soft deletion is not secure erasure.",
+		],
+		how: [
+			"Call memory_forget(memory_id) to mark the item inactive.",
+			"Optional filters constrain the exact-ID lookup; a filter mismatch returns not_found.",
+			"Do not treat memory_forget as secure erasure or a user-data erasure guarantee.",
+		],
+		examples: ["memory_forget(memory_id=123)"],
+	},
+	prompt_hint:
+		"At task start: call memory_search_index for exact terms or memory_pack for conceptual context; during work: memory_timeline + memory_get_observations; at milestones: memory_remember.",
+	recommended_system_prompt: [
+		"Trigger policy (1-liner): If the user references prior work or starts a task,",
+		"call memory_search_index for exact terms or memory_pack for conceptual context; then use",
+		"memory_timeline + memory_get_observations; at milestones, call memory_remember.",
+		"",
+		"System prompt:",
+		"You have access to codemem MCP tools. If unfamiliar, call memory_learn first.",
+		"",
+		"Recall:",
+		"- For exact terms or identifiers, use memory_search_index for compact candidates or memory_search for bodies.",
+		"- For conceptually relevant context, use memory_pack; it falls back to keyword search without embeddings.",
+		'- If prior work is referenced ("as before", "last time", "we already did…", "regression"),',
+		"  call memory_search_index, memory_pack, or memory_timeline as appropriate.",
+		"- Use memory_get or memory_get_observations only after filtering IDs.",
+		"- Prefer project-scoped queries unless the user asks for cross-project.",
+		"- Project, trust, and ownership filters select memories; they do not authenticate or isolate tenants.",
+		"",
+		"Persistence:",
+		"- On milestones (task done, key decision, new facts learned), call memory_remember.",
+		"- Use kind=decision for tradeoffs, kind=change for outcomes, kind=discovery/exploration for useful findings.",
+		"- Keep titles short and bodies high-signal.",
+		"- ALWAYS pass the project parameter if known.",
+		"",
+		"Safety:",
+		"- Use memory_forget(memory_id) to soft-delete incorrect or obsolete items; this is not secure erasure.",
+		"",
+		"Examples:",
+		'- memory_search_index(query="billing cache bug")',
+		"- memory_timeline(memory_id=123)",
+		"- memory_get_observations(ids=[123, 456])",
+		'- memory_remember(kind="decision", title="Use async cache", body="Chose async cache to avoid lock contention in X.", project="my-service")',
+		'- memory_remember(kind="change", title="Fixed retry loop", body="Root cause was Y; added guard in Z.", project="my-service")',
+		"- memory_forget(memory_id=123)",
+	].join("\n"),
+} as const;
+
 export function registerLearnTools(server: McpServer): void {
 	server.tool(
 		"memory_learn",
 		"Learn how to use codemem memory tools. Call this first if unfamiliar.",
 		{},
-		async () => {
-			return jsonContent({
-				intro: "Use this tool when you're new to codemem or unsure when to recall/persist.",
-				client_hint: "If you are unfamiliar with codemem, call memory.learn first.",
-				recall: {
-					when: [
-						"Start of a task or when the user references prior work.",
-						"When you need background context, decisions, or recent changes.",
-					],
-					how: [
-						"Use memory.search_index to get compact candidates.",
-						"Use memory.timeline to expand around a promising memory.",
-						"Use memory.get_observations for full details only when needed.",
-						"Use memory.pack for quick one-shot context blocks.",
-						"Use the project filter unless the user requests cross-project context.",
-					],
-					examples: [
-						'memory.search_index("billing cache bug", limit=5)',
-						"memory.timeline(memory_id=123)",
-						"memory.get_observations([123, 456])",
-					],
-				},
-				persistence: {
-					when: [
-						"Milestones (task done, key decision, new facts learned).",
-						"Notable regressions or follow-ups that should be remembered.",
-					],
-					how: [
-						"Use memory.remember with kind decision/discovery/change/exploration.",
-						"Keep titles short and bodies high-signal.",
-						"ALWAYS pass the project parameter if known.",
-					],
-					examples: [
-						'memory.remember(kind="decision", title="Switch to async cache", body="...why...", project="my-service")',
-						'memory.remember(kind="change", title="Fixed retry loop", body="...impact...", project="my-service")',
-					],
-				},
-				forget: {
-					when: [
-						"Accidental or sensitive data stored in memory items.",
-						"Obsolete or incorrect items that should no longer surface.",
-					],
-					how: [
-						"Call memory.forget(id) to mark the item inactive.",
-						"Prefer forgetting over overwriting to preserve auditability.",
-					],
-					examples: ["memory.forget(123)"],
-				},
-				prompt_hint:
-					"At task start: call memory.search_index; during work: memory.timeline + memory.get_observations; at milestones: memory.remember.",
-				recommended_system_prompt: [
-					"Trigger policy (1-liner): If the user references prior work or starts a task,",
-					"immediately call memory.search_index; then use memory.timeline + memory.get_observations;",
-					"at milestones, call memory.remember; use memory.forget for incorrect/sensitive items.",
-					"",
-					"System prompt:",
-					"You have access to codemem MCP tools. If unfamiliar, call memory.learn first.",
-					"",
-					"Recall:",
-					"- Start of any task: call memory.search_index with a concise task query.",
-					'- If prior work is referenced ("as before", "last time", "we already did…", "regression"),',
-					"  call memory.search_index or memory.timeline.",
-					"- Use memory.get_observations only after filtering IDs.",
-					"- Prefer project-scoped queries unless the user asks for cross-project.",
-					"",
-					"Persistence:",
-					"- On milestones (task done, key decision, new facts learned), call memory.remember.",
-					"- Use kind=decision for tradeoffs, kind=change for outcomes, kind=discovery/exploration for useful findings.",
-					"- Keep titles short and bodies high-signal.",
-					"- ALWAYS pass the project parameter if known.",
-					"",
-					"Safety:",
-					"- Use memory.forget(id) for incorrect or sensitive items.",
-					"",
-					"Examples:",
-					'- memory.search_index("billing cache bug")',
-					"- memory.timeline(memory_id=123)",
-					"- memory.get_observations([123, 456])",
-					'- memory.remember(kind="decision", title="Use async cache", body="Chose async cache to avoid lock contention in X.", project="my-service")',
-					'- memory.remember(kind="change", title="Fixed retry loop", body="Root cause was Y; added guard in Z.", project="my-service")',
-					"- memory.forget(123)",
-				].join("\n"),
-			});
-		},
+		async () => jsonContent(MEMORY_LEARN_GUIDANCE),
 	);
 }

--- a/packages/mcp-server/src/tools/search.ts
+++ b/packages/mcp-server/src/tools/search.ts
@@ -11,7 +11,7 @@ export function registerSearchTools(server: McpServer, context: ToolRegistration
 
 	server.tool(
 		"memory_search",
-		"Search memories by text query. Returns full body text for each match.",
+		"Keyword-search memories when you know exact terms or identifiers. Returns full body text for each match; use memory_search_index when you only need compact candidates.",
 		{
 			query: z.string().describe("Search query"),
 			limit: z.number().int().min(1).max(50).default(5).describe("Max results"),
@@ -56,7 +56,7 @@ export function registerSearchTools(server: McpServer, context: ToolRegistration
 
 	server.tool(
 		"memory_search_index",
-		"Search memories by text query. Returns compact index entries (no body) for browsing.",
+		"Keyword-search memories when you know exact terms or identifiers. Returns compact entries with IDs and titles, without bodies; expand selected IDs with memory_get or memory_get_observations.",
 		{
 			query: z.string().describe("Search query"),
 			limit: z.number().int().min(1).max(50).default(8).describe("Max results"),
@@ -170,7 +170,7 @@ export function registerSearchTools(server: McpServer, context: ToolRegistration
 
 	server.tool(
 		"memory_pack",
-		"Build a formatted memory pack from search results — quick one-shot context block.",
+		"Build a formatted context block for a concept or task using keyword and semantic search when embeddings are available, with automatic keyword-only fallback. Use for conceptually relevant context; use memory_search or memory_search_index for exact identifiers.",
 		{
 			context: z.string().describe("Context description to search for"),
 			limit: z.number().int().min(1).max(50).optional().describe("Max items to include"),


### PR DESCRIPTION
## Description
Clarify MCP tool guidance without changing retrieval behavior: keyword versus hybrid routing, valid underscore call names, direct-ID/default-project behavior, batch omissions, and soft-delete/filter caveats. Adds regression tests against actual tools/list and memory_learn responses.

First PR in a stack; annotations and structured output contracts follow separately.

## Type of Change
- [x] 📚 Documentation (tool guidance)
- [x] 🧪 Testing

## Testing
- [x] MCP package suite: 176 tests across 12 files
- [x] Workspace TypeScript build
- [x] Scoped Biome checks (two unchanged legacy function-length warnings)
- [x] Diff checks and independent review fixes

Serialized tools/list metadata: 24,478 → 25,219 bytes (+3.03%). No model-selection evaluation or Glama-grade improvement claimed. Full workspace test suite not run.

## Checklist
- [x] Self-review completed
- [x] Guidance and examples updated
- [x] No new lint warnings
