### PR TITLE
fix(recall): fuse retrieval ranks and preserve candidate metadata

### DIFF
--- a/docs/pack-ranking.md
+++ b/docs/pack-ranking.md
@@ -1,0 +1,33 @@
+# Pack candidate ranking
+
+Hybrid packs combine keyword and semantic evidence with equal-weight reciprocal rank fusion (RRF), so incompatible raw score scales cannot decide which channel wins.
+
+## Ranking contract
+
+Each eligible channel ranks unique memory IDs by descending raw score before fusion.
+
+- Ranks start at one. The fixed rank constant is **60**, and each channel contributes `1 / (60 + rank)`; a missing channel contributes zero. This dampens differences near the top without calibrating BM25 and vector similarity onto one scale.
+- Duplicate IDs contribute once per channel, using their highest finite score. Invalid IDs and non-finite semantic scores contribute no evidence. Equal raw scores use ascending memory ID for deterministic ranks.
+- Fused relevance sorts first. Existing recency, kind, role, ownership, trust, and path preferences only break exact fused-score ties, calculated with a zero raw-score component. Memory ID breaks remaining ties.
+
+## Scope and compatibility
+
+Fusion consumes the existing keyword candidate pool and scoped, revalidated semantic rows; it does not expand authorization or eligibility.
+
+Semantic rows use the same row conversion as keyword rows, including authoritative actor, device, workspace, visibility, trust, and file metadata. Existing project, scope, visibility, and automatic requester-session checks still run before semantic fusion. Keyword candidate generation, truncation, and weak-result widening retain their existing behavior.
+
+Ordinary single-channel search and public raw `MemoryResult.score` values retain their existing meaning. For a hybrid duplicate, the keyword result supplies the public raw score; the semantic raw score remains available in diagnostics. Fusion is an ordering mechanism, not a confidence estimate or an abstention threshold.
+
+Hybrid ordering deliberately changes: recency, personal ownership, and soft shared-trust preferences now break exact fused-relevance ties rather than override relevance through arithmetic bonuses or penalties. An eligible shared or unreviewed memory can therefore outrank a personal or trusted memory when its fused relevance is higher. Access filters and ordinary single-channel search are unchanged; this is not a claim that all hybrid ordering is unchanged.
+
+## Diagnostics and later stages
+
+Candidate traces expose fusion evidence separately from public raw scores.
+
+`scores.fusion` contains `fts_score`, `fts_rank`, `semantic_score`, `semantic_rank`, `fused_score`, `rank_constant`, `fusion_rank`, and `secondary_score`. Missing channel evidence is `null`. `combined_score` retains its legacy raw-score-plus-preferences calculation and is **not the hybrid selection key**. Hybrid ordering uses `fused_score` first and `secondary_score` only for exact ties; `fusion_rank` records the pre-limit fused position, while the existing candidate `rank` still records first exposure order.
+
+Human-readable CLI traces show `fused_score` with eight significant digits and `fusion_rank` separately from the legacy two-decimal score display. Each pack runs at most one fusion merge within its chosen mode, so its ID-keyed evidence map describes one ranking pass rather than accumulating multiple queries.
+
+The retrieval ledger validates these supported fusion keys and persists them as flat numeric/null fields alongside existing score components. Readback and cached-attempt cloning retain all evidence. Unknown keys, conflicting nested/flat fields, and non-finite values remain invalid; legacy traces without fusion retain their existing serialized shape.
+
+Task-query broadening, later word-overlap and kind sorting, section allocation, fallback, deduplication, and budgeting remain separate stages. They can change final pack membership or order after fusion, so a better fused ranking alone does not guarantee a better final pack.

--- a/packages/cli/src/commands/pack-ledger.test.ts
+++ b/packages/cli/src/commands/pack-ledger.test.ts
@@ -7,6 +7,7 @@ import {
 	connect,
 	getRetrievalAttempt,
 	MemoryStore,
+	search,
 } from "@codemem/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { initTestSchema, insertTestSession } from "../../../core/src/test-utils.js";
