### PR TITLE
feat(mcp): add tool annotations and structured output contracts

### DIFF
--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -255,6 +255,14 @@ slash commands in the OpenCode chat input.
 The MCP server exposes memory retrieval and write tools such as `memory_search`,
 `memory_pack`, `memory_recent`, `memory_remember`, and `memory_forget`.
 
+### MCP result and annotation contract
+
+All 14 tools publish the standard optional `outputSchema` and `annotations` fields; `packages/mcp-server/src/tool-contracts.ts` is the authority. On success, `structuredContent` is an object that validates against the declared schema, and `content[0].text` remains compact JSON for compatible text-only clients. The two representations are identical after JSON serialization, so `undefined` properties are omitted.
+
+Check `isError` before reading `structuredContent`: errors set `isError: true`, provide only the JSON error text, and omit `structuredContent` so SDKs do not validate an error against the success schema.
+
+Annotations are conservative client hints, not authorization; they can trigger approval prompts. Metadata/schema tools are read-only; retrieval tools are not read-only or idempotent because they append local delivery-ledger diagnostics. `memory_remember` adds data, while `memory_forget` is a destructive soft delete and is idempotent only in the no-added-effects sense—repeating it returns `not_found`. `memory_pack`, `memory_distill_candidates`, and `memory_remember` may load an external model or invoke the observer. These annotations do not change authentication or transport.
+
 `memory_distill_candidates` mines recurring lessons into reviewable context
 candidates. It is read-only and does not modify documentation files. By
 default an observer-model worthiness pass drops routine-activity clusters

--- a/packages/mcp-server/src/content.ts
+++ b/packages/mcp-server/src/content.ts
@@ -1,7 +1,23 @@
+function parseStructuredObject(text: string): Record<string, unknown> {
+	const value: unknown = JSON.parse(text);
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		throw new TypeError("MCP structured content must be a JSON object");
+	}
+	return value as Record<string, unknown>;
+}
+
 export function jsonContent(data: unknown) {
-	return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+	const text = JSON.stringify(data);
+	if (text === undefined) throw new TypeError("MCP structured content must be JSON serializable");
+	return {
+		content: [{ type: "text" as const, text }],
+		structuredContent: parseStructuredObject(text),
+	};
 }
 
 export function errorContent(message: string) {
-	return { content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }] };
+	return {
+		content: [{ type: "text" as const, text: JSON.stringify({ error: message }) }],
+		isError: true,
+	};
 }

