### PR TITLE
fix(mcp): classify queries by primary read-only behavior

### DIFF
--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -261,7 +261,7 @@ All 14 tools publish the standard optional `outputSchema` and `annotations` fiel
 
 Check `isError` before reading `structuredContent`: errors set `isError: true`, provide only the JSON error text, and omit `structuredContent` so SDKs do not validate an error against the success schema.
 
-Annotations are conservative client hints, not authorization; they can trigger approval prompts. Metadata/schema tools are read-only; retrieval tools are not read-only or idempotent because they append local delivery-ledger diagnostics. `memory_remember` adds data, while `memory_forget` is a destructive soft delete and is idempotent only in the no-added-effects sense—repeating it returns `not_found`. `memory_pack`, `memory_distill_candidates`, and `memory_remember` may load an external model or invoke the observer. These annotations do not change authentication or transport.
+Annotations describe each tool's primary operation on user data and its access beyond the local server; they are not authorization. Retrieval, metadata/schema, pack, and proposal-only distill tools are read-only. Incidental delivery logging, usage records, and caches do not change that classification. `memory_remember` adds data, while `memory_forget` is a destructive soft delete and is idempotent only in the no-added-effects sense—repeating it returns `not_found`. `memory_pack`, `memory_distill_candidates`, and `memory_remember` may load an external model or invoke the observer, so their open-world hints remain enabled. These annotations do not change authentication or transport, and clients may still apply their own prompting policies.
 
 `memory_distill_candidates` mines recurring lessons into reviewable context
 candidates. It is read-only and does not modify documentation files. By