@@ -35,6 +36,28 @@ beforeEach(() => {
 afterEach(() => {
 	store.close();
 	rmSync(directory, { recursive: true, force: true });
+});
+
+it("persists hybrid evidence through the CLI instrumented ledger handler", () => {
+	const sessionId = insertTestSession(store.db);
+	const memoryId = store.remember(sessionId, "decision", "quasar evidence", "quasar fact", 0.9);
+	const semantic = search(store, "quasar", 10).map((item) => ({ ...item, score: 0.75 }));
+	const artifacts = buildMemoryPackWithTrace(store, "quasar", 10, null, undefined, semantic);
+	const outcome = handleInstrumentedPackLedger(
+		store.db,
+		{ attempt_id: id(500), source: "opencode", request_id: "hybrid-ledger" },
+		"quasar",
+		{},
+		artifacts,
+	);
+	const fusion = artifacts.trace.retrieval.candidates.find((item) => item.id === memoryId)?.scores
+		.fusion;
+	if (!fusion) throw new Error("fixture must produce hybrid evidence");
+	const recorded = getRetrievalAttempt(store.db, id(500));
+	const scoreSummary = recorded?.exposures.find((item) => item.memoryId === memoryId)?.scoreSummary;
+	expect(outcome.ok).toBe(true);
+	expect(scoreSummary).toMatchObject(fusion);
+	expect(scoreSummary).not.toHaveProperty("fusion");
 });
 
 it("enriches the same local ledger through CLI delivery with retry-safe measurements", () => {

--- a/packages/cli/src/commands/pack.test.ts
+++ b/packages/cli/src/commands/pack.test.ts
@@ -156,7 +156,7 @@ describe("pack command", () => {
 		expect(longs).toContain("--all-projects");
 	});
 
-	it("renders grouped human-readable trace text", () => {
+	it.each([false, true])("renders grouped human-readable trace text (hybrid=%s)", (hybrid) => {
 		const rendered = renderPackTrace({
 			version: 1,
 			inputs: {
@@ -181,6 +181,18 @@ describe("pack command", () => {
 						title: "Keep Search as the inspector entry point",
 						preview: "Search is the first manual query surface.",
 						scores: {
+							fusion: hybrid
+								? {
+										fts_score: 1.2,
+										fts_rank: 1,
+										semantic_score: null,
+										semantic_rank: null,
+										fused_score: 1 / 61,
+										fusion_rank: 2,
+										rank_constant: 60,
+										secondary_score: 0.6,
+									}
+								: undefined,
 							base_score: 1.2,
 							combined_score: 2.4,
 							recency: 0.9,
@@ -266,6 +278,16 @@ describe("pack command", () => {
 		expect(rendered).toContain("truncated: no");
 		expect(rendered).toContain("Final pack");
 		expect(rendered).toContain("## Summary");
+		expect(rendered).toContain("combined=2.40 base=1.20");
+		if (hybrid) {
+			expect(rendered).toContain("fused_score=0.016393443 fusion_rank=2");
+			expect(rendered).toContain(
+				"combined_score is a legacy diagnostic, not the hybrid selection key",
+			);
+		} else {
+			expect(rendered).not.toContain("fused_score=");
+			expect(rendered).not.toContain("hybrid selection key");
+		}
 	});
 
 	it("supports the main pack commander path with json output", async () => {

--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -245,6 +245,12 @@ function describeCandidate(candidate: PackTrace["retrieval"]["candidates"][numbe
 	if (candidate.section) lines.push(`   - section: ${candidate.section}`);
 	if (candidate.reasons.length > 0) lines.push(`   - reasons: ${candidate.reasons.join(", ")}`);
 	if (scoreParts) lines.push(`   - scores: ${scoreParts}`);
+	const fusion = candidate.scores.fusion;
+	if (fusion) {
+		lines.push(
+			`   - hybrid: fused_score=${fusion.fused_score.toPrecision(8)} fusion_rank=${fusion.fusion_rank}; combined_score is a legacy diagnostic, not the hybrid selection key`,
+		);
+	}
 	if (candidate.preview) lines.push(`   - preview: ${candidate.preview}`);
 	return lines;
 }

--- a/packages/core/src/pack-fusion.test.ts
+++ b/packages/core/src/pack-fusion.test.ts
@@ -1,0 +1,451 @@
+import { describe, expect, it } from "vitest";
+import { buildMemoryPackWithTrace } from "./pack.js";
+import { fusePackCandidates } from "./pack-fusion.js";
+import { scoreResult, search } from "./search.js";
+import { MemoryStore } from "./store.js";
+import { insertTestSession } from "./test-utils.js";
+import type { MemoryResult } from "./types.js";
+
+function memory(id: number, score: number): MemoryResult {
+	return {
+		id,
+		score,
+		kind: "discovery",
+		title: `item ${id}`,
+		body_text: "evidence",
+		confidence: 0.8,
+		created_at: "2026-01-01",
+		updated_at: "2026-01-01",
+		tags_text: "",
+		session_id: 1,
+		metadata: {},
+		narrative: null,
+		facts: null,
+	};
+}
+
+describe("pack reciprocal rank fusion", () => {
+	it("keeps hybrid pack ranking invariant to semantic scale and input order", () => {
+		// Arrange
+		const store = new MemoryStore(":memory:");
+		try {
+			const session = insertTestSession(store.db);
+			const exactId = store.remember(
+				session,
+				"decision",
+				"RFC-427",
+				"RFC-427 defines the retry protocol",
+				0.9,
+			);
+			store.remember(
+				session,
+				"discovery",
+				"Retry protocol notes",
+				"Background notes that mention RFC-427",
+				0.8,
+			);
+			const semanticOnlyId = store.remember(
+				session,
+				"discovery",
+				"Transport backoff",
+				"Semantically related transport guidance",
+				0.8,
+			);
+			const semantic = [memory(semanticOnlyId, 0.99), memory(exactId, 0.5)];
+			const rescaledAndShuffled = [memory(exactId, 500), memory(semanticOnlyId, 990)];
+			const exactFtsRank =
+				search(store, "RFC-427", 10).findIndex((item) => item.id === exactId) + 1;
+
+			// Act
+			const baseline = buildMemoryPackWithTrace(store, "RFC-427", 10, null, undefined, semantic);
+			const rescaled = buildMemoryPackWithTrace(
+				store,
+				"RFC-427",
+				10,
+				null,
+				undefined,
+				rescaledAndShuffled,
+			);
+
+			// Assert
+			expect(exactFtsRank).toBeGreaterThan(0);
+			expect(rescaled.response.item_ids).toEqual(baseline.response.item_ids);
+			expect(baseline.response.item_ids[0]).toBe(exactId);
+			expect(
+				baseline.trace.retrieval.candidates.find((item) => item.id === exactId)?.scores.fusion,
+			).toMatchObject({ fts_rank: exactFtsRank, semantic_rank: 2, fusion_rank: 1 });
+			expect(
+				rescaled.trace.retrieval.candidates.find((item) => item.id === exactId)?.scores.fusion,
+			).toMatchObject({
+				fts_rank: exactFtsRank,
+				semantic_rank: 2,
+				fusion_rank: 1,
+				semantic_score: 500,
+			});
+		} finally {
+			store.close();
+		}
+	});
+
+	it.each(["quasar", "continue quasar", "recall quasar"])(
+		"retains both channel traces for %s",
+		(query) => {
+			const store = new MemoryStore(":memory:");
+			try {
+				const session = insertTestSession(store.db);
+				const id = store.remember(session, "discovery", "quasar", "quasar evidence", 0.8);
+				const lexical = search(store, query, 10);
+				const { trace } = buildMemoryPackWithTrace(store, query, 10, null, undefined, [
+					memory(id, 0.7),
+				]);
+				const scores = trace.retrieval.candidates.find((item) => item.id === id)?.scores;
+				expect(scores?.fusion).toMatchObject({
+					fts_rank: 1,
+					semantic_rank: 1,
+					semantic_score: 0.7,
+					fusion_rank: 1,
+				});
+				expect(scores?.fusion?.fused_score).toBe(2 / 61);
+				const lexicalItem = lexical[0];
+				if (!lexicalItem) throw new Error("fixture must produce a lexical candidate");
+				expect(scores?.combined_score).toBe(
+					scoreResult(store, lexicalItem, undefined, query).combined_score,
+				);
+				if (query === "quasar") expect(scores?.fusion?.fts_score).toBe(lexical[0]?.score);
+			} finally {
+				store.close();
+			}
+		},
+	);
+
+	it("converts scoped semantic metadata like keyword metadata rather than trusting supplied fields", () => {
+		// Arrange
+		const store = new MemoryStore(":memory:");
+		try {
+			const session = insertTestSession(store.db);
+			const lexicalId = store.remember(session, "discovery", "quasar", "quasar evidence", 0.8);
+			const semanticId = store.remember(session, "discovery", "nebula", "nebula evidence", 0.8);
+			store.db
+				.prepare(
+					`UPDATE memory_items
+					 SET metadata_json = ?, actor_id = ?, actor_display_name = ?, visibility = ?,
+					     workspace_id = ?, workspace_kind = ?, origin_device_id = ?, origin_source = ?,
+					     trust_state = ?
+					 WHERE id = ?`,
+				)
+				.run(
+					JSON.stringify({ actor_id: "forged", custom: "retained", workspace_id: "forged" }),
+					store.actorId,
+					"Local Tester",
+					"private",
+					"workspace-real",
+					"repository",
+					store.deviceId,
+					"opencode",
+					"reviewed",
+					semanticId,
+				);
+			const expected = search(store, "nebula", 10)[0]?.metadata;
+			const supplied = {
+				...memory(semanticId, 0.8),
+				metadata: {
+					actor_id: "forged",
+					origin_device_id: "forged",
+					trust_state: "forged",
+					workspace_id: "forged",
+				},
+			};
+
+			// Act
+			const { response, trace } = buildMemoryPackWithTrace(store, "quasar", 10, null, undefined, [
+				supplied,
+			]);
+
+			// Assert
+			expect(response.items.find((item) => item.id === semanticId)?.metadata).toEqual(expected);
+			expect(expected).toMatchObject({
+				actor_id: store.actorId,
+				actor_display_name: "Local Tester",
+				custom: "retained",
+				origin_device_id: store.deviceId,
+				origin_source: "opencode",
+				trust_state: "reviewed",
+				visibility: "private",
+				workspace_id: "workspace-real",
+				workspace_kind: "repository",
+			});
+			expect(
+				trace.retrieval.candidates.find((item) => item.id === lexicalId)?.scores.fusion
+					?.semantic_rank,
+			).toBeNull();
+			expect(
+				trace.retrieval.candidates.find((item) => item.id === semanticId)?.scores.fusion?.fts_rank,
+			).toBeNull();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("is invariant to independent channel scales and preserves raw evidence", () => {
+		const fts = [memory(1, 37.8), memory(2, 12)];
+		const semantic = [memory(3, 0.9), memory(2, 0.61)];
+		const fused = fusePackCandidates(fts, semantic, () => 0);
+		const scaled = fusePackCandidates(
+			fts.map((item) => ({ ...item, score: item.score / 10000 })),
+			semantic.map((item) => ({ ...item, score: item.score * 1000 })),
+			() => 0,
+		);
+		expect(fused.map(({ item }) => item.id)).toEqual([2, 1, 3]);
+		expect(scaled.map(({ item }) => item.id)).toEqual([2, 1, 3]);
+		expect(fused[0]?.evidence).toMatchObject({
+			fts_score: 12,
+			semantic_score: 0.61,
+			fts_rank: 2,
+			semantic_rank: 2,
+		});
+		expect(fused[0]?.item.score).toBe(12);
+		expect(fts[0]?.score).toBe(37.8);
+	});
+
+	it("counts each channel once and ignores malformed evidence without rank gaps", () => {
+		const fused = fusePackCandidates(
+			[memory(1, 4), memory(1, 2), memory(-1, 100), memory(4, Number.NaN)],
+			[memory(2, Number.POSITIVE_INFINITY), memory(2, 0.8), memory(1, 0.7), memory(1, 0.6)],
+			() => 0,
+		);
+		expect(fused.map(({ item }) => item.id)).toEqual([1, 2]);
+		expect(fused[0]?.evidence.fused_score).toBe(1 / 61 + 1 / 62);
+		expect(fused[1]?.evidence.semantic_rank).toBe(1);
+	});
+
+	it("deduplicates and rejects malformed semantic evidence in the hybrid pack trace", () => {
+		// Arrange
+		const store = new MemoryStore(":memory:");
+		try {
+			const session = insertTestSession(store.db);
+			const firstId = store.remember(
+				session,
+				"discovery",
+				"Hybrid duplicate first",
+				"hybridduplicate evidence",
+				0.8,
+			);
+			const secondId = store.remember(
+				session,
+				"discovery",
+				"Hybrid duplicate second",
+				"hybridduplicate evidence",
+				0.8,
+			);
+			const malformedStoredId = store.remember(
+				session,
+				"discovery",
+				"Malformed score",
+				"hybridduplicate evidence",
+				0.8,
+			);
+			const semantic = [
+				memory(secondId, 0.1),
+				memory(-1, 100),
+				memory(firstId, 0.8),
+				memory(malformedStoredId, Number.NaN),
+				memory(secondId, 0.9),
+				memory(Number.MAX_SAFE_INTEGER + 1, 200),
+			];
+
+			// Act
+			const { trace } = buildMemoryPackWithTrace(
+				store,
+				"hybridduplicate",
+				10,
+				null,
+				undefined,
+				semantic,
+			);
+			const shuffled = buildMemoryPackWithTrace(store, "hybridduplicate", 10, null, undefined, [
+				memory(secondId, 0.9),
+				memory(malformedStoredId, Number.NaN),
+				memory(secondId, 0.1),
+				memory(firstId, 0.8),
+			]).trace;
+			const candidates = trace.retrieval.candidates;
+			const firstFusion = candidates.find((item) => item.id === firstId)?.scores.fusion;
+			const secondFusion = candidates.find((item) => item.id === secondId)?.scores.fusion;
+			const semanticRanks = (candidateTrace: typeof trace) =>
+				candidateTrace.retrieval.candidates
+					.filter((item) => item.scores.fusion?.semantic_rank != null)
+					.map((item) => [item.id, item.scores.fusion?.semantic_rank]);
+
+			// Assert
+			expect(candidates.filter((item) => item.id === secondId)).toHaveLength(1);
+			expect(secondFusion).toMatchObject({ semantic_rank: 1, semantic_score: 0.9 });
+			expect(firstFusion).toMatchObject({ semantic_rank: 2, semantic_score: 0.8 });
+			expect(semanticRanks(shuffled)).toEqual(semanticRanks(trace));
+			expect(candidates.map((item) => item.id)).not.toContain(-1);
+			expect(candidates.map((item) => item.id)).not.toContain(Number.MAX_SAFE_INTEGER + 1);
+			expect(
+				candidates.find((item) => item.id === malformedStoredId)?.scores.fusion?.semantic_rank,
+			).toBeNull();
+		} finally {
+			store.close();
+		}
+	});
+
+	it("preserves empty and single-channel behavior", () => {
+		// Arrange
+		const fts = [memory(2, 1), memory(1, 2)];
+		const semantic = [memory(4, 0.6), memory(3, 0.8)];
+
+		// Act
+		const empty = fusePackCandidates([], [], () => 0);
+		const ftsOnly = fusePackCandidates(fts, [], () => 0);
+		const semanticOnly = fusePackCandidates([], semantic, () => 0);
+
+		// Assert
+		expect(empty).toEqual([]);
+		expect(ftsOnly.map(({ item }) => item.id)).toEqual([1, 2]);
+		expect(ftsOnly.map(({ evidence }) => evidence.semantic_rank)).toEqual([null, null]);
+		expect(semanticOnly.map(({ item }) => item.id)).toEqual([3, 4]);
+		expect(semanticOnly.map(({ evidence }) => evidence.fts_rank)).toEqual([null, null]);
+	});
+
+	it("keeps project, visibility, scope, and requester-session gates on hybrid candidates", () => {
+		// Arrange
+		const store = new MemoryStore(":memory:");
+		try {
+			const currentSession = insertTestSession(store.db);
+			const foreignSession = insertTestSession(store.db);
+			const otherProjectSession = Number(
+				store.db
+					.prepare(
+						"INSERT INTO sessions(started_at, cwd, project, user, tool_version) VALUES (?, ?, ?, ?, ?)",
+					)
+					.run(
+						"2026-01-01T00:00:00.000Z",
+						"/tmp/other-project",
+						"other-project",
+						"test-user",
+						"test",
+					).lastInsertRowid,
+			);
+			store.db
+				.prepare(
+					"INSERT INTO opencode_sessions(source, stream_id, opencode_session_id, session_id, created_at) VALUES (?, ?, ?, ?, ?)",
+				)
+				.run(
+					"opencode",
+					"host-current",
+					"host-current",
+					currentSession,
+					"2026-01-01T00:00:00.000Z",
+				);
+			const currentSummaryId = store.remember(
+				currentSession,
+				"session_summary",
+				"Current boundary summary",
+				"boundaryhybrid evidence",
+				0.9,
+			);
+			const durableId = store.remember(
+				foreignSession,
+				"decision",
+				"Durable boundary fact",
+				"boundaryhybrid evidence",
+				0.8,
+			);
+			const foreignSummaryId = store.remember(
+				foreignSession,
+				"session_summary",
+				"Foreign boundary summary",
+				"boundaryhybrid evidence",
+				0.99,
+			);
+			const wrongProjectId = store.remember(
+				otherProjectSession,
+				"decision",
+				"Wrong project boundary fact",
+				"boundaryhybrid evidence",
+				0.99,
+			);
+			const foreignPrivateId = store.remember(
+				foreignSession,
+				"decision",
+				"Foreign private boundary fact",
+				"boundaryhybrid evidence",
+				0.99,
+			);
+			store.db
+				.prepare(
+					"UPDATE memory_items SET actor_id = 'remote-actor', origin_device_id = 'remote-device', visibility = 'private' WHERE id = ?",
+				)
+				.run(foreignPrivateId);
+			const foreignPrivateRow = store.db
+				.prepare("SELECT * FROM memory_items WHERE id = ?")
+				.get(foreignPrivateId) as Record<string, unknown>;
+			expect(store.memoryOwnedBySelf(foreignPrivateRow)).toBe(false);
+			store.db
+				.prepare(
+					`INSERT INTO replication_scopes(
+						scope_id, label, kind, authority_type, coordinator_id, group_id,
+						membership_epoch, status, created_at, updated_at
+					 ) VALUES (?, ?, 'team', 'coordinator', 'fixture-coordinator', 'fixture-group', 0, 'active', ?, ?)`,
+				)
+				.run(
+					"hidden-boundary-scope",
+					"Hidden boundary scope",
+					"2026-01-01T00:00:00.000Z",
+					"2026-01-01T00:00:00.000Z",
+				);
+			const hiddenSharedId = store.remember(
+				foreignSession,
+				"decision",
+				"Hidden shared boundary fact",
+				"boundaryhybrid evidence",
+				0.99,
+			);
+			store.db
+				.prepare("UPDATE memory_items SET visibility = 'shared', scope_id = ? WHERE id = ?")
+				.run("hidden-boundary-scope", hiddenSharedId);
+			const allIds = [
+				currentSummaryId,
+				durableId,
+				foreignSummaryId,
+				wrongProjectId,
+				foreignPrivateId,
+				hiddenSharedId,
+			];
+
+			// Act
+			const { response, trace } = buildMemoryPackWithTrace(
+				store,
+				"boundaryhybrid",
+				10,
+				null,
+				// Local-default rows pass the scope gate regardless of ownership.
+				// Exercise visibility explicitly rather than assuming a private-row deny rule.
+				{ project: "test-project", include_visibility: ["shared"] },
+				allIds.map((id, index) => memory(id, 1 - index / 10)),
+				undefined,
+				{ source: "opencode", hostSessionId: "host-current" },
+			);
+			const candidateIds = trace.retrieval.candidates.map((item) => item.id);
+
+			// Assert
+			expect(response.item_ids).toContain(currentSummaryId);
+			expect(response.item_ids).toContain(durableId);
+			for (const hiddenId of [foreignSummaryId, wrongProjectId, foreignPrivateId, hiddenSharedId]) {
+				expect(candidateIds).not.toContain(hiddenId);
+				expect(response.item_ids).not.toContain(hiddenId);
+			}
+		} finally {
+			store.close();
+		}
+	});
+
+	it("lets preferences break ties but never overtake stronger fused relevance", () => {
+		const fused = fusePackCandidates([memory(1, 10), memory(2, 9)], [memory(3, 0.8)], (item) =>
+			item.id === 1 ? -1000 : 1000,
+		);
+		expect(fused.map(({ item }) => item.id)).toEqual([3, 1, 2]);
+	});
+});

--- a/packages/core/src/pack-fusion.ts
+++ b/packages/core/src/pack-fusion.ts
@@ -1,0 +1,60 @@
+import type { MemoryResult, PackFusionEvidence } from "./types.js";
+
+/** Equal-weight reciprocal rank fusion; 60 dampens differences near the top. */
+export const PACK_RRF_RANK_CONSTANT = 60;
+
+function rankChannel(results: MemoryResult[]): MemoryResult[] {
+	const seen = new Set<number>();
+	return results
+		.filter((item) => Number.isSafeInteger(item.id) && item.id > 0 && Number.isFinite(item.score))
+		.toSorted((a, b) => b.score - a.score || a.id - b.id)
+		.filter((item) => {
+			if (seen.has(item.id)) return false;
+			seen.add(item.id);
+			return true;
+		});
+}
+
+/** Rank only within each raw-score scale. Never replace a result's public score. */
+export function fusePackCandidates(
+	fts: MemoryResult[],
+	semantic: MemoryResult[],
+	secondaryScore: (item: MemoryResult) => number,
+): Array<{ item: MemoryResult; evidence: PackFusionEvidence }> {
+	const candidates = new Map<number, { item: MemoryResult; evidence: PackFusionEvidence }>();
+	for (const [channel, results] of [
+		["fts", fts],
+		["semantic", semantic],
+	] as const) {
+		for (const [index, item] of rankChannel(results).entries()) {
+			const rank = index + 1;
+			const entry = candidates.get(item.id) ?? {
+				item,
+				evidence: {
+					fts_score: null,
+					fts_rank: null,
+					semantic_score: null,
+					semantic_rank: null,
+					fused_score: 0,
+					rank_constant: PACK_RRF_RANK_CONSTANT,
+					fusion_rank: 0,
+					secondary_score: secondaryScore(item),
+				},
+			};
+			entry.evidence[`${channel}_score`] = item.score;
+			entry.evidence[`${channel}_rank`] = rank;
+			entry.evidence.fused_score += 1 / (PACK_RRF_RANK_CONSTANT + rank);
+			candidates.set(item.id, entry);
+		}
+	}
+	const ranked = [...candidates.values()].sort(
+		(a, b) =>
+			b.evidence.fused_score - a.evidence.fused_score ||
+			b.evidence.secondary_score - a.evidence.secondary_score ||
+			a.item.id - b.item.id,
+	);
+	return ranked.map((entry, index) => ({
+		...entry,
+		evidence: { ...entry.evidence, fusion_rank: index + 1 },
+	}));
+}

--- a/packages/core/src/pack.ts
+++ b/packages/core/src/pack.ts
@@ -15,16 +15,24 @@
  */
 
 import { createHash } from "node:crypto";
-import { type Database, fromJson } from "./db.js";
+import type { Database } from "./db.js";
 import { buildFilterClausesWithContext } from "./filters.js";
 import { inferMemoryRole, readArtifactClass } from "./memory-quality.js";
+import { fusePackCandidates } from "./pack-fusion.js";
 import { projectBasename } from "./project.js";
 import { sanitizeSearchQuery } from "./query-sanitizer.js";
 import { memoryLooksRecapLike, queryPrefersRecap } from "./recap-policy.js";
 import { findByFile } from "./ref-queries.js";
 import { MAX_RETRIEVAL_DIAGNOSTIC_EXPOSURES } from "./retrieval-ledger.js";
 import type { StoreHandle } from "./search.js";
-import { ownershipFilterContext, rerankResults, scoreResult, search, timeline } from "./search.js";
+import {
+	ownershipFilterContext,
+	rerankResults,
+	rowToMemoryResult,
+	scoreResult,
+	search,
+	timeline,
+} from "./search.js";
 import {
 	canonicalMemoryKind,
 	getSummaryMetadata,
@@ -38,6 +46,7 @@ import type {
 	MemoryFilters,
 	MemoryItemResponse,
 	MemoryResult,
+	PackFusionEvidence,
 	PackItem,
 	PackRenderOptions,
 	PackResponse,
@@ -1327,8 +1336,7 @@ function recordPackUsage(store: StoreHandle, metrics: Record<string, unknown>): 
  * 5. Format sections into pack_text
  */
 /**
- * Merge FTS and semantic results by ID, keeping the higher score for dupes.
- * Matches Python's always-merge behavior when semantic results are available.
+ * Fuse eligible channel ranks, retaining raw scores for diagnostics.
  */
 function mergeResults(
 	store: StoreHandle,
@@ -1344,26 +1352,37 @@ function mergeResults(
 	semanticCandidates: MemoryResult[];
 	ftsCount: number;
 	semanticCount: number;
+	fusion: Map<number, PackFusionEvidence>;
 } {
-	const seen = new Map<number, MemoryResult>();
-	for (const r of ftsResults) {
-		const existing = seen.get(r.id);
-		if (!existing || r.score > existing.score) seen.set(r.id, r);
-	}
 	const scopedSemanticResults = rehydrateScopedCandidateResults(
 		store,
 		semanticResults,
 		filters,
 	).filter(eligible);
-	let semanticCount = 0;
-	for (const r of scopedSemanticResults) {
-		if (!seen.has(r.id)) semanticCount++;
-		const existing = seen.get(r.id);
-		if (!existing || r.score > existing.score) seen.set(r.id, r);
-	}
-	const candidates = [...seen.values()];
-	const merged = rerankResults(store, candidates, limit, filters, query);
+	const ftsIds = new Set(ftsResults.map((item) => item.id));
+	// FTS candidates already passed eligibility in retrieval.search -> searchOnce.
+	const semanticCount = scopedSemanticResults.filter((item) => !ftsIds.has(item.id)).length;
+	const referenceNow = new Date();
+	const ownership =
+		store.buildOwnershipPredicate?.() ?? ((item: MemoryResult) => store.memoryOwnedBySelf(item));
+	const ranked = fusePackCandidates(
+		ftsResults,
+		scopedSemanticResults,
+		(item) =>
+			scoreResult(store, { ...item, score: 0 }, filters, query, referenceNow, ownership)
+				.combined_score ?? 0,
+	);
+	const hybrid =
+		ranked.some(({ evidence }) => evidence.fts_rank != null) &&
+		ranked.some(({ evidence }) => evidence.semantic_rank != null);
+	const candidates = hybrid
+		? ranked.map(({ item }) => item)
+		: [...ftsResults, ...scopedSemanticResults];
+	const merged = hybrid
+		? candidates.slice(0, limit)
+		: rerankResults(store, candidates, limit, filters, query);
 	return {
+		fusion: new Map(hybrid ? ranked.map(({ item, evidence }) => [item.id, evidence]) : []),
 		merged,
 		candidates,
 		semanticCandidates: scopedSemanticResults,
@@ -1372,17 +1391,23 @@ function mergeResults(
 	};
 }
 
+function validCandidateResultsById(candidates: MemoryResult[]): Map<number, MemoryResult> {
+	const originalById = new Map<number, MemoryResult>();
+	for (const item of candidates) {
+		if (!Number.isSafeInteger(item.id) || item.id <= 0) continue;
+		if (!Number.isFinite(item.score)) continue;
+		const original = originalById.get(item.id);
+		if (!original || item.score > original.score) originalById.set(item.id, item);
+	}
+	return originalById;
+}
+
 function rehydrateScopedCandidateResults(
 	store: StoreHandle,
 	candidates: MemoryResult[],
 	filters?: MemoryFilters,
 ): MemoryResult[] {
-	if (candidates.length === 0) return [];
-	const originalById = new Map<number, MemoryResult>();
-	for (const item of candidates) {
-		if (!Number.isSafeInteger(item.id) || item.id <= 0) continue;
-		if (!originalById.has(item.id)) originalById.set(item.id, item);
-	}
+	const originalById = validCandidateResultsById(candidates);
 	const ids = [...originalById.keys()];
 	if (ids.length === 0) return [];
 
@@ -1410,22 +1435,12 @@ function rehydrateScopedCandidateResults(
 			const id = Number(row.id);
 			const original = originalById.get(id);
 			if (!original) continue;
-			const metadataJson = row.metadata_json == null ? null : String(row.metadata_json);
-			scopedById.set(id, {
+			const preserveFilteredKind =
+				typeof filters?.kind === "string" && filters.kind.trim().length > 0;
+			scopedById.set(
 				id,
-				kind: canonicalMemoryKind(String(row.kind ?? "observation"), metadataJson),
-				title: String(row.title ?? ""),
-				body_text: String(row.body_text ?? ""),
-				confidence: Number(row.confidence ?? 0),
-				created_at: String(row.created_at ?? ""),
-				updated_at: String(row.updated_at ?? ""),
-				tags_text: String(row.tags_text ?? ""),
-				score: original.score,
-				session_id: Number(row.session_id),
-				metadata: fromJson(metadataJson),
-				narrative: row.narrative == null ? null : String(row.narrative),
-				facts: row.facts == null ? null : String(row.facts),
-			});
+				rowToMemoryResult({ ...row, score: original.score }, preserveFilteredKind),
+			);
 		}
 	}
 
@@ -1495,13 +1510,29 @@ function createPackRetrieval(
 	},
 ) {
 	const { limit, filters, eligible, summarySessionId } = options;
+	// Each mutually exclusive pack mode merges at most once, so IDs identify
+	// evidence from one fusion pass; this map is not a multi-query accumulator.
+	const fusion = new Map<number, PackFusionEvidence>();
 	return {
+		fusion,
 		search: (query: string) => search(store, query, limit, filters, eligible, summarySessionId),
-		merge: (results: MemoryResult[], semantic: MemoryResult[], query: string) =>
-			mergeResults(store, results, semantic, limit, query, filters, eligible),
+		merge: (results: MemoryResult[], semantic: MemoryResult[], query: string) => {
+			const merged = mergeResults(store, results, semantic, limit, query, filters, eligible);
+			for (const [id, evidence] of merged.fusion) fusion.set(id, evidence);
+			return merged;
+		},
 		fileRefs: (results: MemoryResult[]) =>
 			mergeFileRefCandidates(store, results, filters, limit, summarySessionId).filter(eligible),
 	};
+}
+
+function withFusionScores(
+	scores: ReturnType<typeof scoreResult>,
+	fusion: PackFusionEvidence | undefined,
+): ReturnType<typeof scoreResult> {
+	if (!fusion) return scores;
+	// Keep the legacy diagnostic calculation; fusion alone supplies the hybrid key.
+	return { ...scores, fusion };
 }
 
 function buildPackArtifacts(
@@ -2105,7 +2136,7 @@ function buildPackArtifacts(
 						: "dropped";
 		const baseScores = scoreResult(store, item, filters, query, referenceNow, traceOwnership);
 		const scoredCandidate = {
-			...baseScores,
+			...withFusionScores(baseScores, retrieval.fusion.get(item.id)),
 			text_overlap: textOverlapScore(item, query),
 			tag_overlap: countOverlap(item.tags_text, queryContentTokens(query)),
 		};

--- a/packages/core/src/prompt-pack-ledger.test.ts
+++ b/packages/core/src/prompt-pack-ledger.test.ts
@@ -11,6 +11,7 @@ import {
 	recordPromptPackTerminal,
 } from "./prompt-pack-ledger.js";
 import { getRetrievalAttempt, updateRetrievalDelivery } from "./retrieval-ledger.js";
+import { search } from "./search.js";
 import { MemoryStore } from "./store.js";
 import { initTestSchema, insertTestSession } from "./test-utils.js";
 import type { MemoryResult } from "./types.js";
@@ -113,6 +114,53 @@ describe("prompt-pack retrieval ledger", () => {
 		expect(attempt?.exposures.flatMap((exposure) => exposure.reasonCodes ?? [])).toEqual(
 			expect.arrayContaining([expect.stringMatching(/^[a-z0-9][a-z0-9._-]{0,63}$/)]),
 		);
+	});
+
+	it("persists and clones hybrid channel evidence through automatic pack recording", () => {
+		store.remember(sessionId, "decision", "quasar shared", "quasar shared evidence", 0.8);
+		store.remember(sessionId, "discovery", "quasar lexical", "quasar lexical evidence", 0.8);
+		store.remember(sessionId, "discovery", "nebula semantic", "nebula semantic evidence", 0.8);
+		const lexical = search(store, "quasar", 10);
+		const semanticOnly = search(store, "nebula", 10);
+		const semantic = [...lexical.slice(0, 1), ...semanticOnly].map((item, index) => ({
+			...item,
+			score: 0.9 - index / 10,
+		}));
+		const artifacts = buildMemoryPackWithTrace(store, "quasar", 10, null, undefined, semantic);
+		expect(artifacts.trace.retrieval.candidates.filter((item) => item.scores.fusion)).toHaveLength(
+			3,
+		);
+		const outcome = recordPromptPackArtifacts(
+			store.db,
+			{
+				attemptId: id(500),
+				startedAt,
+				completedAt,
+				source: "opencode",
+			},
+			"quasar",
+			undefined,
+			artifacts,
+		);
+		expect(outcome.ok).toBe(true);
+		const recorded = getRetrievalAttempt(store.db, id(500));
+		for (const candidate of artifacts.trace.retrieval.candidates) {
+			const { fusion, ...legacyScores } = candidate.scores;
+			expect(
+				recorded?.exposures.find((item) => item.memoryId === candidate.id)?.scoreSummary,
+			).toEqual({ ...legacyScores, ...fusion });
+		}
+		expect(
+			clonePromptPackAttempt(store.db, id(500), {
+				attemptId: id(501),
+				startedAt,
+				completedAt,
+				source: "opencode",
+			}).ok,
+		).toBe(true);
+		expect(
+			getRetrievalAttempt(store.db, id(501))?.exposures.map((item) => item.scoreSummary),
+		).toEqual(recorded?.exposures.map((item) => item.scoreSummary));
 	});
 
 	it("treats an exact caller retry as idempotent", () => {

--- a/packages/core/src/retrieval-ledger.test.ts
+++ b/packages/core/src/retrieval-ledger.test.ts
@@ -2230,6 +2230,9 @@ describe("retrieval attribution ledger", () => {
 			'{"combined_score":[]}',
 			'{"combined_score":1e309}',
 			'{"recency":null}',
+			'{"fused_score":1e309}',
+			'{"fts_rank":"1"}',
+			'{"unknown_fusion_score":1}',
 		]) {
 			db.prepare(
 				"UPDATE retrieval_exposures SET score_summary_json = ? WHERE attempt_id = ? AND rank = 1",
@@ -2240,6 +2243,48 @@ describe("retrieval attribution ledger", () => {
 			expect(queryRetrievalAttempts(db).map((attempt) => attempt.attemptId)).toContain(
 				recorded.attempt.attemptId,
 			);
+		}
+	});
+
+	it("strictly validates flat and nested fusion scores without accepting unrelated keys", () => {
+		const selected = input().exposures[0];
+		if (selected == null) throw new Error("fixture must contain a selected exposure");
+		const invalidScores = [
+			{ fusion: { private_score: 1 } },
+			{ fusion: { base_score: 1 } },
+			{ fusion: [] },
+			{ fusion: null },
+			{ fusion: { fused_score: 0.1 }, fused_score: 0.2 },
+			{ fused_score: null },
+			{ secondary_score: null },
+			...[
+				"fts_score",
+				"fts_rank",
+				"semantic_score",
+				"semantic_rank",
+				"fused_score",
+				"rank_constant",
+				"fusion_rank",
+				"secondary_score",
+			].flatMap((key) =>
+				[Number.NaN, Infinity, -Infinity, "0.5", {}, true].flatMap((value) => [
+					{ [key]: value },
+					{ fusion: { [key]: value } },
+				]),
+			),
+		];
+		for (const [index, scoreSummary] of invalidScores.entries()) {
+			const invalid = input({
+				attemptId: attemptId(4000 + index),
+				requestId: `invalid-fusion-${index}`,
+				candidateCount: 1,
+				exposures: [{ ...selected, scoreSummary: scoreSummary as never }],
+			});
+			expect(tryRecordRetrievalAttempt(db, invalid)).toMatchObject({
+				ok: false,
+				reason: "invalid_input",
+			});
+			expect(getRetrievalAttempt(db, invalid.attemptId)).toBeNull();
 		}
 	});
 

--- a/packages/core/src/retrieval-ledger.ts
+++ b/packages/core/src/retrieval-ledger.ts
@@ -1,7 +1,12 @@
 import { createHash } from "node:crypto";
 import { isAbsolute, posix, win32 } from "node:path";
 import type { Database } from "./db.js";
-import type { MemoryFilters, PackTraceCandidateScores, PackTraceSection } from "./types.js";
+import type {
+	MemoryFilters,
+	PackFusionEvidence,
+	PackTraceCandidateScores,
+	PackTraceSection,
+} from "./types.js";
 
 export const RETRIEVAL_LEDGER_CONTRACT_VERSION = 1 as const;
 export const DEFAULT_RETRIEVAL_LEDGER_RETENTION_DAYS = 90;
@@ -30,7 +35,8 @@ export type RetrievalDeliveryStatus = "not_attempted" | "handed_off" | "failed" 
 export type RetrievalDisposition = "selected" | "dropped" | "deduped" | "trimmed" | "compressed";
 
 export type RetrievalFilterSummary = Omit<MemoryFilters, "working_set_paths">;
-export type RetrievalScoreSummary = Partial<PackTraceCandidateScores>;
+/** Accept trace evidence on write; persisted/read summaries use flat numeric fields. */
+export type RetrievalScoreSummary = Partial<PackTraceCandidateScores & PackFusionEvidence>;
 
 export interface RetrievalExposureInput {
 	memoryId?: number | null;
@@ -230,6 +236,17 @@ const FILTER_KEY_ORDER = [
 ] as const satisfies readonly (keyof RetrievalFilterSummary)[];
 const FILTER_KEYS = new Set<string>(FILTER_KEY_ORDER);
 
+const FUSION_SCORE_KEY_ORDER = [
+	"fts_score",
+	"fts_rank",
+	"semantic_score",
+	"semantic_rank",
+	"fused_score",
+	"rank_constant",
+	"fusion_rank",
+	"secondary_score",
+] as const satisfies readonly (keyof PackFusionEvidence)[];
+const FUSION_SCORE_KEYS = new Set<string>(FUSION_SCORE_KEY_ORDER);
 const SCORE_KEY_ORDER = [
 	"base_score",
 	"combined_score",
@@ -245,9 +262,17 @@ const SCORE_KEY_ORDER = [
 	"tasklike_penalty",
 	"text_overlap",
 	"tag_overlap",
+	...FUSION_SCORE_KEY_ORDER,
 ] as const satisfies readonly (keyof RetrievalScoreSummary)[];
 const SCORE_KEYS = new Set<string>(SCORE_KEY_ORDER);
-const NULLABLE_SCORE_KEYS = new Set<string>(["base_score", "combined_score"]);
+const NULLABLE_SCORE_KEYS = new Set<string>([
+	"base_score",
+	"combined_score",
+	"fts_score",
+	"fts_rank",
+	"semantic_score",
+	"semantic_rank",
+]);
 
 const RETRIEVAL_SURFACES = new Set<RetrievalSurface>([
 	"prompt_pack",
@@ -385,13 +410,35 @@ function serializeFilterSummary(input: RetrievalFilterSummary | null | undefined
 	return boundedJson(output, "filterSummary");
 }
 
+function flattenScoreSummary(input: RetrievalScoreSummary): Record<string, unknown> {
+	const { fusion, ...flat } = input;
+	if (fusion === undefined) return flat;
+	if (!isPlainObjectRecord(fusion)) {
+		throw new RetrievalLedgerValidationError("scoreSummary.fusion contains an invalid value shape");
+	}
+	for (const key of Object.keys(fusion)) {
+		if (!FUSION_SCORE_KEYS.has(key)) {
+			throw new RetrievalLedgerValidationError(
+				`scoreSummary.fusion contains unsupported key: ${key}`,
+			);
+		}
+		if (Object.hasOwn(flat, key)) {
+			throw new RetrievalLedgerValidationError(
+				`scoreSummary contains duplicate fusion key: ${key}`,
+			);
+		}
+	}
+	// All values still pass the same finite-number/null validator below.
+	return { ...flat, ...fusion };
+}
+
 function serializeScoreSummary(input: RetrievalScoreSummary | null | undefined): string | null {
 	if (input == null) return null;
 	if (!isPlainObjectRecord(input)) {
 		throw new RetrievalLedgerValidationError("scoreSummary contains an invalid value shape");
 	}
 	const definedEntries: Record<string, unknown> = {};
-	for (const [key, value] of Object.entries(input)) {
+	for (const [key, value] of Object.entries(flattenScoreSummary(input))) {
 		if (!SCORE_KEYS.has(key)) {
 			throw new RetrievalLedgerValidationError(`scoreSummary contains unsupported key: ${key}`);
 		}

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -662,7 +662,7 @@ function queryPathOverlapBoost(item: MemoryResult, query: string): number {
 	return Math.min(0.18, boost);
 }
 
-function rowToMemoryResult(
+export function rowToMemoryResult(
 	row: Record<string, unknown>,
 	preserveFilteredKind: boolean,
 ): MemoryResult {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -83,7 +83,19 @@ export type PackTraceDisposition = "selected" | "dropped" | "deduped" | "trimmed
 
 export type PackTraceSection = "summary" | "timeline" | "observations";
 
+export type PackFusionEvidence = {
+	fts_score: number | null;
+	fts_rank: number | null;
+	semantic_score: number | null;
+	semantic_rank: number | null;
+	fused_score: number;
+	rank_constant: number;
+	fusion_rank: number;
+	secondary_score: number;
+};
+
 export type PackTraceCandidateScores = {
+	fusion?: PackFusionEvidence;
 	base_score: number | null;
 	combined_score: number | null;
 	recency: number;

--- a/packages/viewer-server/src/index.test.ts
+++ b/packages/viewer-server/src/index.test.ts
@@ -5978,6 +5978,55 @@ describe("viewer-server", () => {
 			}
 		});
 
+		it("persists hybrid evidence through the Viewer automatic pack route", async () => {
+			const { app, ensureStore, cleanup } = createTestApp();
+			try {
+				const store = ensureStore();
+				const sessionId = insertTestSession(store.db);
+				const memoryId = store.remember(
+					sessionId,
+					"decision",
+					"quasar evidence",
+					"quasar fact",
+					0.9,
+				);
+				const semantic = core.search(store, "quasar", 10).map((item) => ({ ...item, score: 0.75 }));
+				const artifacts = core.buildMemoryPackWithTrace(
+					store,
+					"quasar",
+					10,
+					null,
+					undefined,
+					semantic,
+				);
+				// Supply deterministic candidates without invoking an embedding provider.
+				vi.spyOn(store, "buildMemoryPackWithTraceAsync").mockResolvedValue(artifacts);
+				const response = await postViewerJson(app, "/api/pack", {
+					context: "quasar",
+					all_projects: true,
+					attempt: {
+						attempt_id: promptPackAttemptId(500),
+						source: "opencode",
+						started_at: "2026-08-03T10:00:00.000Z",
+						request_id: "hybrid-ledger",
+					},
+				});
+				expect(response.status).toBe(200);
+				expect(await response.json()).not.toHaveProperty("ledger_outcome");
+				const fusion = artifacts.trace.retrieval.candidates.find((item) => item.id === memoryId)
+					?.scores.fusion;
+				if (!fusion) throw new Error("fixture must produce hybrid evidence");
+				const recorded = core.getRetrievalAttempt(store.db, promptPackAttemptId(500));
+				const scoreSummary = recorded?.exposures.find(
+					(item) => item.memoryId === memoryId,
+				)?.scoreSummary;
+				expect(scoreSummary).toMatchObject(fusion);
+				expect(scoreSummary).not.toHaveProperty("fusion");
+			} finally {
+				cleanup();
+			}
+		});
+
 		it("returns a stable structured error when pack construction fails", async () => {
 			const { app, ensureStore, cleanup } = createTestApp();
 			try {


### PR DESCRIPTION
## Description

Repair hybrid pack ranking so raw keyword scores and bounded vector scores are not compared as if they shared a scale.

- Fuse per-channel ranks with equal-weight reciprocal rank fusion and retain both channels' evidence.
- Reuse scoped row conversion so semantic candidates carry the same ownership, workspace, and trust metadata as keyword candidates.
- Validate and persist fusion evidence through the retrieval ledger, including cached attempts, CLI, and Viewer paths.
- Show explicit fused score/rank in CLI diagnostics without changing legacy `combined_score` semantics.

Hybrid relevance is the primary ordering key. Recency, ownership, and soft shared-trust preferences break exact fused ties rather than overriding relevance through arithmetic bonuses. An eligible shared or unreviewed candidate can therefore outrank a personal or trusted candidate. Access filters and ordinary single-channel search remain unchanged.

Task routing and later assembly ordering are intentionally handled in the next PR. This change does not introduce a confidence threshold or claim a general task-performance improvement.

## Type of Change

- [ ] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Ran `pnpm run build` and `pnpm run check`. The PR checkpoint passed 6,640 workspace tests with 3 existing TODOs, plus release, adapter-normalizer, and CI-workflow tests. Focused tests cover score scaling, duplicate channels, malformed evidence, metadata parity, exact identifiers, eligibility, ledger round-trips, and CLI/Viewer integration. Independent correctness and maintainability reviews completed.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] No new warnings introduced

Lint passes with complexity/style warnings, including test-block length warnings; this is not a warning-free claim. No unrelated lint cleanup or private evaluation data is included.