--- a/packages/mcp-server/src/structured-output.test.ts
+++ b/packages/mcp-server/src/structured-output.test.ts
@@ -1,0 +1,480 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connect, initTestSchema, MemoryStore } from "@codemem/core";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCodememMcpServer } from "./index.js";
+
+type ToolResult = Awaited<ReturnType<Client["callTool"]>>;
+
+const expectedAnnotations = {
+	memory_distill_candidates: {
+		readOnlyHint: false,
+		destructiveHint: false,
+		idempotentHint: false,
+		openWorldHint: true,
+	},
+	memory_expand: {
+		readOnlyHint: false,
+		destructiveHint: false,
+		idempotentHint: false,
+		openWorldHint: false,
+	},
+	memory_explain: {
+		readOnlyHint: false,
+		destructiveHint: false,
+		idempotentHint: false,
+		openWorldHint: false,
+	},
+	memory_forget: {
+		readOnlyHint: false,
+		destructiveHint: true,
+		idempotentHint: true,
+		openWorldHint: false,
+	},
+	memory_get: {
+		readOnlyHint: false,
+		destructiveHint: false,
+		idempotentHint: false,
+		openWorldHint: false,
+	},
+	memory_get_observations: {
+		readOnlyHint: false,
+		destructiveHint: false,
+		idempotentHint: false,
+		openWorldHint: false,
+	},
+	memory_learn: {
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: false,
+	},
+	memory_pack: {
+		readOnlyHint: false,
+		destructiveHint: false,
+		idempotentHint: false,
+		openWorldHint: true,
+	},
+	memory_recent: {
+		readOnlyHint: false,
+		destructiveHint: false,
+		idempotentHint: false,
+		openWorldHint: false,
+	},
+	memory_remember: {
+		readOnlyHint: false,
+		destructiveHint: false,
+		idempotentHint: false,
+		openWorldHint: true,
+	},
+	memory_schema: {
+		readOnlyHint: true,
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: false,
+	},
+	memory_search: {
+		readOnlyHint: false,
+		destructiveHint: false,
+		idempotentHint: false,
+		openWorldHint: false,
+	},
+	memory_search_index: {
+		readOnlyHint: false,
+		destructiveHint: false,
+		idempotentHint: false,
+		openWorldHint: false,
+	},
+	memory_timeline: {
+		readOnlyHint: false,
+		destructiveHint: false,
+		idempotentHint: false,
+		openWorldHint: false,
+	},
+} as const;
+
+function textFrom(result: ToolResult): string {
+	if (!("content" in result)) throw new Error("tool returned a task result");
+	const content = result.content[0];
+	if (content?.type !== "text") throw new Error("tool returned no text content");
+	return content.text;
+}
+
+function assertStructuredSuccess(result: ToolResult): Record<string, unknown> {
+	const text = textFrom(result);
+	if (!("structuredContent" in result) || !result.structuredContent) {
+		throw new Error("successful tool result omitted structuredContent");
+	}
+	expect(result.isError).not.toBe(true);
+	expect(result.structuredContent).toEqual(JSON.parse(text));
+	return result.structuredContent;
+}
+
+function assertTextError(result: ToolResult, expectedText?: string): void {
+	expect(result.isError).toBe(true);
+	expect("structuredContent" in result ? result.structuredContent : undefined).toBeUndefined();
+	if (expectedText !== undefined) expect(textFrom(result)).toBe(expectedText);
+}
+
+let client: Client;
+let server: ReturnType<typeof createCodememMcpServer>;
+let store: MemoryStore;
+let tempDirectory: string;
+let fixtureDirectory: string;
+let previousConfig: string | undefined;
+let previousEmbeddingDisabled: string | undefined;
+let previousHome: string | undefined;
+let previousProject: string | undefined;
+
+beforeEach(async () => {
+	previousConfig = process.env.CODEMEM_CONFIG;
+	previousEmbeddingDisabled = process.env.CODEMEM_EMBEDDING_DISABLED;
+	previousHome = process.env.HOME;
+	previousProject = process.env.CODEMEM_PROJECT;
+	tempDirectory = mkdtempSync(join(tmpdir(), "codemem-mcp-contract-"));
+	fixtureDirectory = join(tempDirectory, "contract-fixture");
+	mkdirSync(fixtureDirectory);
+	process.env.CODEMEM_CONFIG = join(tempDirectory, "config.json");
+	process.env.CODEMEM_EMBEDDING_DISABLED = "1";
+	process.env.HOME = tempDirectory;
+	delete process.env.CODEMEM_PROJECT;
+	vi.spyOn(process, "cwd").mockReturnValue(fixtureDirectory);
+
+	const databasePath = join(tempDirectory, "memory.sqlite");
+	const database = connect(databasePath);
+	initTestSchema(database);
+	database.close();
+	store = new MemoryStore(databasePath);
+	server = createCodememMcpServer(store, {
+		defaultProject: "contract-fixture",
+		envProject: null,
+		captureRetrievalLedger: false,
+	});
+	client = new Client({ name: "structured-output-test", version: "1.0.0" });
+	const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+	await server.connect(serverTransport);
+	await client.connect(clientTransport);
+});
+
+afterEach(async () => {
+	await client.close();
+	await server.close();
+	store.close();
+	vi.restoreAllMocks();
+	rmSync(tempDirectory, { recursive: true, force: true });
+	if (previousConfig === undefined) delete process.env.CODEMEM_CONFIG;
+	else process.env.CODEMEM_CONFIG = previousConfig;
+	if (previousEmbeddingDisabled === undefined) delete process.env.CODEMEM_EMBEDDING_DISABLED;
+	else process.env.CODEMEM_EMBEDDING_DISABLED = previousEmbeddingDisabled;
+	if (previousHome === undefined) delete process.env.HOME;
+	else process.env.HOME = previousHome;
+	if (previousProject === undefined) delete process.env.CODEMEM_PROJECT;
+	else process.env.CODEMEM_PROJECT = previousProject;
+});
+
+async function callSuccess(
+	name: string,
+	args: Record<string, unknown> = {},
+): Promise<Record<string, unknown>> {
+	return assertStructuredSuccess(await client.callTool({ name, arguments: args }));
+}
+
+async function rememberFixturePair(): Promise<[number, number]> {
+	const first = await callSuccess("memory_remember", {
+		kind: "discovery",
+		title: "Contract sentinel recurring lesson",
+		body: "Contract sentinel recurring lesson should remain machine readable.",
+		confidence: 0.9,
+		project: "contract-fixture",
+	});
+	const second = await callSuccess("memory_remember", {
+		kind: "discovery",
+		title: "Contract sentinel recurring lesson again",
+		body: "Contract sentinel recurring lesson should remain machine readable again.",
+		confidence: 0.8,
+		project: "contract-fixture",
+	});
+	return [first.id as number, second.id as number];
+}
+
+describe("registered MCP tool declarations", () => {
+	it("publishes an output schema and the audited conservative annotations for all 14 tools", async () => {
+		// Arrange: the expected map pins retrieval logging, external compute, and write semantics.
+		const expectedNames = Object.keys(expectedAnnotations).toSorted();
+
+		// Act
+		const tools = (await client.listTools()).tools.toSorted((left, right) =>
+			left.name.localeCompare(right.name),
+		);
+
+		// Assert
+		expect(tools.map((tool) => tool.name)).toEqual(expectedNames);
+		for (const tool of tools) {
+			expect(tool.outputSchema, `${tool.name} output schema`).toMatchObject({ type: "object" });
+			expect(tool.annotations, `${tool.name} annotations`).toEqual(
+				expectedAnnotations[tool.name as keyof typeof expectedAnnotations],
+			);
+		}
+	});
+});
+
+describe("non-empty MCP structured outputs", () => {
+	it("round-trips non-empty state and retrieval results through SDK output validation", async () => {
+		// Arrange: create isolated records through the public MCP write tool.
+		const [firstId, secondId] = await rememberFixturePair();
+		store.db
+			.prepare("UPDATE memory_items SET metadata_json = ? WHERE id = ?")
+			.run(JSON.stringify({ extension: { source: "fixture" } }), firstId);
+
+		// Act
+		const search = await callSuccess("memory_search", { query: "contract sentinel", limit: 10 });
+		const index = await callSuccess("memory_search_index", {
+			query: "contract sentinel",
+			limit: 10,
+		});
+		const recent = await callSuccess("memory_recent", { limit: 10 });
+		const get = await callSuccess("memory_get", { memory_id: firstId });
+		const batch = await callSuccess("memory_get_observations", { ids: [firstId, secondId] });
+		const timeline = await callSuccess("memory_timeline", {
+			memory_id: firstId,
+			depth_before: 1,
+			depth_after: 1,
+		});
+		const expand = await callSuccess("memory_expand", {
+			ids: [firstId],
+			depth_before: 1,
+			depth_after: 1,
+			include_observations: true,
+		});
+		const pack = await callSuccess("memory_pack", {
+			context: "contract sentinel",
+			limit: 5,
+		});
+		const explain = await callSuccess("memory_explain", {
+			query: "contract sentinel",
+			ids: [firstId],
+			limit: 10,
+		});
+
+		// Assert: every retrieval returns useful data, including passthrough metadata.
+		expect((search.items as Array<{ metadata: unknown }>).length).toBeGreaterThan(0);
+		expect(
+			(search.items as Array<{ id: number; metadata: unknown }>).find(
+				(item) => item.id === firstId,
+			),
+		).toMatchObject({ metadata: { extension: { source: "fixture" } } });
+		expect((index.items as unknown[]).length).toBeGreaterThan(0);
+		expect((recent.items as unknown[]).length).toBeGreaterThan(0);
+		expect(get).toMatchObject({ id: firstId, active: 1 });
+		expect((batch.items as unknown[]).length).toBe(2);
+		expect((timeline.items as unknown[]).length).toBeGreaterThan(0);
+		expect((expand.anchors as unknown[]).length).toBe(1);
+		expect((expand.observations as unknown[]).length).toBeGreaterThan(0);
+		expect((pack.items as unknown[]).length).toBeGreaterThan(0);
+		expect(pack.metrics).toMatchObject({
+			total_items: expect.any(Number),
+			pack_item_ids: pack.item_ids,
+		});
+		expect((explain.items as unknown[]).length).toBeGreaterThan(0);
+		expect(explain.errors).toEqual([]);
+	});
+});
+
+describe("nullable MCP retrieval fields", () => {
+	it("round-trips nullable confidence and legacy nullable fields through all affected tools", async () => {
+		// Arrange: these columns are nullable in the real schema despite having insert defaults.
+		const [firstId, secondId] = await rememberFixturePair();
+		store.db
+			.prepare(
+				"UPDATE memory_items SET confidence = NULL, tags_text = NULL, metadata_json = NULL WHERE id IN (?, ?)",
+			)
+			.run(firstId, secondId);
+
+		// Act: call every retrieval surface that emits memory confidence.
+		const search = await callSuccess("memory_search", { query: "contract sentinel", limit: 10 });
+		const recent = await callSuccess("memory_recent", { limit: 10 });
+		const get = await callSuccess("memory_get", { memory_id: firstId });
+		const batch = await callSuccess("memory_get_observations", { ids: [firstId, secondId] });
+		const timeline = await callSuccess("memory_timeline", {
+			memory_id: firstId,
+			depth_before: 1,
+			depth_after: 1,
+		});
+		const expand = await callSuccess("memory_expand", {
+			ids: [firstId],
+			depth_before: 1,
+			depth_after: 1,
+			include_observations: true,
+		});
+		const pack = await callSuccess("memory_pack", {
+			context: "contract sentinel",
+			limit: 5,
+		});
+
+		// Assert: SDK output validation accepts the nullable rows without losing text parity.
+		expect(search.items).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					id: firstId,
+					confidence: null,
+					metadata: expect.any(Object),
+				}),
+			]),
+		);
+		expect(recent.items).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: firstId, confidence: null, metadata_json: {} }),
+			]),
+		);
+		expect(get).toMatchObject({
+			id: firstId,
+			confidence: null,
+			tags_text: null,
+			metadata_json: {},
+		});
+		expect(batch.items).toEqual(
+			expect.arrayContaining([expect.objectContaining({ id: firstId, confidence: null })]),
+		);
+		expect(timeline.items).toEqual(
+			expect.arrayContaining([expect.objectContaining({ id: firstId, confidence: null })]),
+		);
+		expect(expand.anchors).toEqual([expect.objectContaining({ id: firstId, confidence: null })]);
+		expect(expand.observations).toEqual(
+			expect.arrayContaining([expect.objectContaining({ id: firstId, confidence: null })]),
+		);
+		expect(pack.items).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ confidence: null, metadata: expect.any(Object) }),
+			]),
+		);
+	});
+});
+
+describe("catalog and distill MCP structured outputs", () => {
+	it("returns successful structured catalogs and a local unjudged distill candidate", async () => {
+		// Arrange: recurring isolated memories make distillation non-empty without an observer or downloads.
+		const ids = await rememberFixturePair();
+
+		// Act
+		const distill = await callSuccess("memory_distill_candidates", {
+			all_projects: true,
+			include_documented: false,
+			judge: false,
+			limit: 10,
+			max_evidence_items: 5,
+			min_recurrence: 2,
+		});
+		const schema = await callSuccess("memory_schema");
+		const learn = await callSuccess("memory_learn");
+
+		// Assert
+		expect(distill).toMatchObject({
+			version: 1,
+			candidates: [{ member_ids: ids, recurrence: 2 }],
+			metadata: { candidate_count: 1 },
+		});
+		expect((schema.kinds as unknown[]).length).toBeGreaterThan(0);
+		expect(schema.filters).toEqual(expect.arrayContaining(["project", "kind"]));
+		expect(learn).toMatchObject({ intro: expect.any(String), recall: { when: expect.any(Array) } });
+	});
+});
+
+describe("empty MCP structured outputs", () => {
+	it("keeps valid zero-result calls inside their declared success envelopes", async () => {
+		// Arrange
+		const missingProject = "no-such-fixture-project";
+
+		// Act
+		const search = await callSuccess("memory_search", { query: "absent", project: missingProject });
+		const index = await callSuccess("memory_search_index", {
+			query: "absent",
+			project: missingProject,
+		});
+		const recent = await callSuccess("memory_recent", { project: missingProject });
+		const batch = await callSuccess("memory_get_observations", { ids: [] });
+		const timeline = await callSuccess("memory_timeline", {
+			query: "absent",
+			project: missingProject,
+		});
+		const pack = await callSuccess("memory_pack", {
+			context: "absent",
+			project: missingProject,
+			limit: 5,
+		});
+		const explain = await callSuccess("memory_explain", { ids: [999_999] });
+		const expand = await callSuccess("memory_expand", { ids: ["invalid", 999_999] });
+		const distill = await callSuccess("memory_distill_candidates", {
+			all_projects: true,
+			judge: false,
+			min_recurrence: 50,
+		});
+
+		// Assert
+		expect(search).toEqual({ items: [] });
+		expect(index).toEqual({ items: [] });
+		expect(recent).toEqual({ items: [] });
+		expect(batch).toEqual({ items: [] });
+		expect(timeline).toEqual({ items: [] });
+		expect(pack).toMatchObject({ items: [], item_ids: [], metrics: { total_items: 0 } });
+		expect(explain).toMatchObject({
+			items: [],
+			missing_ids: [999_999],
+			errors: [{ code: "NOT_FOUND", ids: [999_999] }],
+		});
+		expect(expand).toMatchObject({
+			anchors: [],
+			timeline: [],
+			observations: [],
+			missing_ids: [999_999],
+			errors: [{ code: "INVALID_ARGUMENT" }, { code: "NOT_FOUND" }],
+		});
+		expect(distill).toMatchObject({ version: 1, candidates: [] });
+	});
+});
+
+describe("MCP text error outputs", () => {
+	it("keeps not-found, filter-mismatch, invalid-input, and repeated-forget results text-only", async () => {
+		// Arrange
+		const [memoryId] = await rememberFixturePair();
+		const rowCountBefore = store.db.prepare("SELECT COUNT(*) AS count FROM memory_items").get() as {
+			count: number;
+		};
+
+		// Act
+		const missing = await client.callTool({
+			name: "memory_get",
+			arguments: { memory_id: 999_999 },
+		});
+		const filtered = await client.callTool({
+			name: "memory_get",
+			arguments: { memory_id: memoryId, project: "other-project" },
+		});
+		const invalid = await client.callTool({
+			name: "memory_get",
+			arguments: { memory_id: "invalid" },
+		});
+		const forgotten = await callSuccess("memory_forget", { memory_id: memoryId });
+		const repeated = await client.callTool({
+			name: "memory_forget",
+			arguments: { memory_id: memoryId },
+		});
+		const stored = store.db
+			.prepare("SELECT active FROM memory_items WHERE id = ?")
+			.get(memoryId) as { active: number };
+		const rowCountAfter = store.db.prepare("SELECT COUNT(*) AS count FROM memory_items").get() as {
+			count: number;
+		};
+
+		// Assert
+		assertTextError(missing, JSON.stringify({ error: "not_found" }));
+		assertTextError(filtered, JSON.stringify({ error: "not_found" }));
+		assertTextError(invalid);
+		expect(forgotten).toEqual({ status: "ok" });
+		assertTextError(repeated, JSON.stringify({ error: "not_found" }));
+		expect(stored).toEqual({ active: 0 });
+		expect(rowCountAfter).toEqual(rowCountBefore);
+	});
+});