--- a/packages/mcp-server/src/structured-output.test.ts
+++ b/packages/mcp-server/src/structured-output.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { connect, initTestSchema, MemoryStore } from "@codemem/core";
+import { connect, initTestSchema, MemoryStore, queryRetrievalAttempts } from "@codemem/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -11,21 +11,15 @@ type ToolResult = Awaited<ReturnType<Client["callTool"]>>;
 
 const expectedAnnotations = {
 	memory_distill_candidates: {
-		readOnlyHint: false,
-		destructiveHint: false,
-		idempotentHint: false,
+		readOnlyHint: true,
 		openWorldHint: true,
 	},
 	memory_expand: {
-		readOnlyHint: false,
-		destructiveHint: false,
-		idempotentHint: false,
+		readOnlyHint: true,
 		openWorldHint: false,
 	},
 	memory_explain: {
-		readOnlyHint: false,
-		destructiveHint: false,
-		idempotentHint: false,
+		readOnlyHint: true,
 		openWorldHint: false,
 	},
 	memory_forget: {
@@ -35,33 +29,23 @@ const expectedAnnotations = {
 		openWorldHint: false,
 	},
 	memory_get: {
-		readOnlyHint: false,
-		destructiveHint: false,
-		idempotentHint: false,
+		readOnlyHint: true,
 		openWorldHint: false,
 	},
 	memory_get_observations: {
-		readOnlyHint: false,
-		destructiveHint: false,
-		idempotentHint: false,
+		readOnlyHint: true,
 		openWorldHint: false,
 	},
 	memory_learn: {
 		readOnlyHint: true,
-		destructiveHint: false,
-		idempotentHint: true,
 		openWorldHint: false,
 	},
 	memory_pack: {
-		readOnlyHint: false,
-		destructiveHint: false,
-		idempotentHint: false,
+		readOnlyHint: true,
 		openWorldHint: true,
 	},
 	memory_recent: {
-		readOnlyHint: false,
-		destructiveHint: false,
-		idempotentHint: false,
+		readOnlyHint: true,
 		openWorldHint: false,
 	},
 	memory_remember: {
@@ -72,26 +56,18 @@ const expectedAnnotations = {
 	},
 	memory_schema: {
 		readOnlyHint: true,
-		destructiveHint: false,
-		idempotentHint: true,
 		openWorldHint: false,
 	},
 	memory_search: {
-		readOnlyHint: false,
-		destructiveHint: false,
-		idempotentHint: false,
+		readOnlyHint: true,
 		openWorldHint: false,
 	},
 	memory_search_index: {
-		readOnlyHint: false,
-		destructiveHint: false,
-		idempotentHint: false,
+		readOnlyHint: true,
 		openWorldHint: false,
 	},
 	memory_timeline: {
-		readOnlyHint: false,
-		destructiveHint: false,
-		idempotentHint: false,
+		readOnlyHint: true,
 		openWorldHint: false,
 	},
 } as const;
@@ -201,8 +177,8 @@ async function rememberFixturePair(): Promise<[number, number]> {
 }
 
 describe("registered MCP tool declarations", () => {
-	it("publishes an output schema and the audited conservative annotations for all 14 tools", async () => {
-		// Arrange: the expected map pins retrieval logging, external compute, and write semantics.
+	it("publishes an output schema and the audited annotations for all 14 tools", async () => {
+		// Arrange: the expected map pins read locality and write semantics.
 		const expectedNames = Object.keys(expectedAnnotations).toSorted();
 
 		// Act
@@ -217,6 +193,53 @@ describe("registered MCP tool declarations", () => {
 			expect(tool.annotations, `${tool.name} annotations`).toEqual(
 				expectedAnnotations[tool.name as keyof typeof expectedAnnotations],
 			);
+		}
+	});
+
+	it("keeps retrieval tools read-only when default ledger capture records a real query", async () => {
+		// Arrange: the fixture server disables capture, while this server uses the enabled default.
+		const [memoryId] = await rememberFixturePair();
+		const attemptsBefore = queryRetrievalAttempts(store.db, { surface: "mcp_search" }).length;
+		const captureServer = createCodememMcpServer(store, {
+			defaultProject: "contract-fixture",
+			envProject: null,
+		});
+		const captureClient = new Client({ name: "ledger-contract-test", version: "1.0.0" });
+		const [captureClientTransport, captureServerTransport] = InMemoryTransport.createLinkedPair();
+		await captureServer.connect(captureServerTransport);
+		await captureClient.connect(captureClientTransport);
+
+		try {
+			// Act: compare declarations across capture modes, then perform a captured retrieval.
+			const disabledCaptureTool = (await client.listTools()).tools.find(
+				(tool) => tool.name === "memory_search",
+			);
+			const defaultCaptureTool = (await captureClient.listTools()).tools.find(
+				(tool) => tool.name === "memory_search",
+			);
+			const result = assertStructuredSuccess(
+				await captureClient.callTool({
+					name: "memory_search",
+					arguments: { query: "contract sentinel", limit: 10 },
+				}),
+			);
+			const attemptsAfter = queryRetrievalAttempts(store.db, { surface: "mcp_search" }).length;
+
+			// Assert: incidental local ledger writes do not change the tool's primary classification.
+			expect(defaultCaptureTool?.annotations).toEqual({
+				readOnlyHint: true,
+				openWorldHint: false,
+			});
+			expect(defaultCaptureTool?.annotations).toEqual(disabledCaptureTool?.annotations);
+			expect(defaultCaptureTool?.annotations).not.toHaveProperty("destructiveHint");
+			expect(defaultCaptureTool?.annotations).not.toHaveProperty("idempotentHint");
+			expect(result.items).toEqual(
+				expect.arrayContaining([expect.objectContaining({ id: memoryId })]),
+			);
+			expect(attemptsAfter).toBe(attemptsBefore + 1);
+		} finally {
+			await captureClient.close();
+			await captureServer.close();
 		}
 	});
 });

--- a/packages/mcp-server/src/tool-contracts.ts
+++ b/packages/mcp-server/src/tool-contracts.ts
@@ -210,42 +210,29 @@ export const toolOutputSchemas = {
 	}),
 } as const;
 
-// Retrievals append delivery diagnostics to the local ledger, so they are not
-// read-only or idempotent even though their primary operation only reads memories.
-const localRetrievalAnnotations = {
-	readOnlyHint: false,
-	destructiveHint: false,
-	idempotentHint: false,
+// Incidental diagnostics and caches do not change the primary read operation.
+const localReadAnnotations = {
+	readOnlyHint: true,
 	openWorldHint: false,
 } satisfies ToolAnnotations;
 
-// Pack/distill execution may load embedding models or call the observer. Those
-// interactions can populate caches or contact entities outside the local store.
-const externalComputeAnnotations = {
-	readOnlyHint: false,
-	destructiveHint: false,
-	idempotentHint: false,
+// Pack/distill remain read-only while model loading or observer calls may access
+// entities outside the local store.
+const externalReadAnnotations = {
+	readOnlyHint: true,
 	openWorldHint: true,
 } satisfies ToolAnnotations;
 
-// These static catalogs neither mutate state nor interact outside the server.
-const metadataAnnotations = {
-	readOnlyHint: true,
-	destructiveHint: false,
-	idempotentHint: true,
-	openWorldHint: false,
-} satisfies ToolAnnotations;
-
 export const toolAnnotations = {
-	memory_search: localRetrievalAnnotations,
-	memory_search_index: localRetrievalAnnotations,
-	memory_explain: localRetrievalAnnotations,
-	memory_recent: localRetrievalAnnotations,
-	memory_pack: externalComputeAnnotations,
-	memory_timeline: localRetrievalAnnotations,
-	memory_expand: localRetrievalAnnotations,
-	memory_get: localRetrievalAnnotations,
-	memory_get_observations: localRetrievalAnnotations,
+	memory_search: localReadAnnotations,
+	memory_search_index: localReadAnnotations,
+	memory_explain: localReadAnnotations,
+	memory_recent: localReadAnnotations,
+	memory_pack: externalReadAnnotations,
+	memory_timeline: localReadAnnotations,
+	memory_expand: localReadAnnotations,
+	memory_get: localReadAnnotations,
+	memory_get_observations: localReadAnnotations,
 	// Remember is additive, but embedding generation can load external model assets.
 	memory_remember: {
 		readOnlyHint: false,
@@ -260,7 +247,7 @@ export const toolAnnotations = {
 		idempotentHint: true,
 		openWorldHint: false,
 	},
-	memory_distill_candidates: externalComputeAnnotations,
-	memory_schema: metadataAnnotations,
-	memory_learn: metadataAnnotations,
+	memory_distill_candidates: externalReadAnnotations,
+	memory_schema: localReadAnnotations,
+	memory_learn: localReadAnnotations,
 } as const satisfies Record<keyof typeof toolOutputSchemas, ToolAnnotations>;


### PR DESCRIPTION
## Description
Corrects the read-only interpretation shipped in #1680: incidental logging, usage bookkeeping, and caches do not turn a query into a user-data mutation.

- Mark retrieval, pack, proposal-only distill, schema, and learn tools read-only according to their primary operation.
- Keep openWorldHint independent: model/observer-capable reads still declare external interaction.
- Omit destructiveHint and idempotentHint on read-only tools, where they are not applicable.
- Preserve memory_remember and memory_forget mutation annotations exactly.
- Update docs and add a regression proving a real retrieval ledger write does not alter read-only classification, whether ledger capture is enabled or disabled.

No output schemas, tool outputs, core behavior, auth, or transport changes. Clients still control their own approval policy.

## Type of Change
- [x] 🐛 Bug fix
- [x] 📚 Documentation
- [x] 🧪 Testing

## Testing
- [x] MCP package: 188 tests across 14 files passed
- [x] Workspace TypeScript build passed
- [x] Scoped Biome and diff checks passed with no diagnostics
- [x] Independent source review confirmed no user-memory/context mutation on read paths

Full workspace test suite and live-client permission prompts were not tested.

## Checklist
- [x] Self-review completed
- [x] Documentation updated
- [x] Regression test added
- [x] No new warnings introduced