--- a/packages/mcp-server/src/tool-contracts.test.ts
+++ b/packages/mcp-server/src/tool-contracts.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { ZodType } from "zod";
+import { jsonContent } from "./content.js";
+import { toolOutputSchemas } from "./tool-contracts.js";
+
+const malformedOutputs: ReadonlyArray<{
+	label: string;
+	schema: ZodType;
+	fixture: unknown;
+}> = [
+	{ label: "remember id", schema: toolOutputSchemas.memory_remember, fixture: { id: "1" } },
+	{
+		label: "stored body",
+		schema: toolOutputSchemas.memory_get,
+		fixture: { id: 1, kind: "discovery", title: "missing body" },
+	},
+	{
+		label: "pack metrics",
+		schema: toolOutputSchemas.memory_pack,
+		fixture: {
+			context: "fixture",
+			items: [],
+			item_ids: [],
+			pack_text: "",
+			metrics: {
+				total_items: 0,
+				pack_tokens: "0",
+				fallback_used: false,
+				limit: 5,
+				project: null,
+				pack_item_ids: [],
+			},
+		},
+	},
+	{
+		label: "explain error details",
+		schema: toolOutputSchemas.memory_explain,
+		fixture: {
+			items: [],
+			missing_ids: [],
+			errors: [{ code: "INVALID_ARGUMENT", field: "query" }],
+			metadata: {
+				query: null,
+				project: null,
+				requested_ids_count: 0,
+				returned_items_count: 0,
+				include_pack_context: false,
+			},
+		},
+	},
+];
+
+describe("MCP tool output schemas", () => {
+	it.each(malformedOutputs)("rejects malformed $label output", ({ schema, fixture }) => {
+		// Arrange: each fixture corrupts or omits one contract field.
+		const malformedOutput = fixture;
+
+		// Act
+		const result = schema.safeParse(malformedOutput);
+
+		// Assert
+		expect(result.success).toBe(false);
+	});
+
+	it("preserves unknown metadata while pruning undefined values identically from text and structure", () => {
+		// Arrange
+		const value = {
+			status: "ok",
+			metadata: { extension: { source: "fixture" }, omitted: undefined },
+		};
+
+		// Act
+		const result = jsonContent(value);
+		const parsedText = JSON.parse(result.content[0].text);
+
+		// Assert
+		expect(result.structuredContent).toEqual(parsedText);
+		expect(result.structuredContent).toEqual({
+			status: "ok",
+			metadata: { extension: { source: "fixture" } },
+		});
+	});
+});

--- a/packages/mcp-server/src/tool-contracts.ts
+++ b/packages/mcp-server/src/tool-contracts.ts
@@ -1,0 +1,266 @@
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+
+const metadataSchema = z.record(z.string(), z.unknown());
+// The column has a default but no NOT NULL constraint, and legacy rows can emit null.
+const confidenceSchema = z.number().nullable();
+
+const storedMemorySchema = z
+	.object({
+		id: z.number().int(),
+		kind: z.string(),
+		title: z.string(),
+		body_text: z.string(),
+		session_id: z.number().int().optional(),
+		confidence: confidenceSchema.optional(),
+		created_at: z.string().optional(),
+		updated_at: z.string().optional(),
+		metadata_json: metadataSchema.optional(),
+	})
+	.passthrough();
+
+const searchMemorySchema = z
+	.object({
+		id: z.number().int(),
+		kind: z.string(),
+		title: z.string(),
+		body: z.string(),
+		confidence: confidenceSchema.optional(),
+		score: z.number().optional(),
+		session_id: z.number().int().optional(),
+		metadata: metadataSchema.optional(),
+	})
+	.passthrough();
+
+const indexMemorySchema = z
+	.object({
+		id: z.number().int(),
+		kind: z.string(),
+		title: z.string(),
+		score: z.number(),
+		created_at: z.string(),
+		session_id: z.number().int(),
+		metadata: metadataSchema,
+	})
+	.passthrough();
+
+const errorDetailSchema = z
+	.object({
+		code: z.string(),
+		field: z.string(),
+		message: z.string(),
+		ids: z.array(z.union([z.string(), z.number()])).optional(),
+	})
+	.passthrough();
+
+const explainItemSchema = z
+	.object({
+		id: z.number().int(),
+		kind: z.string(),
+		title: z.string(),
+		created_at: z.string(),
+		project: z.string().nullable(),
+		retrieval: z.object({ source: z.string(), rank: z.number().int().nullable() }).passthrough(),
+		score: z
+			.object({
+				total: z.number().nullable(),
+				components: z
+					.object({
+						base: z.number().nullable(),
+						recency: z.number(),
+						kind_bonus: z.number(),
+						personal_bias: z.number(),
+						semantic_boost: z.number().nullable(),
+					})
+					.passthrough(),
+			})
+			.passthrough(),
+		role: z.object({ inferred: z.string(), reason: z.string() }).passthrough(),
+		matches: z
+			.object({ query_terms: z.array(z.string()), project_match: z.boolean().nullable() })
+			.passthrough(),
+		pack_context: z
+			.object({ included: z.boolean().nullable(), section: z.string().nullable() })
+			.passthrough()
+			.nullable(),
+	})
+	.passthrough();
+
+const packItemSchema = z
+	.object({
+		id: z.number().int(),
+		kind: z.string(),
+		title: z.string(),
+		body: z.string(),
+		confidence: confidenceSchema,
+		metadata: metadataSchema,
+	})
+	.passthrough();
+
+const stringListSectionSchema = z
+	.object({
+		when: z.array(z.string()),
+		how: z.array(z.string()),
+		examples: z.array(z.string()),
+	})
+	.passthrough();
+
+export const toolOutputSchemas = {
+	memory_search: z.object({ items: z.array(searchMemorySchema) }),
+	memory_search_index: z.object({ items: z.array(indexMemorySchema) }),
+	memory_explain: z.object({
+		items: z.array(explainItemSchema),
+		missing_ids: z.array(z.number().int()),
+		errors: z.array(errorDetailSchema),
+		metadata: z
+			.object({
+				query: z.string().nullable(),
+				project: z.string().nullable(),
+				requested_ids_count: z.number().int(),
+				returned_items_count: z.number().int(),
+				include_pack_context: z.boolean(),
+				sanitized_query: z.string().optional(),
+			})
+			.passthrough(),
+	}),
+	memory_recent: z.object({ items: z.array(storedMemorySchema) }),
+	memory_pack: z.object({
+		context: z.string(),
+		items: z.array(packItemSchema),
+		item_ids: z.array(z.number().int()),
+		pack_text: z.string(),
+		metrics: z
+			.object({
+				total_items: z.number().int(),
+				pack_tokens: z.number().int(),
+				fallback_used: z.boolean(),
+				limit: z.number().int(),
+				project: z.string().nullable(),
+				pack_item_ids: z.array(z.number().int()),
+			})
+			.passthrough(),
+	}),
+	memory_timeline: z.object({ items: z.array(storedMemorySchema) }),
+	memory_expand: z.object({
+		anchors: z.array(storedMemorySchema),
+		timeline: z.array(storedMemorySchema),
+		observations: z.array(storedMemorySchema),
+		missing_ids: z.array(z.number().int()),
+		errors: z.array(errorDetailSchema),
+		metadata: z
+			.object({
+				project: z.string().nullable(),
+				requested_ids_count: z.number().int(),
+				returned_anchor_count: z.number().int(),
+				timeline_count: z.number().int(),
+				include_observations: z.boolean(),
+			})
+			.passthrough(),
+	}),
+	memory_get: storedMemorySchema,
+	memory_get_observations: z.object({ items: z.array(storedMemorySchema) }),
+	memory_remember: z.object({ id: z.number().int() }),
+	memory_forget: z.object({ status: z.literal("ok") }),
+	memory_distill_candidates: z.object({
+		version: z.literal(1),
+		candidates: z.array(
+			z
+				.object({
+					scope: z.enum(["project", "user"]),
+					suggested_target: z.string().nullable(),
+					score: z.number(),
+					recurrence: z.number().int(),
+					projects: z.array(z.string()),
+					member_ids: z.array(z.number().int()),
+					representative_id: z.number().int(),
+					concepts: z.array(z.string()),
+					artifact_kind: z.enum(["context_fact", "skill"]),
+					evidence: z.array(z.string()),
+					draft_text: z.string().nullable(),
+				})
+				.passthrough(),
+		),
+		metadata: z
+			.object({
+				candidate_count: z.number().int(),
+				cluster_count: z.number().int(),
+				context_document_count: z.number().int(),
+				corpus_count: z.number().int(),
+				corpus_limit: z.number().int(),
+				documented_cluster_count: z.number().int(),
+				include_documented: z.boolean(),
+				min_recurrence: z.number().int(),
+			})
+			.passthrough(),
+	}),
+	memory_schema: z.object({
+		kinds: z.array(z.string()),
+		kind_descriptions: z.record(z.string(), z.string()),
+		fields: z.record(z.string(), z.string()),
+		filters: z.array(z.string()),
+	}),
+	memory_learn: z.object({
+		intro: z.string(),
+		client_hint: z.string(),
+		recall: stringListSectionSchema,
+		persistence: stringListSectionSchema,
+		forget: stringListSectionSchema,
+		prompt_hint: z.string(),
+		recommended_system_prompt: z.string(),
+	}),
+} as const;
+
+// Retrievals append delivery diagnostics to the local ledger, so they are not
+// read-only or idempotent even though their primary operation only reads memories.
+const localRetrievalAnnotations = {
+	readOnlyHint: false,
+	destructiveHint: false,
+	idempotentHint: false,
+	openWorldHint: false,
+} satisfies ToolAnnotations;
+
+// Pack/distill execution may load embedding models or call the observer. Those
+// interactions can populate caches or contact entities outside the local store.
+const externalComputeAnnotations = {
+	readOnlyHint: false,
+	destructiveHint: false,
+	idempotentHint: false,
+	openWorldHint: true,
+} satisfies ToolAnnotations;
+
+// These static catalogs neither mutate state nor interact outside the server.
+const metadataAnnotations = {
+	readOnlyHint: true,
+	destructiveHint: false,
+	idempotentHint: true,
+	openWorldHint: false,
+} satisfies ToolAnnotations;
+
+export const toolAnnotations = {
+	memory_search: localRetrievalAnnotations,
+	memory_search_index: localRetrievalAnnotations,
+	memory_explain: localRetrievalAnnotations,
+	memory_recent: localRetrievalAnnotations,
+	memory_pack: externalComputeAnnotations,
+	memory_timeline: localRetrievalAnnotations,
+	memory_expand: localRetrievalAnnotations,
+	memory_get: localRetrievalAnnotations,
+	memory_get_observations: localRetrievalAnnotations,
+	// Remember is additive, but embedding generation can load external model assets.
+	memory_remember: {
+		readOnlyHint: false,
+		destructiveHint: false,
+		idempotentHint: false,
+		openWorldHint: true,
+	},
+	// Repeating a soft delete has no additional environmental effect.
+	memory_forget: {
+		readOnlyHint: false,
+		destructiveHint: true,
+		idempotentHint: true,
+		openWorldHint: false,
+	},
+	memory_distill_candidates: externalComputeAnnotations,
+	memory_schema: metadataAnnotations,
+	memory_learn: metadataAnnotations,
+} as const satisfies Record<keyof typeof toolOutputSchemas, ToolAnnotations>;

--- a/packages/mcp-server/src/tools/distill.ts
+++ b/packages/mcp-server/src/tools/distill.ts
@@ -17,6 +17,37 @@ import { errorContent, jsonContent } from "../content.js";
 import { buildFilters } from "../project-scope.js";
 import { filterSchema } from "../schemas.js";
 import type { ToolRegistrationContext } from "../tool-context.js";
+import { toolAnnotations, toolOutputSchemas } from "../tool-contracts.js";
+
+const distillInputSchema = {
+	limit: z.number().int().min(1).max(50).default(10).describe("Max candidates"),
+	min_recurrence: z
+		.number()
+		.int()
+		.min(1)
+		.max(50)
+		.default(2)
+		.describe("Minimum member count per candidate"),
+	all_projects: z.boolean().default(false).describe("Mine memories across all projects"),
+	include_documented: z
+		.boolean()
+		.default(false)
+		.describe("Include candidates already represented in context files"),
+	max_evidence_items: z
+		.number()
+		.int()
+		.min(1)
+		.max(20)
+		.default(5)
+		.describe("Evidence snippets per candidate"),
+	judge: z
+		.boolean()
+		.default(true)
+		.describe(
+			"Judge candidates with the observer model and drop routine-activity clusters (on by default; falls back to unjudged output when no observer model is configured)",
+		),
+	...filterSchema,
+};
 
 function readContextFile(
 	path: string,
@@ -80,37 +111,14 @@ function buildDistillFilters(
 export function registerDistillTools(server: McpServer, context: ToolRegistrationContext): void {
 	const { defaultProject, store } = context;
 
-	server.tool(
+	server.registerTool(
 		"memory_distill_candidates",
-		"Mine recurring memories into reviewable context candidates. Read-only; does not modify context files.",
 		{
-			limit: z.number().int().min(1).max(50).default(10).describe("Max candidates"),
-			min_recurrence: z
-				.number()
-				.int()
-				.min(1)
-				.max(50)
-				.default(2)
-				.describe("Minimum member count per candidate"),
-			all_projects: z.boolean().default(false).describe("Mine memories across all projects"),
-			include_documented: z
-				.boolean()
-				.default(false)
-				.describe("Include candidates already represented in context files"),
-			max_evidence_items: z
-				.number()
-				.int()
-				.min(1)
-				.max(20)
-				.default(5)
-				.describe("Evidence snippets per candidate"),
-			judge: z
-				.boolean()
-				.default(true)
-				.describe(
-					"Judge candidates with the observer model and drop routine-activity clusters (on by default; falls back to unjudged output when no observer model is configured)",
-				),
-			...filterSchema,
+			description:
+				"Mine recurring memories into reviewable context candidates. Reads project/user context files without modifying them and can call the optional observer when judge=true.",
+			inputSchema: distillInputSchema,
+			outputSchema: toolOutputSchemas.memory_distill_candidates,
+			annotations: toolAnnotations.memory_distill_candidates,
 		},
 		async (args) => {
 			try {

--- a/packages/mcp-server/src/tools/items.ts
+++ b/packages/mcp-server/src/tools/items.ts
@@ -12,16 +12,40 @@ import {
 import { buildFilters } from "../project-scope.js";
 import { filterSchema, memoryKindSchema } from "../schemas.js";
 import type { ToolRegistrationContext } from "../tool-context.js";
+import { toolAnnotations, toolOutputSchemas } from "../tool-contracts.js";
 
-export function registerItemTools(server: McpServer, context: ToolRegistrationContext): void {
-	const { envProject, store } = context;
+const getInputSchema = {
+	memory_id: z.number().int().describe("Memory ID"),
+	...filterSchema,
+};
 
-	server.tool(
+const getObservationsInputSchema = {
+	ids: z.array(z.number().int()).max(200).describe("Memory IDs to fetch"),
+	...filterSchema,
+};
+
+const rememberInputSchema = {
+	kind: memoryKindSchema.describe("Memory kind"),
+	title: z.string().describe("Short title"),
+	body: z.string().describe("Body text (high-signal content)"),
+	confidence: z.number().min(0).max(1).default(0.5).describe("Confidence 0-1"),
+	project: z.string().optional().describe("Project identifier"),
+};
+
+const forgetInputSchema = {
+	memory_id: z.number().int().describe("Memory ID to forget"),
+	...filterSchema,
+};
+
+function registerGetTool(server: McpServer, context: ToolRegistrationContext): void {
+	server.registerTool(
 		"memory_get",
-		"Fetch one memory by exact ID. Does not inherit the default project; optional filters constrain the lookup, and a mismatch returns not_found.",
 		{
-			memory_id: z.number().int().describe("Memory ID"),
-			...filterSchema,
+			description:
+				"Fetch one memory by exact ID. Does not inherit the default project; optional filters constrain the lookup, and a mismatch returns not_found.",
+			inputSchema: getInputSchema,
+			outputSchema: toolOutputSchemas.memory_get,
+			annotations: toolAnnotations.memory_get,
 		},
 		async (args, extra) => {
 			// Direct-ID ops do not inherit the server default project. Callers already
@@ -39,7 +63,7 @@ export function registerItemTools(server: McpServer, context: ToolRegistrationCo
 					invocationIdentity: extra?.signal,
 				},
 				(filters) => {
-					const item = getMemoryForMcp(store, args.memory_id, filters);
+					const item = getMemoryForMcp(context.store, args.memory_id, filters);
 					return item
 						? { value: item, memoryIds: [item.id], filters }
 						: { value: null, memoryIds: [], error: "not_found", filters };
@@ -47,13 +71,17 @@ export function registerItemTools(server: McpServer, context: ToolRegistrationCo
 			);
 		},
 	);
+}
 
-	server.tool(
+function registerGetObservationsTool(server: McpServer, context: ToolRegistrationContext): void {
+	server.registerTool(
 		"memory_get_observations",
-		"Fetch multiple memories by exact IDs. Does not inherit the default project. Missing or filtered-out IDs are omitted from results, not reported as not_found.",
 		{
-			ids: z.array(z.number().int()).max(200).describe("Memory IDs to fetch"),
-			...filterSchema,
+			description:
+				"Fetch multiple memories by exact IDs. Does not inherit the default project. Missing or filtered-out IDs are omitted from results, not reported as not_found.",
+			inputSchema: getObservationsInputSchema,
+			outputSchema: toolOutputSchemas.memory_get_observations,
+			annotations: toolAnnotations.memory_get_observations,
 		},
 		async (args, extra) => {
 			return withMcpRetrieval(
@@ -69,33 +97,33 @@ export function registerItemTools(server: McpServer, context: ToolRegistrationCo
 					invocationIdentity: extra?.signal,
 				},
 				(filters) => {
-					const items = getManyForMcp(store, args.ids, filters);
+					const items = getManyForMcp(context.store, args.ids, filters);
 					return { value: { items }, memoryIds: items.map((item) => item.id), filters };
 				},
 			);
 		},
 	);
+}
 
-	server.tool(
+function registerRememberTool(server: McpServer, context: ToolRegistrationContext): void {
+	server.registerTool(
 		"memory_remember",
-		"Create a new memory. Use for milestones, decisions, and notable facts.",
 		{
-			kind: memoryKindSchema.describe("Memory kind"),
-			title: z.string().describe("Short title"),
-			body: z.string().describe("Body text (high-signal content)"),
-			confidence: z.number().min(0).max(1).default(0.5).describe("Confidence 0-1"),
-			project: z.string().optional().describe("Project identifier"),
+			description: "Create a new memory. Use for milestones, decisions, and notable facts.",
+			inputSchema: rememberInputSchema,
+			outputSchema: toolOutputSchemas.memory_remember,
+			annotations: toolAnnotations.memory_remember,
 		},
 		async (args) => {
 			try {
 				// Writes never inherit the server default project. They only honor an
 				// explicit `project` input or CODEMEM_PROJECT; otherwise project stays null.
-				const result = rememberMemoryForMcp(store, args, {
-					envProject: envProject(),
+				const result = rememberMemoryForMcp(context.store, args, {
+					envProject: context.envProject(),
 				});
 
 				try {
-					await storeVectors(store.db, result.memId, result.title, result.body);
+					await storeVectors(context.store.db, result.memId, result.title, result.body);
 				} catch {
 					// Memory writes should succeed even if embeddings are unavailable.
 				}
@@ -106,17 +134,21 @@ export function registerItemTools(server: McpServer, context: ToolRegistrationCo
 			}
 		},
 	);
+}
 
-	server.tool(
+function registerForgetTool(server: McpServer, context: ToolRegistrationContext): void {
+	server.registerTool(
 		"memory_forget",
-		"Soft-delete a memory by exact ID so it no longer appears in normal retrieval; this is not secure erasure. Does not inherit the default project; optional filters must match or the tool returns not_found.",
 		{
-			memory_id: z.number().int().describe("Memory ID to forget"),
-			...filterSchema,
+			description:
+				"Soft-delete a memory by exact ID so it no longer appears in normal retrieval; this is not secure erasure. Does not inherit the default project; optional filters must match or the tool returns not_found.",
+			inputSchema: forgetInputSchema,
+			outputSchema: toolOutputSchemas.memory_forget,
+			annotations: toolAnnotations.memory_forget,
 		},
 		async (args) => {
 			try {
-				if (!forgetMemoryForMcp(store, args.memory_id, buildFilters(args, null))) {
+				if (!forgetMemoryForMcp(context.store, args.memory_id, buildFilters(args, null))) {
 					return errorContent("not_found");
 				}
 				return jsonContent({ status: "ok" });
@@ -125,4 +157,11 @@ export function registerItemTools(server: McpServer, context: ToolRegistrationCo
 			}
 		},
 	);
+}
+
+export function registerItemTools(server: McpServer, context: ToolRegistrationContext): void {
+	registerGetTool(server, context);
+	registerGetObservationsTool(server, context);
+	registerRememberTool(server, context);
+	registerForgetTool(server, context);
 }

--- a/packages/mcp-server/src/tools/learn.ts
+++ b/packages/mcp-server/src/tools/learn.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { jsonContent } from "../content.js";
+import { toolAnnotations, toolOutputSchemas } from "../tool-contracts.js";
 
 const MEMORY_LEARN_GUIDANCE = {
 	intro: "Use this tool when you're new to codemem or unsure when to recall/persist.",
@@ -89,10 +90,14 @@ const MEMORY_LEARN_GUIDANCE = {
 } as const;
 
 export function registerLearnTools(server: McpServer): void {
-	server.tool(
+	server.registerTool(
 		"memory_learn",
-		"Learn how to use codemem memory tools. Call this first if unfamiliar.",
-		{},
+		{
+			description: "Learn how to use codemem memory tools. Call this first if unfamiliar.",
+			inputSchema: {},
+			outputSchema: toolOutputSchemas.memory_learn,
+			annotations: toolAnnotations.memory_learn,
+		},
 		async () => jsonContent(MEMORY_LEARN_GUIDANCE),
 	);
 }

--- a/packages/mcp-server/src/tools/schema.ts
+++ b/packages/mcp-server/src/tools/schema.ts
@@ -2,12 +2,17 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { jsonContent } from "../content.js";
 import { MEMORY_KINDS } from "../memory-kinds.js";
 import { filterNames } from "../schemas.js";
+import { toolAnnotations, toolOutputSchemas } from "../tool-contracts.js";
 
 export function registerSchemaTools(server: McpServer): void {
-	server.tool(
+	server.registerTool(
 		"memory_schema",
-		"Return the memory schema — kinds, fields, and available filters.",
-		{},
+		{
+			description: "Return the memory schema — kinds, fields, and available filters.",
+			inputSchema: {},
+			outputSchema: toolOutputSchemas.memory_schema,
+			annotations: toolAnnotations.memory_schema,
+		},
 		async () => {
 			return jsonContent({
 				kinds: Object.keys(MEMORY_KINDS),

--- a/packages/mcp-server/src/tools/search.ts
+++ b/packages/mcp-server/src/tools/search.ts
@@ -5,17 +5,69 @@ import { withMcpRetrieval } from "../mcp-retrieval-ledger.js";
 import { buildFilters } from "../project-scope.js";
 import { filterSchema } from "../schemas.js";
 import type { ToolRegistrationContext } from "../tool-context.js";
+import { toolAnnotations, toolOutputSchemas } from "../tool-contracts.js";
+
+const searchInputSchema = {
+	query: z.string().describe("Search query"),
+	limit: z.number().int().min(1).max(50).default(5).describe("Max results"),
+	...filterSchema,
+};
+
+const searchIndexInputSchema = {
+	query: z.string().describe("Search query"),
+	limit: z.number().int().min(1).max(50).default(8).describe("Max results"),
+	...filterSchema,
+};
+
+const explainInputSchema = {
+	query: z.string().optional().describe("Search query"),
+	ids: z.array(z.number().int()).max(200).optional().describe("Specific memory IDs to explain"),
+	limit: z.number().int().min(1).max(50).default(10).describe("Max results"),
+	include_pack_context: z.boolean().default(false).describe("Include formatted pack context"),
+	...filterSchema,
+};
+
+const recentInputSchema = {
+	limit: z.number().int().min(1).max(100).default(8).describe("Max results"),
+	...filterSchema,
+};
+
+const packInputSchema = {
+	context: z.string().describe("Context description to search for"),
+	limit: z.number().int().min(1).max(50).optional().describe("Max items to include"),
+	compact: z
+		.boolean()
+		.optional()
+		.describe(
+			"When true, render a scannable index of all items with full detail only for the top N (default 3). Saves tokens when broad overview matters more than per-item detail.",
+		),
+	compact_detail_count: z
+		.number()
+		.int()
+		.min(0)
+		.max(50)
+		.optional()
+		.describe("Number of items to show in full detail in compact mode (default 3)"),
+	compression_mode: z
+		.enum(["off", "compact", "ids"])
+		.optional()
+		.describe(
+			"Near-related compression mode: off disables it, compact applies only to compact rendering, ids applies in all modes. Defaults to CODEMEM_PACK_COMPRESSION or compact.",
+		),
+	...filterSchema,
+};
 
 export function registerSearchTools(server: McpServer, context: ToolRegistrationContext): void {
 	const { defaultProject, store } = context;
 
-	server.tool(
+	server.registerTool(
 		"memory_search",
-		"Keyword-search memories when you know exact terms or identifiers. Returns full body text for each match; use memory_search_index when you only need compact candidates.",
 		{
-			query: z.string().describe("Search query"),
-			limit: z.number().int().min(1).max(50).default(5).describe("Max results"),
-			...filterSchema,
+			description:
+				"Keyword-search memories when you know exact terms or identifiers. Returns full body text for each match; use memory_search_index when you only need compact candidates.",
+			inputSchema: searchInputSchema,
+			outputSchema: toolOutputSchemas.memory_search,
+			annotations: toolAnnotations.memory_search,
 		},
 		async (args, extra) => {
 			return withMcpRetrieval(
@@ -54,13 +106,14 @@ export function registerSearchTools(server: McpServer, context: ToolRegistration
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"memory_search_index",
-		"Keyword-search memories when you know exact terms or identifiers. Returns compact entries with IDs and titles, without bodies; expand selected IDs with memory_get or memory_get_observations.",
 		{
-			query: z.string().describe("Search query"),
-			limit: z.number().int().min(1).max(50).default(8).describe("Max results"),
-			...filterSchema,
+			description:
+				"Keyword-search memories when you know exact terms or identifiers. Returns compact entries with IDs and titles, without bodies; expand selected IDs with memory_get or memory_get_observations.",
+			inputSchema: searchIndexInputSchema,
+			outputSchema: toolOutputSchemas.memory_search_index,
+			annotations: toolAnnotations.memory_search_index,
 		},
 		async (args, extra) => {
 			return withMcpRetrieval(
@@ -98,15 +151,13 @@ export function registerSearchTools(server: McpServer, context: ToolRegistration
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"memory_explain",
-		"Explain search results with detailed scoring breakdown.",
 		{
-			query: z.string().optional().describe("Search query"),
-			ids: z.array(z.number().int()).max(200).optional().describe("Specific memory IDs to explain"),
-			limit: z.number().int().min(1).max(50).default(10).describe("Max results"),
-			include_pack_context: z.boolean().default(false).describe("Include formatted pack context"),
-			...filterSchema,
+			description: "Explain search results with detailed scoring breakdown.",
+			inputSchema: explainInputSchema,
+			outputSchema: toolOutputSchemas.memory_explain,
+			annotations: toolAnnotations.memory_explain,
 		},
 		async (args, extra) => {
 			return withMcpRetrieval(
@@ -140,12 +191,13 @@ export function registerSearchTools(server: McpServer, context: ToolRegistration
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"memory_recent",
-		"Return recent memories, newest first.",
 		{
-			limit: z.number().int().min(1).max(100).default(8).describe("Max results"),
-			...filterSchema,
+			description: "Return recent memories, newest first.",
+			inputSchema: recentInputSchema,
+			outputSchema: toolOutputSchemas.memory_recent,
+			annotations: toolAnnotations.memory_recent,
 		},
 		async (args, extra) => {
 			return withMcpRetrieval(
@@ -168,32 +220,14 @@ export function registerSearchTools(server: McpServer, context: ToolRegistration
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"memory_pack",
-		"Build a formatted context block for a concept or task using keyword and semantic search when embeddings are available, with automatic keyword-only fallback. Use for conceptually relevant context; use memory_search or memory_search_index for exact identifiers.",
 		{
-			context: z.string().describe("Context description to search for"),
-			limit: z.number().int().min(1).max(50).optional().describe("Max items to include"),
-			compact: z
-				.boolean()
-				.optional()
-				.describe(
-					"When true, render a scannable index of all items with full detail only for the top N (default 3). Saves tokens when broad overview matters more than per-item detail.",
-				),
-			compact_detail_count: z
-				.number()
-				.int()
-				.min(0)
-				.max(50)
-				.optional()
-				.describe("Number of items to show in full detail in compact mode (default 3)"),
-			compression_mode: z
-				.enum(["off", "compact", "ids"])
-				.optional()
-				.describe(
-					"Near-related compression mode: off disables it, compact applies only to compact rendering, ids applies in all modes. Defaults to CODEMEM_PACK_COMPRESSION or compact.",
-				),
-			...filterSchema,
+			description:
+				"Build a formatted context block for a concept or task using keyword and semantic search when embeddings are available, with automatic keyword-only fallback. Use for conceptually relevant context; use memory_search or memory_search_index for exact identifiers.",
+			inputSchema: packInputSchema,
+			outputSchema: toolOutputSchemas.memory_pack,
+			annotations: toolAnnotations.memory_pack,
 		},
 		async (args, extra) => {
 			return withMcpRetrieval(

--- a/packages/mcp-server/src/tools/timeline.ts
+++ b/packages/mcp-server/src/tools/timeline.ts
@@ -6,19 +6,37 @@ import { getManyForMcp } from "../memory-access.js";
 import { buildFilters } from "../project-scope.js";
 import { filterSchema } from "../schemas.js";
 import type { ToolRegistrationContext } from "../tool-context.js";
+import { toolAnnotations, toolOutputSchemas } from "../tool-contracts.js";
+
+const timelineInputSchema = {
+	query: z.string().optional().describe("Search query to find anchor"),
+	memory_id: z.number().int().optional().describe("Anchor memory ID"),
+	depth_before: z.number().int().min(0).default(3).describe("Items before anchor"),
+	depth_after: z.number().int().min(0).default(3).describe("Items after anchor"),
+	...filterSchema,
+};
+
+const expandInputSchema = {
+	ids: z
+		.array(z.union([z.number(), z.string()]))
+		.max(200)
+		.describe("Memory IDs to expand"),
+	depth_before: z.number().int().min(0).default(3).describe("Timeline items before"),
+	depth_after: z.number().int().min(0).default(3).describe("Timeline items after"),
+	include_observations: z.boolean().default(false).describe("Include full observation details"),
+	...filterSchema,
+};
 
 export function registerTimelineTools(server: McpServer, context: ToolRegistrationContext): void {
 	const { defaultProject, store } = context;
 
-	server.tool(
+	server.registerTool(
 		"memory_timeline",
-		"Get a chronological window of memories around an anchor (by ID or query).",
 		{
-			query: z.string().optional().describe("Search query to find anchor"),
-			memory_id: z.number().int().optional().describe("Anchor memory ID"),
-			depth_before: z.number().int().min(0).default(3).describe("Items before anchor"),
-			depth_after: z.number().int().min(0).default(3).describe("Items after anchor"),
-			...filterSchema,
+			description: "Get a chronological window of memories around an anchor (by ID or query).",
+			inputSchema: timelineInputSchema,
+			outputSchema: toolOutputSchemas.memory_timeline,
+			annotations: toolAnnotations.memory_timeline,
 		},
 		async (args, extra) => {
 			return withMcpRetrieval(
@@ -48,18 +66,13 @@ export function registerTimelineTools(server: McpServer, context: ToolRegistrati
 		},
 	);
 
-	server.tool(
+	server.registerTool(
 		"memory_expand",
-		"Fetch memories by ID with surrounding timeline context.",
 		{
-			ids: z
-				.array(z.union([z.number(), z.string()]))
-				.max(200)
-				.describe("Memory IDs to expand"),
-			depth_before: z.number().int().min(0).default(3).describe("Timeline items before"),
-			depth_after: z.number().int().min(0).default(3).describe("Timeline items after"),
-			include_observations: z.boolean().default(false).describe("Include full observation details"),
-			...filterSchema,
+			description: "Fetch memories by ID with surrounding timeline context.",
+			inputSchema: expandInputSchema,
+			outputSchema: toolOutputSchemas.memory_expand,
+			annotations: toolAnnotations.memory_expand,
 		},
 		async (args, extra) => {
 			return withMcpRetrieval(


### PR DESCRIPTION
## Description
Follow-up to merged guidance PR #1679. Adds SDK 1.30-compatible annotations and output schemas for all 14 MCP tools, with matching structuredContent on successful calls.

- Retains the existing compact JSON text payload alongside the structured object, including identical undefined/null serialization behavior.
- Adds isError: true to existing JSON error responses; errors omit structuredContent and bypass success-schema validation. This is an intentional client-visible change documented in the plugin reference.
- Uses conservative annotations for retrieval-ledger writes and external embedding/observer work; metadata tools are read-only, remember is additive/non-idempotent, and forget is destructive/idempotent with repeat not_found behavior.
- Preserves valid legacy rows with nullable confidence. Schemas describe stable required fields while allowing evolving metadata and detailed metrics.
- Adds real in-memory SDK coverage for every tool, populated/empty outputs, errors, legacy nullable rows, and text/structured parity.

## Type of Change
- [x] 🚀 Feature (protocol metadata and structured results)
- [x] 📚 Documentation
- [x] 🧪 Testing

## Testing
- [x] MCP package suite: 187 tests across 14 files
- [x] pnpm run tsc
- [x] Scoped Biome checks and git diff --check
- [x] Independent correctness/security review and pragmatic maintainability review

Scoped lint has six legacy warnings, reduced from eight on the parent; no new warnings. The full workspace test suite and E2E smoke were not run.

## Compatibility and size
- Existing content[0].text JSON is preserved; consumers should check isError before using structuredContent.
- Conservative readOnlyHint=false on ledger-writing retrievals can cause clients to request approval; hints are not authorization controls.
- Serialized tools/list increases from 25,219 to 42,128 bytes (+16,909; 67.05%) due to schemas and annotations. No token-count or model-selection improvement claimed.
- No MCP dependency upgrade, output-shape coercion, or core retrieval/auth behavior change.

## Checklist
- [x] Self-review completed
- [x] Documentation updated
- [x] Regression tests added
- [x] No new warnings introduced
