### PR TITLE
feat(update): support mise-managed installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ npm install -g codemem
 
 For a smaller keyword-only install, use `npm install -g codemem --omit=optional` and set `CODEMEM_EMBEDDING_DISABLED=1` in every Codemem process. The flag is required because npm also omits sqlite-vec's optional platform package; the CLI then remains functional with FTS5.
 
-An npm-capable manager, such as mise's `npm:codemem` backend, can also provide the durable CLI. Ensure `codemem` is on your `PATH`, then run `codemem setup --opencode-only`.
+An npm-capable manager, such as mise's `npm:codemem` backend, can also provide the durable CLI. Ensure `codemem` is on your `PATH`, then run `codemem setup --opencode-only`. For a mise-managed CLI, `codemem update check` reports the exact global update command. An explicit `codemem update install` confirms from bounded `mise ls --json` output that the active tool source matches a global source under the user's home directory and that its install path owns the running entry. It writes the exact release into mise's primary global config, confirms the global configured version, and runs the configured tool through `mise exec` outside the invoking project rather than through a possibly stale or locally overridden `PATH` entry.
 
 Upgrade a durable CLI with the package manager that installed it, then rerun the corresponding setup command for an existing setup-managed integration. Setup replaces its old managed `npx -y codemem mcp` launcher and codemem MCP entries detected as UV/UVX-based so both packages share one runtime; other custom MCP commands remain unchanged. The host plugin is managed independently. Claude marketplace installs use the plugin's bundled MCP configuration and do not require a separate `setup --claude-only` step.
 
@@ -309,11 +309,21 @@ pass `--refresh` to force a registry request or `--json` for one channel-aware s
 The Viewer Health page reads the same status from `/api/update-status`. The OpenCode plugin
 checks it after startup and shows at most one best-effort notification for each newly discovered
 same-channel release. `notify` is the default. `codemem update install` performs the explicit, fail-closed
-installation; bare `codemem update` remains non-mutating. Explicit plugin
+installation for proven npm-global and mise-managed CLIs. Mise updates require matching active and
+global machine-readable source records under the user's home directory plus matching install-path
+evidence. A recognized user-level `~/.config/mise.toml` source may instead migrate when the bounded
+global query succeeds with an empty result. Updates pin public default and `@codemem` npm registries, run
+`mise use -g npm:codemem@<exact-version>` without a shell to write the exact release into the primary
+global config, and verify with
+an exact target in the post-update global `version` or `requested_version`, followed by
+`mise exec -- codemem version` outside the invoking project. Linux also sets
+`ONNXRUNTIME_NODE_INSTALL=skip`. Bare
+`codemem update` remains non-mutating. Explicit plugin
 `auto` policy may run a paired, version-pinned public-registry install of `codemem` and
 `@codemem/embeddings` only
 after the CLI reports a fresh, validated same-channel npm release observed for at least 24 hours
-and an installation whose npm origin can be proven. Pinned, cross-channel, unsupported-channel,
+and an installation whose npm-global origin can be proven. Mise is never eligible for background
+auto-update because changing its global tool configuration requires a direct user command. Pinned, cross-channel, unsupported-channel,
 downgrade, repository-development, stale, Docker, and unknown installs refuse execution. Set
 `CODEMEM_BACKEND_UPDATE_POLICY=off` to disable release checks.
 On Linux, plugin-owned auto-updates preserve the OpenCode environment and set

--- a/docs/plans/2026-09-11-mise-managed-update-design.md
+++ b/docs/plans/2026-09-11-mise-managed-update-design.md
@@ -1,0 +1,36 @@
+# Mise-Managed Update Design
+
+**Status:** Approved
+**Date:** 2026-09-11
+
+## Decision
+
+Codemem will detect installations managed by mise's `npm:codemem` backend and provide a channel-preserving upgrade command. An explicit `codemem update install` may run mise, but background auto-update remains limited to npm-global installations.
+
+## Detection
+
+Installation detection will continue to use the resolved CLI entry path as evidence. Detection requires a semver-qualified `mise/installs/npm-codemem/<version>/` segment or the equivalent path beneath a normalized `MISE_DATA_DIR`, avoiding generic `installs/npm-codemem` false positives.
+
+The detector will classify a matching path as `mise`. Environment markers may narrow permissions but will not be allowed to claim an executable install kind, preserving the current fail-closed policy.
+
+## Update Behavior
+
+`codemem update check` will return this exact action for a mise-managed release:
+
+```text
+mise use -g npm:codemem@<version>
+```
+
+The explicit `codemem update install` command will retain the update lock, read bounded JSON from active and global `mise ls` queries, require their canonical source paths to match under the user's home directory, and require the active install path to own the running CLI entrypoint. A recognized user-level `~/.config/mise.toml` source may migrate only when the global query succeeds with an empty array. System, unresolved, and ambiguous custom sources fail closed. It runs the update without a shell using inherited environment, pinned public npm registries, and Linux's CPU-only ONNX setting, writing the exact release into the primary global config. Verification permits the source to move from user `conf.d` or `~/.config/mise.toml` to `config.toml`, re-reads bounded global state, requires an exact target `version` or `requested_version` value, then runs `mise exec -- codemem version` outside the invoking project. It reports unproven global ownership, missing mise, command failure, and version mismatch as actionable errors.
+
+Mise installations will remain ineligible for background auto-update. Updating a mise global tool changes declarative user configuration, so only a direct user command may authorize it.
+
+## Alternatives Rejected
+
+- Probing npm, pnpm, Yarn, and mise was rejected because `PATH` may contain multiple installations and identify a manager that does not own the running executable.
+- Writing installation metadata from lifecycle scripts was rejected because existing installs lack the metadata and additional install scripts increase supply-chain exposure.
+- Treating mise as npm-global was rejected because npm could update a different prefix while leaving the active mise installation unchanged.
+
+## Validation
+
+Tests will cover Unix and Windows-style path normalization, exact extracted versions, detection precedence, exact release guidance, explicit mise command execution, source and install-path ownership, failed execution, configured-state and executable version verification, and refusal of background eligibility. The UI type mirror and user-facing update documentation will include the new install kind.

--- a/docs/plans/2026-09-11-mise-managed-update-implementation.md
+++ b/docs/plans/2026-09-11-mise-managed-update-implementation.md
@@ -1,0 +1,33 @@
+# Mise-Managed Update Implementation Plan
+
+The implementation adds one evidence-backed installer kind and keeps unattended behavior unchanged.
+
+## 1. Extend Release Discovery
+
+- Add `mise` to `InstallKind`.
+- Detect semver-qualified resolved entry paths beneath mise's own data layout or a normalized `MISE_DATA_DIR` before generic package-manager patterns.
+- Return `mise use -g npm:codemem@<latest-version>` as the recommended action.
+- Keep `auto_update_eligible` false for mise.
+- Add focused detection, precedence, guidance, and eligibility tests.
+
+## 2. Execute Explicit Mise Updates
+
+- Export explicit install eligibility from core while keeping background eligibility npm-only.
+- Select npm or mise install arguments from the detected kind.
+- Compare bounded JSON from active and global mise source queries before mutation, allowing a recognized user-level `~/.config/mise.toml` source only when the global query succeeds with an empty array, and refusing other local overrides, system or ambiguous custom sources, and install paths that do not canonically own the running entry.
+- Spawn mise without a shell using inherited environment, pinned public npm registries, and Linux's CPU-only ONNX setting.
+- Write the exact release into the primary global config, then re-read bounded global state, require an exact target `version` or `requested_version` value without requiring an unchanged source, and verify through unpinned `mise exec -- codemem version` outside the invoking project.
+- Test Unix and Windows options, user and system source handling, symlinked ownership, bounded command output, failed execution, stale configured state, and executable verification failure.
+
+## 3. Update Consumers and Documentation
+
+- Add `mise` to the browser-side update-status type.
+- Document mise detection, the exact manual command, explicit install behavior, and the background-update restriction.
+- Avoid advertising pnpm, Yarn, or Bun installation until their native dependency behavior has dedicated validation.
+
+## 4. Validate
+
+- Run the core release-discovery tests.
+- Run the CLI update-command tests.
+- Run affected viewer and plugin update tests if the wire-contract change reaches their fixtures.
+- Run TypeScript and lint checks for the final changed set.

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -474,7 +474,7 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_PLUGIN_CMD_TIMEOUT` | Milliseconds before a plugin CLI call is aborted (default `20000`). |
 | `CODEMEM_MIN_VERSION` | Minimum required CLI version for plugin compatibility warnings (default `0.9.20`). |
 | `CODEMEM_BACKEND_UPDATE_POLICY` | Compatibility and release-notification policy: `notify` (default), `auto`, or `off`. |
-| `CODEMEM_INSTALL_KIND` | Internal/advanced release-guidance detection override (`npm-global`, `npx`, `docker`, `repo-dev`, `pinned`, or `unknown`). This does not enable installation. |
+| `CODEMEM_INSTALL_KIND` | Internal/advanced release-guidance detection override (`npm-global`, `mise`, `npx`, `docker`, `repo-dev`, `pinned`, or `unknown`). This does not prove ownership or enable installation. |
 | `CODEMEM_CODEX_ENDPOINT` | Override Codex OAuth endpoint. |
 | `CODEMEM_PLUGIN_DEBUG` | Set to `1`, `true`, or `yes` to log plugin lifecycle events. |
 | `CODEMEM_PLUGIN_IGNORE` | Skip all plugin behavior for this process. |
@@ -532,7 +532,7 @@ Update policy:
 - `CODEMEM_BACKEND_UPDATE_POLICY=auto`: try a best-effort auto-update for eligible compatibility-floor mismatches and fresh same-channel releases observed for at least 24 hours, then warn if still outdated
 	- skipped for `node` dev-mode runners
 	- skipped when `CODEMEM_RUNNER_FROM` is pinned to a fixed package/version
-	- skipped for Docker, unknown, stale, unsupported-channel, cross-channel, or downgrade states
+	- skipped for mise, Docker, unknown, stale, unsupported-channel, cross-channel, or downgrade states
 - `CODEMEM_BACKEND_UPDATE_POLICY=off`: no compatibility toast (logging still records mismatch)
 
 After its startup delay, the plugin also runs `codemem update check --json` through the same
@@ -549,6 +549,16 @@ effort: it does not
 use the CLI install lock or Windows npm-shim handling, and plugin-owned auto-update is disabled on
 Windows. Avoid starting simultaneous automatic updates from multiple OpenCode sessions; use
 `codemem update install` when serialized installation is required.
+
+Mise-managed CLIs are detected from a semver-qualified mise install path or normalized
+`MISE_DATA_DIR` path and receive global `mise use -g npm:codemem@<exact-version>` guidance. Only the
+user's explicit `codemem update install` command may execute that argv-only update. It first compares
+bounded machine-readable active and global mise source records, requires a user-owned global source,
+and canonicalizes current install-path ownership. It then pins public npm registries for the spawned
+command and writes the exact release into mise's primary global config. Verification allows the source
+to move from user `conf.d` or the recognized user-level `~/.config/mise.toml` file to `config.toml` but requires the post-update global
+`version` or `requested_version` before running `mise exec -- codemem version` outside the invoking project; plugin background
+auto-update never treats mise as eligible.
 
 Docker images set `CODEMEM_INSTALL_KIND=docker` so release guidance cannot mistake the bundled
 global npm package for a host npm installation. Docker deployments never self-update; rebuild and

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -42,13 +42,26 @@ codemem update check --json
 - Stale validated cache data remains clearly labeled and may provide guidance when the registry is
   unavailable.
 - This command never installs or executes an update. Release installation remains outside this
-  read-only check. `codemem update install` is the separate, fail-closed installer: it refreshes
-  release status, requires a proven global npm installation and a same-channel release observed for at
-  least 24 hours, installs exact matching `codemem` and `@codemem/embeddings` versions from the
-  public npm registry, and verifies the active `codemem` command. It refuses npx, Docker, pinned,
+  read-only check. For a mise-managed CLI, it reports the exact global mise action; on Linux that
+  action is `env ONNXRUNTIME_NODE_INSTALL=skip mise use -g npm:codemem@<exact-version>`.
+- `codemem update install` is the separate, fail-closed installer. Proven npm-global installations
+  retain the 24-hour first-seen delay and install exact matching `codemem` and
+  `@codemem/embeddings` versions from the public npm registry. Before a mise mutation, the installer
+  reads bounded JSON from `mise ls --current` and `mise ls --global`, requires the active source
+  to match a global source under the user's home directory, and requires its canonical install path
+  to own the running CLI entrypoint. System, unresolved, and ambiguous custom sources are refused. It then runs
+  `mise use -g npm:codemem@<exact-version>` with inherited
+  environment, public default and `@codemem` registries, and Linux's CPU-only ONNX setting. Mise
+  writes that exact release into the primary global config, which may move a declaration from a
+  user `conf.d` or recognized user-level `~/.config/mise.toml` source to `config.toml`. Verification re-reads global state and requires `version`
+  or `requested_version` to match the target,
+  then uses `mise exec -- codemem version` from outside the invoking project, avoiding stale `PATH`
+  entries and project-local overrides. Both paths refresh release status and stay on the installed channel. It refuses npx, Docker, pinned,
   development, stale, cross-channel, downgrade, unsupported-channel, and unknown installations. Bare `codemem update`
   remains non-mutating. As with a
   manual npm install, npm runs the packages' installation scripts for native CPU dependencies.
+- Mise installations are never eligible for plugin background auto-update. Changing mise's global
+  tool configuration requires the direct `codemem update install` command or the reported manual action.
 
 ## Start or restart the viewer
 - `codemem serve` runs the viewer in the foreground.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -83,17 +83,33 @@ and `--json` for the additive automation contract. Existing stable-only cache re
 for stable installations, but no cache or in-process result is reused across channels. If a refresh
 fails, a previously validated same-channel cache may be returned as stale guidance. A running process
 backs off failed registry checks for 15 minutes, while `--refresh` bypasses that backoff.
-`codemem update check` remains informational.
-`codemem update install` separately requires fresh validated status, a 24-hour first-seen delay,
-and a proven eligible npm installation before it installs exact matching `codemem` and
-`@codemem/embeddings` versions with an argv-only npm command and verifies the active CLI version.
+`codemem update check` remains informational. It detects a semver-qualified
+`mise/installs/npm-codemem/<version>/` layout from the resolved CLI entry path, or the equivalent
+layout beneath a normalized `MISE_DATA_DIR`, and reports
+`mise use -g npm:codemem@<exact-version>` for that installation kind.
+`codemem update install` separately requires fresh validated status. Proven npm-global installations
+retain the 24-hour first-seen delay and install exact matching `codemem` and
+`@codemem/embeddings` versions with an argv-only npm command. Before mutation, proven mise
+installations compare bounded machine-readable active and global source records and require current
+install-path ownership. A recognized user-level `~/.config/mise.toml` source may migrate when the
+bounded global query succeeds with an empty result. The matching source must resolve within the user's home directory; system,
+unresolved, and ambiguous custom paths fail closed. Matching evidence authorizes codemem to
+execute the exact reported `mise use -g` command without a shell, inherited environment, and pinned
+public default and `@codemem` registries; Linux also sets `ONNXRUNTIME_NODE_INSTALL=skip`. This writes
+the exact release into the primary global config, so a declaration may move from user `conf.d` or `~/.config/mise.toml` to
+`config.toml`. Mise verification re-reads bounded global state, requires an exact target `version` or
+`requested_version` value, and runs `mise exec -- codemem version` outside the invoking project;
+npm-global verification uses the active CLI.
 Bare `codemem update` remains non-mutating. Installing an alpha, beta, or release candidate is
 explicit opt-in, so the
 existing auto-update policy may install a delayed eligible update within that installed channel.
 Installation refuses pinned, cross-channel, unsupported-prerelease, downgrade, development, stale,
-Docker, and unknown states. Updater internals always install exact matching `codemem` and
+Docker, and unknown states. The npm-global updater always installs exact matching `codemem` and
 `@codemem/embeddings` versions. The npm operation runs the packages' installation scripts for native
 CPU dependencies, just as a manual global install does.
+Mise remains ineligible for background auto-update because its command changes declarative global
+tool configuration; only a direct user install command may authorize that change, and a local source
+that overrides the global source is refused with manual global-update guidance.
 
 Release discovery compares the running product version with the latest release on its channel.
 It is separate from the compatibility-floor check below: discovering a newer release does not

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -24,7 +24,15 @@ vi.mock("@codemem/core", async (importOriginal) => {
 import { updateCommand } from "./update.js";
 
 const originalHome = process.env.HOME;
+const originalArgv = [...process.argv];
+const originalMiseConfigDir = process.env.MISE_CONFIG_DIR;
+const originalMiseGlobalConfigFile = process.env.MISE_GLOBAL_CONFIG_FILE;
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
 let testHome = "";
+
+function useMiseEntrypoint(): void {
+	process.argv[1] = "/home/user/.local/share/mise/installs/npm-codemem/0.40.2/dist/index.js";
+}
 
 const availableStatus = {
 	current_version: "0.40.2",
@@ -46,6 +54,45 @@ const currentStatus = {
 	update_available: false,
 	recommended_action: "No action required; codemem is up to date.",
 } as const;
+
+const miseStatus = {
+	...availableStatus,
+	install_kind: "mise",
+	recommended_action: "mise use -g npm:codemem@0.41.0",
+} as const;
+
+function miseState(
+	options: {
+		installPath?: string;
+		requestedVersion?: string;
+		source?: Record<string, unknown>;
+		version?: string;
+	} = {},
+): string {
+	const version = options.version ?? "0.40.2";
+	return JSON.stringify([
+		{
+			active: true,
+			install_path:
+				options.installPath ?? "/home/user/.local/share/mise/installs/npm-codemem/0.40.2",
+			requested_version: options.requestedVersion ?? version,
+			source:
+				options.source ??
+				({ path: join(testHome, ".config", "mise", "config.toml"), type: "mise.toml" } as const),
+			version,
+		},
+	]);
+}
+
+const globalMiseState = (): string => miseState();
+const updatedGlobalMiseState = (source?: Record<string, unknown>): string =>
+	miseState({
+		installPath: "/home/user/.local/share/mise/installs/npm-codemem/0.41.0",
+		source,
+		version: "0.41.0",
+	});
+const localMiseState = (): string =>
+	miseState({ source: { path: join(testHome, "workspace", "mise.toml"), type: "mise.toml" } });
 
 const unavailableStatus = {
 	...availableStatus,
@@ -69,18 +116,40 @@ async function parseUpdateCommand(args: string[]): Promise<void> {
 beforeEach(async () => {
 	testHome = await mkdtemp(join(tmpdir(), "codemem-update-test-"));
 	process.env.HOME = testHome;
+	delete process.env.MISE_CONFIG_DIR;
+	delete process.env.MISE_GLOBAL_CONFIG_FILE;
+	delete process.env.XDG_CONFIG_HOME;
+	const miseConfigDirectory = join(testHome, ".config", "mise");
+	await mkdir(miseConfigDirectory, { recursive: true });
+	await writeFile(join(miseConfigDirectory, "config.toml"), "");
 });
 
 afterEach(async () => {
 	getUpdateStatus.mockReset();
 	spawn.mockReset();
 	process.exitCode = undefined;
-	process.env.HOME = originalHome;
+	process.argv.splice(0, process.argv.length, ...originalArgv);
+	if (originalHome === undefined) delete process.env.HOME;
+	else process.env.HOME = originalHome;
+	if (originalMiseConfigDir === undefined) delete process.env.MISE_CONFIG_DIR;
+	else process.env.MISE_CONFIG_DIR = originalMiseConfigDir;
+	if (originalMiseGlobalConfigFile === undefined) delete process.env.MISE_GLOBAL_CONFIG_FILE;
+	else process.env.MISE_GLOBAL_CONFIG_FILE = originalMiseGlobalConfigFile;
+	if (originalXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+	else process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
 	await rm(testHome, { recursive: true, force: true });
 	vi.restoreAllMocks();
 });
 
-function commandProcess(options: { stdout?: string; stderr?: string; exitCode?: number } = {}) {
+function commandProcess(
+	options: {
+		stdout?: string;
+		stdoutChunks?: string[];
+		stderr?: string;
+		exitCode?: number;
+		error?: Error;
+	} = {},
+) {
 	const child = new EventEmitter() as EventEmitter & {
 		kill: ReturnType<typeof vi.fn>;
 		stdout: EventEmitter & { setEncoding: () => void };
@@ -90,7 +159,13 @@ function commandProcess(options: { stdout?: string; stderr?: string; exitCode?: 
 	child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
 	child.kill = vi.fn();
 	queueMicrotask(() => {
-		if (options.stdout) child.stdout.emit("data", options.stdout);
+		if (options.error) {
+			child.emit("error", options.error);
+			return;
+		}
+		for (const chunk of options.stdoutChunks ?? (options.stdout ? [options.stdout] : [])) {
+			child.stdout.emit("data", chunk);
+		}
 		if (options.stderr) child.stderr.emit("data", options.stderr);
 		child.emit("close", options.exitCode ?? 0);
 	});
@@ -125,6 +200,24 @@ describe("update check command", () => {
 		// Assert
 		expect(log.mock.calls.flat().join("\n")).toMatch(/0\.40\.2.*up to date/i);
 		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("describes repository source without claiming its package metadata is up to date", async () => {
+		getUpdateStatus.mockResolvedValue({
+			...currentStatus,
+			install_kind: "repo-dev",
+			latest_version: "0.41.0",
+			recommended_action:
+				"Package-release updates do not apply to repository source. Run git pull, pnpm install, and pnpm build in the codemem repository.",
+		});
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["check"]);
+
+		const output = log.mock.calls.flat().join("\n");
+		expect(output).toMatch(/running from repository source/i);
+		expect(output).toMatch(/package metadata: 0\.40\.2/i);
+		expect(output).not.toMatch(/up to date/i);
 	});
 
 	it("qualifies a stale up-to-date human result as cached", async () => {
@@ -311,7 +404,7 @@ describe("update install command", () => {
 		expect(process.exitCode).toBeUndefined();
 	});
 
-	it("installs an eligible prerelease within the reported channel with exact package pairing", async () => {
+	it("installs an eligible prerelease within its reported channel", async () => {
 		vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
 		getUpdateStatus.mockResolvedValue({
 			...availableStatus,
@@ -334,6 +427,480 @@ describe("update install command", () => {
 			expect.objectContaining({ shell: false }),
 		);
 		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("does not terminate a successful npm install when command output exceeds the capture limit", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+		getUpdateStatus.mockResolvedValue({ ...availableStatus, auto_update_eligible: true });
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: "x".repeat(65 * 1_024) }))
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(spawn.mock.results[0]?.value.kill).not.toHaveBeenCalled();
+		expect(spawn).toHaveBeenCalledTimes(2);
+		expect(process.exitCode).toBeUndefined();
+	});
+});
+
+describe("mise update install execution", () => {
+	beforeEach(useMiseEntrypoint);
+	it("proves global ownership and installs with safe Unix options", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: updatedGlobalMiseState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(spawn.mock.calls.map(([, args]) => args)).toEqual([
+			["ls", "npm:codemem", "--current", "--json"],
+			["ls", "npm:codemem", "--global", "--json"],
+			["use", "-g", "npm:codemem@0.41.0"],
+			["ls", "npm:codemem", "--global", "--json"],
+			["exec", "--", "codemem", "version"],
+		]);
+		expect(spawn.mock.calls[2]?.[2]).toEqual(
+			expect.objectContaining({
+				cwd: "/",
+				detached: true,
+				env: expect.objectContaining({
+					HOME: testHome,
+					ONNXRUNTIME_NODE_INSTALL: "skip",
+					npm_config_registry: "https://registry.npmjs.org/",
+					"npm_config_@codemem:registry": "https://registry.npmjs.org/",
+				}),
+				shell: false,
+			}),
+		);
+		expect(spawn.mock.calls[4]?.[2]).toEqual(expect.objectContaining({ cwd: "/" }));
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			previous_version: "0.40.2",
+			installed_version: "0.41.0",
+		});
+		expect(process.exitCode).toBeUndefined();
+	});
+});
+
+describe("mise update install failures", () => {
+	beforeEach(useMiseEntrypoint);
+	it("reports a failed mise update", async () => {
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }))
+			.mockImplementationOnce(() =>
+				commandProcess({ stderr: "mise backend failed\n", exitCode: 1 }),
+			);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			error: "update_install_failed",
+			message: "mise backend failed",
+		});
+		expect(spawn).toHaveBeenCalledTimes(3);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("bounds failed install output without returning raw oversized stderr", async () => {
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }))
+			.mockImplementationOnce(() =>
+				commandProcess({ stderr: `sensitive-marker${"x".repeat(65 * 1_024)}`, exitCode: 1 }),
+			);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_failed",
+			message: "command output too large",
+		});
+		expect(log.mock.calls.flat().join("\n")).not.toContain("sensitive-marker");
+		expect(process.exitCode).toBe(1);
+	});
+});
+
+describe("mise update install safeguards", () => {
+	beforeEach(useMiseEntrypoint);
+	it("reports missing mise with the exact manual recovery command", async () => {
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		const missingMise = Object.assign(new Error("spawn mise ENOENT"), { code: "ENOENT" });
+		spawn.mockImplementationOnce(() => commandProcess({ error: missingMise }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			error: "update_install_failed",
+			message: "mise was not found on PATH; install mise, then run mise use -g npm:codemem@0.41.0",
+		});
+		expect(process.exitCode).toBe(1);
+	});
+});
+
+describe("mise update ownership safeguards", () => {
+	beforeEach(useMiseEntrypoint);
+	it("refuses when the active mise source is not the global source", async () => {
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: localMiseState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_refused",
+			message:
+				"Could not prove the active mise codemem installation is globally configured. mise use -g npm:codemem@0.41.0",
+		});
+		expect(spawn).toHaveBeenCalledTimes(2);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("refuses a matching system-scope global source", async () => {
+		const systemState = miseState({
+			source: { path: "/etc/mise/config.toml", type: "mise.toml" },
+		});
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: systemState }))
+			.mockImplementationOnce(() => commandProcess({ stdout: systemState }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			error: "update_install_refused",
+		});
+		expect(spawn).toHaveBeenCalledTimes(2);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("accepts a user conf.d source before writing the exact release to config.toml", async () => {
+		const confSource = {
+			path: join(testHome, ".config", "mise", "conf.d", "codemem.toml"),
+			type: "mise.toml",
+		};
+		const configSource = {
+			path: join(testHome, ".config", "mise", "config.toml"),
+			type: "mise.toml",
+		};
+		await mkdir(join(testHome, ".config", "mise", "conf.d"), { recursive: true });
+		await writeFile(confSource.path, "");
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: miseState({ source: confSource }) }))
+			.mockImplementationOnce(() => commandProcess({ stdout: miseState({ source: confSource }) }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() =>
+				commandProcess({ stdout: updatedGlobalMiseState(configSource) }),
+			)
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(spawn).toHaveBeenCalledTimes(5);
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("accepts an explicit user-owned MISE_GLOBAL_CONFIG_FILE", async () => {
+		const source = {
+			path: join(testHome, "dotfiles", "mise-global.toml"),
+			type: "mise.toml",
+		};
+		await mkdir(join(testHome, "dotfiles"), { recursive: true });
+		await writeFile(source.path, "");
+		process.env.MISE_GLOBAL_CONFIG_FILE = source.path;
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: miseState({ source }) }))
+			.mockImplementationOnce(() => commandProcess({ stdout: miseState({ source }) }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: updatedGlobalMiseState(source) }))
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(spawn).toHaveBeenCalledTimes(5);
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("migrates a user-level ~/.config/mise.toml source when --global is empty", async () => {
+		const source = {
+			path: join(testHome, ".config", "mise.toml"),
+			type: "mise.toml",
+		};
+		await writeFile(source.path, "");
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: miseState({ source }) }))
+			.mockImplementationOnce(() => commandProcess({ stdout: "[]" }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: updatedGlobalMiseState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(spawn).toHaveBeenCalledTimes(5);
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("refuses an empty --global result for a non-legacy source", async () => {
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: "[]" }));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(spawn).toHaveBeenCalledTimes(2);
+		expect(process.exitCode).toBe(1);
+	});
+});
+
+describe("mise install-path ownership safeguards", () => {
+	beforeEach(useMiseEntrypoint);
+	it("refuses when the active install path does not own the running entry", async () => {
+		const previousArgv = [...process.argv];
+		process.argv[1] =
+			"/home/user/.local/share/mise/installs/npm-codemem/0.40.2/lib/node_modules/codemem/dist/index.js";
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn.mockImplementationOnce(() =>
+			commandProcess({
+				stdout: miseState({
+					installPath: "/home/other/.local/share/mise/installs/npm-codemem/0.40.2",
+				}),
+			}),
+		);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		try {
+			await parseUpdateCommand(["install", "--json"]);
+		} finally {
+			process.argv.splice(0, process.argv.length, ...previousArgv);
+		}
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			error: "update_install_refused",
+		});
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it.runIf(process.platform !== "win32")(
+		"canonicalizes a symlinked mise install path before ownership comparison",
+		async () => {
+			const installPath = join(
+				testHome,
+				".local",
+				"share",
+				"mise",
+				"installs",
+				"npm-codemem",
+				"0.40.2",
+			);
+			const entryPath = join(installPath, "lib", "node_modules", "codemem", "dist", "index.js");
+			const linkedInstallPath = join(testHome, "linked-mise-install");
+			await mkdir(join(installPath, "lib", "node_modules", "codemem", "dist"), {
+				recursive: true,
+			});
+			await writeFile(entryPath, "#!/usr/bin/env node\n", "utf8");
+			await symlink(installPath, linkedInstallPath, "dir");
+			const previousArgv = [...process.argv];
+			process.argv[1] = entryPath;
+			const activeState = miseState({ installPath: linkedInstallPath });
+			getUpdateStatus.mockResolvedValue(miseStatus);
+			spawn
+				.mockImplementationOnce(() => commandProcess({ stdout: activeState }))
+				.mockImplementationOnce(() => commandProcess({ stdout: activeState }))
+				.mockImplementationOnce(() => commandProcess())
+				.mockImplementationOnce(() => commandProcess({ stdout: updatedGlobalMiseState() }))
+				.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+			vi.spyOn(console, "log").mockImplementation(() => {});
+
+			try {
+				await parseUpdateCommand(["install", "--json"]);
+			} finally {
+				process.argv.splice(0, process.argv.length, ...previousArgv);
+			}
+
+			expect(spawn).toHaveBeenCalledTimes(5);
+			expect(process.exitCode).toBeUndefined();
+		},
+	);
+});
+
+describe("mise update state validation", () => {
+	beforeEach(useMiseEntrypoint);
+	it("ignores additional bounded fields in mise source metadata", async () => {
+		const source = Object.fromEntries([
+			["path", join(testHome, ".config", "mise", "config.toml")],
+			["metadata", { origin: "future-mise-version" }],
+			...Array.from({ length: 9 }, (_, index) => [`field-${index}`, `value-${index}`]),
+			["x".repeat(5_000), "long-key"],
+		]);
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: miseState({ source }) }))
+			.mockImplementationOnce(() => commandProcess({ stdout: miseState({ source }) }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() =>
+				commandProcess({ stdout: miseState({ source, version: "0.41.0" }) }),
+			)
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(spawn).toHaveBeenCalledTimes(5);
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("refuses malformed mise ownership state before mutation", async () => {
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn.mockImplementationOnce(() => commandProcess({ stdout: "{not-json" }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			error: "update_install_refused",
+			message: expect.stringContaining("mise use -g npm:codemem@0.41.0"),
+		});
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("bounds mise ownership output before parsing", async () => {
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn.mockImplementationOnce(() => commandProcess({ stdout: "x".repeat(65 * 1_024) }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			error: "update_install_refused",
+		});
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(process.exitCode).toBe(1);
+	});
+});
+
+describe("mise update lifecycle safeguards", () => {
+	beforeEach(useMiseEntrypoint);
+	it("refuses a stale mise release before spawning", async () => {
+		getUpdateStatus.mockResolvedValue({ ...miseStatus, stale: true });
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			error: "update_install_refused",
+		});
+		expect(spawn).not.toHaveBeenCalled();
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("fails when mise exits successfully but global state remains on the old version", async () => {
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			error: "update_verification_failed",
+		});
+		expect(spawn).toHaveBeenCalledTimes(4);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("accepts the target requested version when the installed version field lags", async () => {
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() =>
+				commandProcess({
+					stdout: miseState({ requestedVersion: "0.41.0", version: "0.40.2" }),
+				}),
+			)
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			installed_version: "0.41.0",
+			previous_version: "0.40.2",
+		});
+		expect(spawn).toHaveBeenCalledTimes(5);
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("fails when a mise update does not become the active CLI version", async () => {
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: updatedGlobalMiseState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.40.2\n" }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			error: "update_verification_failed",
+		});
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("bounds verification output and reports a generic failure", async () => {
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: updatedGlobalMiseState() }))
+			.mockImplementationOnce(() =>
+				commandProcess({
+					stdoutChunks: ["0.41.0\n", `sensitive-marker${"x".repeat(65 * 1_024)}`],
+				}),
+			);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_verification_failed",
+			message:
+				"mise updated global configuration, but installed version verification failed; inspect the global mise codemem state before retrying",
+		});
+		expect(log.mock.calls.flat().join("\n")).not.toContain("sensitive-marker");
+		expect(process.exitCode).toBe(1);
 	});
 });
 
@@ -371,6 +938,43 @@ describe("update install command on Windows", () => {
 				`""${npmShim}" install -g --registry https://registry.npmjs.org/ --@codemem:registry=https://registry.npmjs.org/ codemem@0.41.0 @codemem/embeddings@0.41.0"`,
 			],
 			expect.objectContaining({ shell: false, windowsVerbatimArguments: true }),
+		);
+		expect(process.exitCode).toBeUndefined();
+	});
+});
+
+describe("mise update install command on Windows", () => {
+	beforeEach(useMiseEntrypoint);
+	it("uses direct argv and Windows-safe spawn options", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+		getUpdateStatus.mockResolvedValue(miseStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: globalMiseState() }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: updatedGlobalMiseState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(spawn.mock.calls.map(([command, args]) => [command, args])).toEqual([
+			["mise", ["ls", "npm:codemem", "--current", "--json"]],
+			["mise", ["ls", "npm:codemem", "--global", "--json"]],
+			["mise", ["use", "-g", "npm:codemem@0.41.0"]],
+			["mise", ["ls", "npm:codemem", "--global", "--json"]],
+			["mise", ["exec", "--", "codemem", "version"]],
+		]);
+		expect(spawn.mock.calls[2]?.[2]).toEqual(
+			expect.objectContaining({
+				detached: false,
+				env: expect.objectContaining({
+					npm_config_registry: "https://registry.npmjs.org/",
+					"npm_config_@codemem:registry": "https://registry.npmjs.org/",
+				}),
+				shell: false,
+				windowsVerbatimArguments: undefined,
+			}),
 		);
 		expect(process.exitCode).toBeUndefined();
 	});

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,11 +1,14 @@
-import { spawn, spawnSync } from "node:child_process";
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { mkdir, open, readFile, stat, unlink } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, isAbsolute, join } from "node:path";
+import { dirname, isAbsolute, join, win32 } from "node:path";
 import {
 	detectInstallKind,
 	getUpdateStatus,
+	type InstallKind,
+	isExplicitUpdateInstallEligible,
 	isReleaseVersionForChannel,
+	resolveComparablePath,
 	VERSION,
 } from "@codemem/core";
 import { Command, Option } from "commander";
@@ -20,16 +23,109 @@ interface UpdateInstallOptions extends JsonOpts {}
 
 interface CommandResult {
 	exitCode: number;
+	outputExceeded: boolean;
 	stdout: string;
 	stderr: string;
+}
+
+interface ResolvedCommand {
+	command: string;
+	args: string[];
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	windowsVerbatimArguments?: boolean;
+}
+
+interface ExplicitUpdatePlan {
+	installKind: InstallKind;
+	manualGuidance: string;
+	runningEntryPath: string | null;
+	targetVersion: string;
+}
+
+interface MiseToolState {
+	active: boolean;
+	installPath: string;
+	requestedVersion: string | null;
+	sourceIdentity: string;
+	sourcePath: string;
+	version: string | null;
+}
+
+interface MiseStateQuery {
+	empty: boolean;
+	state: MiseToolState | null;
+}
+
+interface CommandOptions {
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	maxOutputBytes?: number;
+	windowsVerbatimArguments?: boolean;
 }
 
 const INSTALL_TIMEOUT_MS = 7 * 60 * 1_000;
 const VERIFY_TIMEOUT_MS = 30_000;
 const PUBLIC_NPM_REGISTRY = "https://registry.npmjs.org/";
 const UPDATE_LOCK_FILE = "update-install.lock";
+const UPDATE_COMMAND_MAX_OUTPUT_BYTES = 64 * 1_024;
 
 class UpdateInstallLockedError extends Error {}
+
+function commandStderr(outputExceeded: boolean, timedOut: boolean, stderr: string): string {
+	if (outputExceeded) return "command output too large";
+	if (timedOut) return "command timed out";
+	return stderr;
+}
+
+function createOutputCapture(maxOutputBytes?: number) {
+	let exceeded = false;
+	let outputBytes = 0;
+	let stderr = "";
+	let stdout = "";
+	return {
+		append(stream: "stderr" | "stdout", chunk: string): void {
+			if (exceeded) return;
+			outputBytes += Buffer.byteLength(chunk);
+			if (maxOutputBytes !== undefined && outputBytes > maxOutputBytes) {
+				exceeded = true;
+				return;
+			}
+			if (stream === "stderr") stderr += chunk;
+			else stdout += chunk;
+		},
+		exceeded: () => exceeded,
+		stderr: () => stderr,
+		stdout: () => stdout,
+	};
+}
+
+function terminateWindowsProcessTree(pid: number | undefined): boolean {
+	if (process.platform !== "win32" || !pid) return false;
+	const systemRoot = process.env.SystemRoot?.trim();
+	if (!systemRoot || !isAbsolute(systemRoot)) return false;
+	spawnSync(join(systemRoot, "System32", "taskkill.exe"), ["/PID", String(pid), "/T", "/F"], {
+		stdio: "ignore",
+		windowsHide: true,
+	});
+	return true;
+}
+
+function terminatePosixProcessGroup(pid: number | undefined, signal: NodeJS.Signals): boolean {
+	if (process.platform === "win32" || !pid) return false;
+	try {
+		process.kill(-pid, signal);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function terminateCommand(child: ChildProcess, signal: NodeJS.Signals): void {
+	if (terminateWindowsProcessTree(child.pid)) return;
+	if (terminatePosixProcessGroup(child.pid, signal)) return;
+	child.kill(signal);
+}
 
 function updateInstallLockPath(): string {
 	return join(process.env.HOME?.trim() || homedir(), ".codemem", UPDATE_LOCK_FILE);
@@ -87,7 +183,7 @@ function runCommand(
 	command: string,
 	args: string[],
 	timeoutMs: number,
-	options: { cwd?: string; env?: NodeJS.ProcessEnv; windowsVerbatimArguments?: boolean } = {},
+	options: CommandOptions = {},
 ): Promise<CommandResult> {
 	return new Promise((resolve, reject) => {
 		const child = spawn(command, args, {
@@ -100,8 +196,7 @@ function runCommand(
 		});
 		let settled = false;
 		let timedOut = false;
-		let stdout = "";
-		let stderr = "";
+		const output = createOutputCapture(options.maxOutputBytes);
 		let timer: ReturnType<typeof setTimeout>;
 		const finish = (result: CommandResult) => {
 			if (settled) return;
@@ -109,31 +204,7 @@ function runCommand(
 			clearTimeout(timer);
 			resolve(result);
 		};
-		const terminate = (signal: NodeJS.Signals) => {
-			if (process.platform === "win32" && child.pid) {
-				const systemRoot = process.env.SystemRoot?.trim();
-				if (systemRoot && isAbsolute(systemRoot)) {
-					spawnSync(
-						join(systemRoot, "System32", "taskkill.exe"),
-						["/PID", String(child.pid), "/T", "/F"],
-						{
-							stdio: "ignore",
-							windowsHide: true,
-						},
-					);
-					return;
-				}
-			}
-			if (process.platform !== "win32" && child.pid) {
-				try {
-					process.kill(-child.pid, signal);
-					return;
-				} catch {
-					// Fall back to terminating the direct child.
-				}
-			}
-			child.kill(signal);
-		};
+		const terminate = (signal: NodeJS.Signals) => terminateCommand(child, signal);
 		timer = setTimeout(() => {
 			timedOut = true;
 			terminate("SIGTERM");
@@ -142,18 +213,24 @@ function runCommand(
 		child.stdout.setEncoding("utf8");
 		child.stderr.setEncoding("utf8");
 		child.stdout.on("data", (chunk: string) => {
-			stdout += chunk;
+			output.append("stdout", chunk);
 		});
 		child.stderr.on("data", (chunk: string) => {
-			stderr += chunk;
+			output.append("stderr", chunk);
 		});
 		child.once("error", (error) => {
 			clearTimeout(timer);
 			if (!settled) reject(error);
 		});
-		child.once("close", (code) =>
-			finish({ exitCode: code ?? 1, stdout, stderr: timedOut ? "command timed out" : stderr }),
-		);
+		child.once("close", (code) => {
+			const stderr = commandStderr(output.exceeded(), timedOut, output.stderr());
+			finish({
+				exitCode: code ?? 1,
+				outputExceeded: output.exceeded(),
+				stdout: output.stdout(),
+				stderr,
+			});
+		});
 	});
 }
 
@@ -162,6 +239,7 @@ async function resolveWindowsShim(name: "npm.cmd" | "codemem.cmd"): Promise<stri
 	if (!systemRoot || !isAbsolute(systemRoot)) throw new Error("Windows SystemRoot is unavailable");
 	const result = await runCommand(join(systemRoot, "System32", "where.exe"), [name], 10_000, {
 		cwd: join(systemRoot, "System32"),
+		maxOutputBytes: UPDATE_COMMAND_MAX_OUTPUT_BYTES,
 	});
 	const shim = result.stdout
 		.split(/\r?\n/)
@@ -175,7 +253,11 @@ function windowsCommandLine(shim: string, args: string[]): string {
 	return `""${shim}" ${args.join(" ")}"`;
 }
 
-async function resolveInstallCommand(): Promise<{ command: string; args: string[]; cwd?: string }> {
+async function resolveNpmInstallCommand(): Promise<{
+	command: string;
+	args: string[];
+	cwd?: string;
+}> {
 	if (process.platform !== "win32") return { command: "npm", args: [] };
 	const systemRoot = process.env.SystemRoot?.trim();
 	if (!systemRoot || !isAbsolute(systemRoot)) throw new Error("Windows SystemRoot is unavailable");
@@ -219,6 +301,9 @@ function renderStatusWarning(error: string | null): string {
 
 function renderHumanStatus(status: Awaited<ReturnType<typeof getUpdateStatus>>): string {
 	const warning = renderStatusWarning(status.error);
+	if (status.install_kind === "repo-dev") {
+		return `Running from repository source (package metadata: ${status.current_version}). ${status.recommended_action}${warning}`;
+	}
 	if (status.update_available) {
 		return `Update available${cacheQualifier(status.stale)}: ${status.current_version} → ${status.latest_version}. ${status.recommended_action}${warning}`;
 	}
@@ -282,73 +367,348 @@ function updateInstallArgs(npmArgs: string[], targetVersion: string): string[] {
 	return [...npmArgs.slice(0, 3), windowsCommandLine(npmArgs[3] ?? "", installArgs)];
 }
 
+function miseCommandEnvironment(): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	const protectedKeys = new Set(["npm_config_registry", "npm_config_@codemem:registry"]);
+	if (process.platform === "linux") protectedKeys.add("onnxruntime_node_install");
+	for (const key of Object.keys(env)) {
+		if (protectedKeys.has(key.toLowerCase())) delete env[key];
+	}
+	env.npm_config_registry = PUBLIC_NPM_REGISTRY;
+	env["npm_config_@codemem:registry"] = PUBLIC_NPM_REGISTRY;
+	if (process.platform === "linux") env.ONNXRUNTIME_NODE_INSTALL = "skip";
+	return env;
+}
+
+function miseGlobalCwd(): string {
+	if (process.platform !== "win32") return "/";
+	const systemRoot = process.env.SystemRoot?.trim();
+	if (systemRoot) {
+		const root = win32.parse(systemRoot).root;
+		if (root) return root;
+	}
+	return process.env.HOME?.trim() || homedir();
+}
+
+async function resolveUpdateInstallCommand(
+	installKind: InstallKind,
+	targetVersion: string,
+): Promise<ResolvedCommand> {
+	if (installKind === "mise") {
+		return {
+			command: "mise",
+			args: ["use", "-g", `npm:codemem@${targetVersion}`],
+			cwd: miseGlobalCwd(),
+			env: miseCommandEnvironment(),
+		};
+	}
+
+	const npm = await resolveNpmInstallCommand();
+	return {
+		command: npm.command,
+		args: updateInstallArgs(npm.args, targetVersion),
+		cwd: npm.cwd,
+		env:
+			process.platform === "linux"
+				? { ...process.env, ONNXRUNTIME_NODE_INSTALL: "skip" }
+				: undefined,
+		windowsVerbatimArguments: process.platform === "win32",
+	};
+}
+
+function installLaunchErrorMessage(
+	installKind: InstallKind,
+	targetVersion: string,
+	error: unknown,
+): string {
+	if (
+		installKind === "mise" &&
+		error instanceof Error &&
+		(error as NodeJS.ErrnoException).code === "ENOENT"
+	) {
+		return `mise was not found on PATH; install mise, then run mise use -g npm:codemem@${targetVersion}`;
+	}
+	return error instanceof Error ? error.message : "update installation failed";
+}
+
+function failedInstallMessage(installKind: InstallKind): string {
+	return installKind === "mise" ? "mise installation failed" : "npm installation failed";
+}
+
+async function runUpdateInstallCommand(
+	installKind: InstallKind,
+	targetVersion: string,
+): Promise<CommandResult> {
+	const install = await resolveUpdateInstallCommand(installKind, targetVersion);
+	try {
+		return await runCommand(install.command, install.args, INSTALL_TIMEOUT_MS, {
+			cwd: install.cwd,
+			env: install.env,
+			maxOutputBytes: UPDATE_COMMAND_MAX_OUTPUT_BYTES,
+			windowsVerbatimArguments: install.windowsVerbatimArguments,
+		});
+	} catch (error) {
+		throw new Error(installLaunchErrorMessage(installKind, targetVersion, error));
+	}
+}
+
+function parseMiseSourcePath(source: unknown): string | null {
+	if (!source || typeof source !== "object" || Array.isArray(source)) return null;
+	const sourcePath = (source as Record<string, unknown>).path;
+	return typeof sourcePath === "string" && sourcePath ? sourcePath : null;
+}
+
+function parseMiseStateRecord(record: unknown): MiseToolState | null {
+	if (!record || typeof record !== "object" || Array.isArray(record)) return null;
+	const candidate = record as Record<string, unknown>;
+	const sourcePath = parseMiseSourcePath(candidate.source);
+	const version = candidate.version;
+	const requestedVersion = candidate.requested_version;
+	if (
+		typeof candidate.active !== "boolean" ||
+		typeof candidate.install_path !== "string" ||
+		!candidate.install_path ||
+		(version !== undefined && (typeof version !== "string" || !version)) ||
+		(requestedVersion !== undefined &&
+			(typeof requestedVersion !== "string" || !requestedVersion)) ||
+		(typeof version !== "string" && typeof requestedVersion !== "string") ||
+		!sourcePath
+	) {
+		return null;
+	}
+	return {
+		active: candidate.active,
+		installPath: candidate.install_path,
+		requestedVersion: typeof requestedVersion === "string" ? requestedVersion : null,
+		sourceIdentity: resolveComparablePath(sourcePath),
+		sourcePath,
+		version: typeof version === "string" ? version : null,
+	};
+}
+
+function parseMiseState(raw: string): MiseStateQuery | null {
+	if (Buffer.byteLength(raw) > UPDATE_COMMAND_MAX_OUTPUT_BYTES) return null;
+	let payload: unknown;
+	try {
+		payload = JSON.parse(raw);
+	} catch {
+		return null;
+	}
+	if (!Array.isArray(payload)) return null;
+	if (payload.length === 0) return { empty: true, state: null };
+	if (payload.length !== 1) return null;
+	const state = parseMiseStateRecord(payload[0]);
+	return state ? { empty: false, state } : null;
+}
+
+async function readMiseState(
+	args: string[],
+	targetVersion: string,
+	options: { cwd?: string } = {},
+): Promise<MiseStateQuery | null> {
+	try {
+		const result = await runCommand("mise", args, VERIFY_TIMEOUT_MS, {
+			cwd: options.cwd,
+			env: miseCommandEnvironment(),
+			maxOutputBytes: UPDATE_COMMAND_MAX_OUTPUT_BYTES,
+		});
+		if (result.exitCode !== 0 || result.outputExceeded) return null;
+		return parseMiseState(result.stdout);
+	} catch (error) {
+		throw new Error(installLaunchErrorMessage("mise", targetVersion, error));
+	}
+}
+
+function isPathWithin(path: string, root: string): boolean {
+	return path === root || path.startsWith(`${root}/`);
+}
+
+function isPortableAbsolutePath(value: string): boolean {
+	return value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value);
+}
+
+function isUserOwnedMiseSource(state: MiseToolState): boolean {
+	if (!isPortableAbsolutePath(state.sourcePath)) return false;
+	const sourcePath = resolveComparablePath(state.sourcePath);
+	const homePath = resolveComparablePath(process.env.HOME?.trim() || homedir());
+	if (homePath === "/" || /^[a-z]:$/i.test(homePath)) return false;
+	return isPathWithin(sourcePath, homePath);
+}
+
+function isLegacyUserMiseSource(state: MiseToolState): boolean {
+	if (!isUserOwnedMiseSource(state)) return false;
+	const home = process.env.HOME?.trim() || homedir();
+	const configHome = process.env.XDG_CONFIG_HOME?.trim() || join(home, ".config");
+	return state.sourceIdentity === resolveComparablePath(join(configHome, "mise.toml"));
+}
+
+function miseStateOwnsEntry(state: MiseToolState, runningEntryPath: string | null): boolean {
+	if (!runningEntryPath) return false;
+	if (!isPortableAbsolutePath(state.installPath)) return false;
+	const installPath = resolveComparablePath(state.installPath);
+	const entryPath = resolveComparablePath(runningEntryPath);
+	if (installPath === "/" || /^[a-z]:$/i.test(installPath)) return false;
+	return entryPath === installPath || entryPath.startsWith(`${installPath}/`);
+}
+
+async function proveGlobalMiseOwnership(plan: ExplicitUpdatePlan): Promise<MiseToolState | null> {
+	const activeQuery = await readMiseState(
+		["ls", "npm:codemem", "--current", "--json"],
+		plan.targetVersion,
+	);
+	const activeState = activeQuery?.state;
+	if (!activeState?.active || !miseStateOwnsEntry(activeState, plan.runningEntryPath)) return null;
+	const globalQuery = await readMiseState(
+		["ls", "npm:codemem", "--global", "--json"],
+		plan.targetVersion,
+		{ cwd: miseGlobalCwd() },
+	);
+	if (globalQuery?.empty && isLegacyUserMiseSource(activeState)) return activeState;
+	const globalState = globalQuery?.state;
+	if (
+		!globalState?.active ||
+		activeState.sourceIdentity !== globalState.sourceIdentity ||
+		!isUserOwnedMiseSource(globalState)
+	)
+		return null;
+	return globalState;
+}
+
+async function resolveExplicitUpdatePlan(
+	options: UpdateInstallOptions,
+): Promise<ExplicitUpdatePlan | null> {
+	const detectedInstallKind = detectInstallKind({
+		entryPath: process.argv[1] ?? "",
+		env: process.env,
+	});
+	const status = await getUpdateStatus({
+		currentVersion: VERSION,
+		installKind: detectedInstallKind,
+		refresh: true,
+	});
+	if (!isExplicitUpdateInstallEligible(status) || !status.latest_version) {
+		failInstall(options, "update_install_refused", status.recommended_action);
+		return null;
+	}
+	if (!status.channel || !isReleaseVersionForChannel(status.latest_version, status.channel)) {
+		failInstall(
+			options,
+			"update_install_refused",
+			"release version does not match the installed channel",
+		);
+		return null;
+	}
+	return {
+		installKind: status.install_kind,
+		manualGuidance: status.recommended_action,
+		runningEntryPath:
+			detectedInstallKind === "mise" ? resolveRunningEntryPath(process.argv[1] ?? "") : null,
+		targetVersion: status.latest_version,
+	};
+}
+
+function resolveRunningEntryPath(entryPath: string): string {
+	return resolveComparablePath(entryPath);
+}
+
+async function verifyMiseInstalledVersion(plan: ExplicitUpdatePlan): Promise<boolean> {
+	const globalQuery = await readMiseState(
+		["ls", "npm:codemem", "--global", "--json"],
+		plan.targetVersion,
+		{ cwd: miseGlobalCwd() },
+	);
+	const globalState = globalQuery?.state;
+	if (
+		!globalState?.active ||
+		(globalState.version !== plan.targetVersion &&
+			globalState.requestedVersion !== plan.targetVersion)
+	) {
+		return false;
+	}
+	const verification = await runCommand(
+		"mise",
+		["exec", "--", "codemem", "version"],
+		VERIFY_TIMEOUT_MS,
+		{
+			cwd: miseGlobalCwd(),
+			env: miseCommandEnvironment(),
+			maxOutputBytes: UPDATE_COMMAND_MAX_OUTPUT_BYTES,
+		},
+	);
+	return (
+		!verification.outputExceeded &&
+		verification.exitCode === 0 &&
+		verification.stdout.trim() === plan.targetVersion
+	);
+}
+
+async function verifyInstalledVersion(plan: ExplicitUpdatePlan): Promise<boolean> {
+	if (plan.installKind === "mise") {
+		return verifyMiseInstalledVersion(plan);
+	}
+	const codemem = await resolveVerificationCommand();
+	const verificationArgs =
+		process.platform === "win32"
+			? [...codemem.args.slice(0, 3), windowsCommandLine(codemem.args[3] ?? "", ["version"])]
+			: ["version"];
+	const verification = await runCommand(codemem.command, verificationArgs, VERIFY_TIMEOUT_MS, {
+		cwd: codemem.cwd,
+		maxOutputBytes: UPDATE_COMMAND_MAX_OUTPUT_BYTES,
+		windowsVerbatimArguments: process.platform === "win32",
+	});
+	return (
+		!verification.outputExceeded &&
+		verification.exitCode === 0 &&
+		verification.stdout.trim() === plan.targetVersion
+	);
+}
+
+function emitInstallSuccess(options: UpdateInstallOptions, targetVersion: string): void {
+	const result = { previous_version: VERSION, installed_version: targetVersion };
+	if (options.json) console.log(JSON.stringify(result));
+	else console.log(`Updated codemem from ${VERSION} to ${targetVersion}.`);
+}
+
+async function executeExplicitUpdate(
+	options: UpdateInstallOptions,
+	plan: ExplicitUpdatePlan,
+): Promise<void> {
+	const globalMiseState = plan.installKind === "mise" ? await proveGlobalMiseOwnership(plan) : null;
+	if (plan.installKind === "mise" && !globalMiseState) {
+		failInstall(
+			options,
+			"update_install_refused",
+			`Could not prove the active mise codemem installation is globally configured. ${plan.manualGuidance}`,
+		);
+		return;
+	}
+	const installation = await runUpdateInstallCommand(plan.installKind, plan.targetVersion);
+	if (installation.exitCode !== 0) {
+		failInstall(
+			options,
+			"update_install_failed",
+			installation.stderr.trim() || failedInstallMessage(plan.installKind),
+		);
+		return;
+	}
+	if (!(await verifyInstalledVersion(plan))) {
+		const message =
+			plan.installKind === "mise"
+				? "mise updated global configuration, but installed version verification failed; inspect the global mise codemem state before retrying"
+				: "installed version verification failed";
+		failInstall(options, "update_verification_failed", message);
+		return;
+	}
+	emitInstallSuccess(options, plan.targetVersion);
+}
+
 async function installUpdate(options: UpdateInstallOptions): Promise<void> {
 	let releaseInstallLock: (() => Promise<void>) | null = null;
 	try {
-		const installKind = detectInstallKind({
-			entryPath: process.argv[1] ?? "",
-			env: process.env,
-		});
-		const status = await getUpdateStatus({
-			currentVersion: VERSION,
-			installKind,
-			refresh: true,
-		});
-		if (!status.auto_update_eligible || !status.latest_version) {
-			failInstall(options, "update_install_refused", status.recommended_action);
-			return;
-		}
-
-		const targetVersion = status.latest_version;
-		if (!status.channel || !isReleaseVersionForChannel(targetVersion, status.channel)) {
-			failInstall(
-				options,
-				"update_install_refused",
-				"release version does not match the installed channel",
-			);
-			return;
-		}
+		const plan = await resolveExplicitUpdatePlan(options);
+		if (!plan) return;
 		releaseInstallLock = await acquireInstallLock();
-		const npm = await resolveInstallCommand();
-		const installation = await runCommand(
-			npm.command,
-			updateInstallArgs(npm.args, targetVersion),
-			INSTALL_TIMEOUT_MS,
-			{
-				cwd: npm.cwd,
-				env:
-					process.platform === "linux"
-						? { ...process.env, ONNXRUNTIME_NODE_INSTALL: "skip" }
-						: undefined,
-				windowsVerbatimArguments: process.platform === "win32",
-			},
-		);
-		if (installation.exitCode !== 0) {
-			failInstall(
-				options,
-				"update_install_failed",
-				installation.stderr.trim() || "npm installation failed",
-			);
-			return;
-		}
-
-		const codemem = await resolveVerificationCommand();
-		const verification = await runCommand(
-			codemem.command,
-			process.platform === "win32"
-				? [...codemem.args.slice(0, 3), windowsCommandLine(codemem.args[3] ?? "", ["version"])]
-				: ["version"],
-			VERIFY_TIMEOUT_MS,
-			{ cwd: codemem.cwd, windowsVerbatimArguments: process.platform === "win32" },
-		);
-		if (verification.exitCode !== 0 || verification.stdout.trim() !== targetVersion) {
-			failInstall(options, "update_verification_failed", "installed version verification failed");
-			return;
-		}
-
-		const result = { previous_version: VERSION, installed_version: targetVersion };
-		if (options.json) console.log(JSON.stringify(result));
-		else console.log(`Updated codemem from ${VERSION} to ${targetVersion}.`);
+		await executeExplicitUpdate(options, plan);
 	} catch (error) {
 		failInstall(
 			options,

--- a/packages/core/src/mise-install-path.ts
+++ b/packages/core/src/mise-install-path.ts
@@ -1,0 +1,68 @@
+import { realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import { posix } from "node:path";
+
+export function normalizePortablePath(value: string): string {
+	const normalized = posix.normalize(value.replaceAll("\\", "/"));
+	return normalized === "/" ? normalized : normalized.replace(/\/+$/, "");
+}
+
+export function comparablePortablePath(value: string): string {
+	return /^[A-Za-z]:\//.test(value) ? value.toLowerCase() : value;
+}
+
+export function resolveComparablePath(value: string): string {
+	try {
+		return comparablePortablePath(normalizePortablePath(realpathSync(value)));
+	} catch {
+		return comparablePortablePath(normalizePortablePath(value));
+	}
+}
+
+export function normalizeInstallEntryPath(entryPath: string): string {
+	if (!entryPath) return "";
+	try {
+		return normalizePortablePath(realpathSync(entryPath));
+	} catch {
+		return normalizePortablePath(entryPath);
+	}
+}
+
+function configuredMiseDataDirectories(env: Record<string, string | undefined>): string[] {
+	const explicitDataDirectory = env.MISE_DATA_DIR?.trim();
+	if (explicitDataDirectory) return [explicitDataDirectory];
+
+	const candidates: string[] = [];
+	const xdgDataHome = env.XDG_DATA_HOME?.trim();
+	if (xdgDataHome) return [posix.join(xdgDataHome, "mise")];
+	const localAppData = env.LOCALAPPDATA?.trim();
+	if (localAppData) return [posix.join(localAppData, "mise")];
+	const home = env.HOME?.trim() || env.USERPROFILE?.trim() || homedir();
+	if (home) candidates.push(posix.join(home, ".local/share/mise"));
+	return candidates;
+}
+
+function versionUnderMiseDataDirectory(entryPath: string, dataDirectory: string): string | null {
+	const installPrefix = `${posix.join(
+		resolveComparablePath(dataDirectory),
+		"installs/npm-codemem",
+	)}/`;
+	if (!entryPath.startsWith(installPrefix)) return null;
+	const versionAndPath = entryPath.slice(installPrefix.length);
+	const separatorIndex = versionAndPath.indexOf("/");
+	return separatorIndex > 0 ? versionAndPath.slice(0, separatorIndex) : null;
+}
+
+export function miseInstallVersionFromPath(
+	entryPath: string,
+	env: Record<string, string | undefined>,
+): string | null {
+	const comparableEntryPath = comparablePortablePath(normalizeInstallEntryPath(entryPath));
+	for (const dataDirectory of configuredMiseDataDirectories(env)) {
+		const version = versionUnderMiseDataDirectory(comparableEntryPath, dataDirectory);
+		if (version) return version;
+	}
+	const defaultMatch = /\/mise\/installs\/npm-codemem\/([^/]+)\//.exec(comparableEntryPath);
+	if (defaultMatch?.[1] !== undefined) return defaultMatch[1];
+	return null;
+}

--- a/packages/core/src/release-discovery.test.ts
+++ b/packages/core/src/release-discovery.test.ts
@@ -1,13 +1,15 @@
-import { mkdir, mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { miseInstallVersionFromPath } from "./mise-install-path.js";
 import {
 	createReleaseCacheIo,
 	createReleaseDiscovery,
 	detectInstallKind,
 	type InstallDetectionInput,
 	type InstallKind,
+	isExplicitUpdateInstallEligible,
 	type ReleaseChannel,
 	type ReleaseDiscoveryDependencies,
 } from "./release-discovery.js";
@@ -482,6 +484,78 @@ describe("release discovery registry contract", () => {
 			registryUrl("rc"),
 			expect.objectContaining({ redirect: "error", signal: expect.any(AbortSignal) }),
 		);
+	});
+});
+
+describe("repository-source release status", () => {
+	it("keeps registry metadata informational", async () => {
+		const status = await check(dependencies({ payload: { version: "0.44.2" } }), {
+			currentVersion: "0.44.0",
+			installKind: "repo-dev",
+		});
+
+		expect(status).toMatchObject({
+			current_version: "0.44.0",
+			install_kind: "repo-dev",
+			latest_version: "0.44.2",
+			update_available: false,
+		});
+		expect(status.recommended_action).toBe(
+			"Package-release updates do not apply to repository source. Run git pull, pnpm install, and pnpm build in the codemem repository.",
+		);
+	});
+});
+
+describe("mise release eligibility", () => {
+	it("never authorizes automatic installation for mise", async () => {
+		const deps = dependencies({
+			cache: JSON.stringify(
+				cacheRecord({
+					first_seen_at: "2026-08-09T12:00:00.000Z",
+					checked_at: NOW.toISOString(),
+				}),
+			),
+		});
+
+		const status = await check(deps, { installKind: "mise" });
+
+		expect(status.auto_update_eligible).toBe(false);
+	});
+
+	it("permits a fresh error-free explicit mise update", async () => {
+		const status = await check(dependencies(), { installKind: "mise" });
+
+		expect(status.auto_update_eligible).toBe(false);
+		expect(isExplicitUpdateInstallEligible(status)).toBe(true);
+	});
+
+	it("preserves delayed npm-global explicit eligibility", async () => {
+		const pending = await check(dependencies(), { installKind: "npm-global" });
+		const eligible = await check(
+			dependencies({
+				cache: JSON.stringify(
+					cacheRecord({
+						first_seen_at: "2026-08-09T12:00:00.000Z",
+						checked_at: NOW.toISOString(),
+					}),
+				),
+			}),
+			{ installKind: "npm-global" },
+		);
+
+		expect(isExplicitUpdateInstallEligible(pending)).toBe(false);
+		expect(isExplicitUpdateInstallEligible(eligible)).toBe(true);
+	});
+});
+
+describe("explicit mise update eligibility", () => {
+	it.each([
+		{ error: "registry request failed", stale: false },
+		{ error: null, stale: true },
+	])("refuses mise when stale=$stale and error=$error", async ({ error, stale }) => {
+		const status = await check(dependencies(), { installKind: "mise" });
+
+		expect(isExplicitUpdateInstallEligible({ ...status, error, stale })).toBe(false);
 	});
 });
 
@@ -1029,6 +1103,160 @@ describe("installation-kind detection", () => {
 	});
 });
 
+describe("mise installation-kind detection", () => {
+	it.each([
+		{
+			label: "Unix path",
+			entryPath:
+				"/home/user/.local/share/mise/installs/npm-codemem/0.41.0/lib/node_modules/codemem/dist/index.js",
+		},
+		{
+			label: "Windows-style path",
+			entryPath:
+				"C:\\Users\\user\\AppData\\Local\\mise\\installs\\npm-codemem\\0.41.0\\lib\\node_modules\\codemem\\dist\\index.js",
+		},
+	])("detects a mise npm backend $label", ({ entryPath }) => {
+		expect(detectInstallKind({ entryPath })).toBe("mise");
+	});
+
+	it("detects an executable beneath a symlinked default mise data directory", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "codemem-mise-default-link-"));
+		temporaryDirectories.push(directory);
+		const home = join(directory, "home");
+		const dataDirectory = join(home, ".local", "share", "mise");
+		const canonicalStore = join(directory, "tool-store");
+		const relativeEntry = join(
+			"installs",
+			"npm-codemem",
+			"0.41.0",
+			"lib",
+			"node_modules",
+			"codemem",
+			"dist",
+			"index.js",
+		);
+		await mkdir(dirname(join(canonicalStore, relativeEntry)), { recursive: true });
+		await writeFile(join(canonicalStore, relativeEntry), "");
+		await mkdir(join(dataDirectory, ".."), { recursive: true });
+		await symlink(canonicalStore, dataDirectory, process.platform === "win32" ? "junction" : "dir");
+
+		expect(
+			detectInstallKind({
+				entryPath: join(dataDirectory, relativeEntry),
+				env: { HOME: home },
+			}),
+		).toBe("mise");
+	});
+});
+
+describe("custom mise data directory detection", () => {
+	it.each([
+		{
+			entryPath:
+				"/home/user/xdg/mise/installs/npm-codemem/0.41.0/lib/node_modules/codemem/dist/index.js",
+			env: { XDG_DATA_HOME: "/home/user/xdg" },
+			label: "XDG data home",
+		},
+		{
+			entryPath:
+				"D:\\Users\\user\\AppData\\Local\\mise\\installs\\npm-codemem\\0.41.0\\lib\\node_modules\\codemem\\dist\\index.js",
+			env: { LOCALAPPDATA: "D:\\Users\\user\\AppData\\Local" },
+			label: "Windows LocalAppData",
+		},
+		{
+			entryPath:
+				"/home/user/.local/share/mise/installs/npm-codemem/0.41.0/lib/node_modules/codemem/dist/index.js",
+			env: { USERPROFILE: "/home/user" },
+			label: "USERPROFILE fallback",
+		},
+	])("detects the default mise root from $label", ({ entryPath, env }) => {
+		expect(detectInstallKind({ entryPath, env })).toBe("mise");
+	});
+
+	it.each([
+		{
+			dataDir: "/opt/mise-data/../mise-data/",
+			entryPath:
+				"/opt/mise-data/installs/npm-codemem/0.41.0/lib/node_modules/codemem/dist/index.js",
+			label: "Unix",
+		},
+		{
+			dataDir: "C:\\mise-data\\.\\",
+			entryPath:
+				"C:\\mise-data\\installs\\npm-codemem\\0.41.0\\lib\\node_modules\\codemem\\dist\\index.js",
+			label: "Windows-style",
+		},
+	])("accepts a normalized $label MISE_DATA_DIR install prefix", ({ dataDir, entryPath }) => {
+		expect(
+			detectInstallKind({
+				entryPath,
+				env: { MISE_DATA_DIR: dataDir },
+			}),
+		).toBe("mise");
+	});
+
+	it("extracts the exact version from the same comparable custom path used for matching", () => {
+		expect(
+			miseInstallVersionFromPath(
+				"C:\\MİSE-DATA\\installs\\npm-codemem\\0.41.0\\lib\\node_modules\\codemem\\dist\\index.js",
+				{ MISE_DATA_DIR: "C:\\MİSE-DATA\\" },
+			),
+		).toBe("0.41.0");
+	});
+
+	it.each([
+		"/opt/tools/installs/npm-codemem/0.41.0/bin/codemem",
+		"/opt/mise-data-other/installs/npm-codemem/0.41.0/bin/codemem",
+	])("rejects insufficient mise path evidence at %s", (entryPath) => {
+		expect(detectInstallKind({ entryPath, env: { MISE_DATA_DIR: "/opt/mise-data" } })).toBe(
+			"unknown",
+		);
+	});
+});
+
+describe("mise installation evidence safeguards", () => {
+	it("fails closed for an unrecognized npm backend install root", () => {
+		expect(
+			detectInstallKind({
+				entryPath:
+					"/opt/tool-store/installs/npm-codemem/0.41.0/lib/node_modules/codemem/dist/index.js",
+			}),
+		).toBe("unknown");
+	});
+
+	it.each([
+		{
+			label: "an unrecognized executable path",
+			entryPath: "/opt/custom/codemem-cli.js",
+		},
+		{
+			label: "conflicting npm-global path evidence",
+			entryPath: "/usr/local/lib/node_modules/codemem/dist/index.js",
+		},
+	])("does not let an explicit mise marker claim $label", ({ entryPath }) => {
+		expect(detectInstallKind({ entryPath, env: { CODEMEM_INSTALL_KIND: "mise" } })).toBe("unknown");
+	});
+
+	it("prefers mise path evidence over the generic npm-global layout", () => {
+		expect(
+			detectInstallKind({
+				entryPath:
+					"/home/user/.local/share/mise/installs/npm-codemem/0.41.0/lib/node_modules/codemem/dist/index.js",
+				env: { CODEMEM_INSTALL_KIND: "npm-global" },
+			}),
+		).toBe("mise");
+	});
+
+	it("requires an exact version segment in mise path evidence", () => {
+		expect(
+			detectInstallKind({
+				entryPath:
+					"/home/user/.local/share/mise/installs/npm-codemem/latest/lib/node_modules/codemem/dist/index.js",
+			}),
+		).toBe("unknown");
+	});
+});
+
 describe("installation guidance", () => {
 	it.each([
 		{ channel: "alpha", currentVersion: "0.44.0-alpha.1", latestVersion: "0.44.0-alpha.2" },
@@ -1095,5 +1323,27 @@ describe("installation guidance", () => {
 
 		// Assert
 		expect(status.recommended_action).toMatch(/up to date|no action/i);
+	});
+});
+
+describe("mise installation guidance", () => {
+	it("returns the exact mise upgrade command off Linux", async () => {
+		const platform = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+		const status = await check(dependencies(), { installKind: "mise" }).finally(() =>
+			platform.mockRestore(),
+		);
+
+		expect(status.recommended_action).toBe("mise use -g npm:codemem@0.41.0");
+	});
+
+	it("returns the exact Linux mise upgrade command with install safeguards", async () => {
+		const platform = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+		const status = await check(dependencies(), { installKind: "mise" }).finally(() =>
+			platform.mockRestore(),
+		);
+
+		expect(status.recommended_action).toBe(
+			"env ONNXRUNTIME_NODE_INSTALL=skip mise use -g npm:codemem@0.41.0",
+		);
 	});
 });

--- a/packages/core/src/release-discovery.ts
+++ b/packages/core/src/release-discovery.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from "node:crypto";
-import { realpathSync } from "node:fs";
 import { mkdir, open, readFile, rename, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { codememHomeDir } from "./home.js";
+import { miseInstallVersionFromPath, normalizeInstallEntryPath } from "./mise-install-path.js";
+
+export { resolveComparablePath } from "./mise-install-path.js";
 
 const REGISTRY_URL_PREFIX = "https://registry.npmjs.org/codemem/";
 const REQUEST_TIMEOUT_MS = 2_000;
@@ -16,8 +18,25 @@ const AUTO_UPDATE_DELAY_MS = 24 * 60 * 60 * 1_000;
 const SEMVER =
 	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 
-export type InstallKind = "npm-global" | "npx" | "docker" | "repo-dev" | "pinned" | "unknown";
+export type InstallKind =
+	| "npm-global"
+	| "mise"
+	| "npx"
+	| "docker"
+	| "repo-dev"
+	| "pinned"
+	| "unknown";
 export type ReleaseChannel = "alpha" | "beta" | "rc" | "latest";
+
+const KNOWN_INSTALL_KINDS: readonly InstallKind[] = [
+	"npm-global",
+	"mise",
+	"npx",
+	"docker",
+	"repo-dev",
+	"pinned",
+	"unknown",
+];
 
 export interface UpdateStatus {
 	current_version: string;
@@ -31,6 +50,16 @@ export interface UpdateStatus {
 	auto_update_eligible: boolean;
 	recommended_action: string;
 	error: string | null;
+}
+
+export function isExplicitUpdateInstallEligible(status: UpdateStatus): boolean {
+	if (status.install_kind === "npm-global") return status.auto_update_eligible;
+	return (
+		status.install_kind === "mise" &&
+		status.update_available &&
+		!status.stale &&
+		status.error === null
+	);
 }
 
 interface ReleaseCacheRecord {
@@ -299,6 +328,9 @@ function recommendedAction(
 	updateAvailable: boolean,
 	channel: ReleaseChannel | null,
 ): string {
+	if (installKind === "repo-dev") {
+		return "Package-release updates do not apply to repository source. Run git pull, pnpm install, and pnpm build in the codemem repository.";
+	}
 	if (!channel || !isReleaseVersionForChannel(currentVersion, channel)) {
 		return "Verify the current codemem version and try again.";
 	}
@@ -310,17 +342,29 @@ function recommendedAction(
 	switch (installKind) {
 		case "npm-global":
 			return `${process.platform === "linux" ? "env ONNXRUNTIME_NODE_INSTALL=skip " : ""}npm install -g codemem@${latestVersion}`;
+		case "mise":
+			return process.platform === "linux"
+				? `env ONNXRUNTIME_NODE_INSTALL=skip mise use -g npm:codemem@${latestVersion}`
+				: `mise use -g npm:codemem@${latestVersion}`;
 		case "npx":
 			return `Update your launcher to request codemem@${latestVersion} and @codemem/embeddings@${latestVersion} together.`;
 		case "docker":
 			return `Set CODEMEM_VERSION=${latestVersion}, then run CODEMEM_VERSION=${latestVersion} docker compose build --pull and docker compose up -d.`;
-		case "repo-dev":
-			return "Run git pull, pnpm install, and pnpm build in the codemem repository.";
 		case "pinned":
 			return `Update the pinned codemem version to ${latestVersion}, then restart codemem.`;
 		default:
 			return `Update codemem to ${latestVersion} using your installation method.`;
 	}
+}
+
+function hasNewerPackageRelease(
+	installKind: InstallKind,
+	currentVersion: string,
+	latestVersion: string | null,
+): boolean {
+	if (installKind === "repo-dev" || latestVersion === null) return false;
+	const comparison = compareSemver(latestVersion, currentVersion);
+	return comparison !== null && comparison > 0;
 }
 
 function toStatus(
@@ -329,8 +373,11 @@ function toStatus(
 	channel: ReleaseChannel | null,
 ): UpdateStatus {
 	const latestVersion = resolution.record?.latest_version ?? null;
-	const comparison = latestVersion ? compareSemver(latestVersion, options.currentVersion) : null;
-	const updateAvailable = comparison !== null && comparison > 0;
+	const updateAvailable = hasNewerPackageRelease(
+		options.installKind,
+		options.currentVersion,
+		latestVersion,
+	);
 	return {
 		current_version: options.currentVersion,
 		channel,
@@ -530,52 +577,62 @@ function isPinnedSource(source: string): boolean {
 	return fragment.length > 0 && !containsWhitespace(fragment);
 }
 
+function miseInstallKindForPath(
+	entryPath: string,
+	env: Record<string, string | undefined>,
+): "mise" | "unknown" | null {
+	const version = miseInstallVersionFromPath(entryPath, env);
+	if (version === null) return null;
+	return parseSemver(version) === null ? "unknown" : "mise";
+}
+
+function narrowedInstallKind(
+	entryPath: string,
+	explicit: string,
+	env: Record<string, string | undefined>,
+): InstallKind | null {
+	if (!explicit) return null;
+	if (!KNOWN_INSTALL_KINDS.includes(explicit as InstallKind)) return "unknown";
+	if (explicit === "mise" && miseInstallKindForPath(entryPath, env) !== "mise") return "unknown";
+	if (["docker", "repo-dev", "pinned", "unknown"].includes(explicit)) {
+		return explicit as InstallKind;
+	}
+	return null;
+}
+
+function runnerInstallKind(runner: string): InstallKind | null {
+	return runner === "node" || runner === "uv" ? "repo-dev" : null;
+}
+
+function installKindForEntryPath(
+	entryPath: string,
+	env: Record<string, string | undefined>,
+): InstallKind {
+	const miseInstallKind = miseInstallKindForPath(entryPath, env);
+	if (miseInstallKind) return miseInstallKind;
+	if (/\/(?:_npx|\.pnpm\/dlx)\//.test(entryPath)) return "npx";
+	if (/\/installs\/npm-codemem\/[^/]+\//.test(entryPath)) return "unknown";
+	if (/\/lib\/node_modules\/codemem\/dist\/index\.js$/.test(entryPath)) return "npm-global";
+	if (/\/AppData\/Roaming\/npm\/node_modules\/codemem\/dist\/index\.js$/i.test(entryPath)) {
+		return "npm-global";
+	}
+	return "unknown";
+}
+
 export function detectInstallKind(input: InstallDetectionInput): InstallKind {
 	const env = input.env ?? {};
 	const source = env.CODEMEM_RUNNER_FROM?.trim() ?? "";
 	if (isPinnedSource(source)) return "pinned";
 
-	let entryPath = input.entryPath;
-	if (entryPath) {
-		try {
-			entryPath = realpathSync(entryPath);
-		} catch {
-			// Preserve synthetic, removed, and otherwise unresolved paths for the
-			// existing pattern checks below.
-		}
-	}
-	entryPath = entryPath.replaceAll("\\", "/");
+	const entryPath = normalizeInstallEntryPath(input.entryPath);
 	if (/\/packages\/cli\/src\/index\.ts$/.test(entryPath)) return "repo-dev";
 
 	const explicit = env.CODEMEM_INSTALL_KIND?.trim().toLowerCase();
-	const knownKinds: readonly InstallKind[] = [
-		"npm-global",
-		"npx",
-		"docker",
-		"repo-dev",
-		"pinned",
-		"unknown",
-	];
-	if (explicit) {
-		if (!knownKinds.includes(explicit as InstallKind)) return "unknown";
-		// An environment marker may safely narrow permissions, but it must never
-		// authorize process execution on its own.
-		if (["docker", "repo-dev", "pinned", "unknown"].includes(explicit)) {
-			return explicit as InstallKind;
-		}
-	}
+	const narrowedKind = narrowedInstallKind(entryPath, explicit ?? "", env);
+	if (narrowedKind) return narrowedKind;
 
 	const runner = env.CODEMEM_RUNNER?.trim().toLowerCase();
-	if (runner === "node" || runner === "uv") return "repo-dev";
-
-	if (/\/(?:_npx|\.pnpm\/dlx)\//.test(entryPath)) return "npx";
-	if (/\/lib\/node_modules\/codemem\/dist\/index\.js$/.test(entryPath)) {
-		return "npm-global";
-	}
-	if (/\/AppData\/Roaming\/npm\/node_modules\/codemem\/dist\/index\.js$/i.test(entryPath)) {
-		return "npm-global";
-	}
-	return "unknown";
+	return runnerInstallKind(runner ?? "") ?? installKindForEntryPath(entryPath, env);
 }
 
 const defaultReleaseDiscovery = createReleaseDiscovery({

--- a/packages/ui/src/lib/api/types.ts
+++ b/packages/ui/src/lib/api/types.ts
@@ -64,7 +64,7 @@ export interface UpdateStatus {
 	first_seen_at: string | null;
 	checked_at: string | null;
 	stale: boolean;
-	install_kind: "npm-global" | "npx" | "docker" | "repo-dev" | "pinned" | "unknown";
+	install_kind: "npm-global" | "mise" | "npx" | "docker" | "repo-dev" | "pinned" | "unknown";
 	auto_update_eligible: boolean;
 	recommended_action: string;
 	error: string | null;

--- a/packages/ui/src/tabs/health.test.ts
+++ b/packages/ui/src/tabs/health.test.ts
@@ -228,6 +228,27 @@ describe("Health update banner", () => {
 		);
 	});
 
+	it("describes repository source without release freshness claims", () => {
+		setUpdateStatus({
+			...availableStatus,
+			current_version: "0.44.0",
+			latest_version: "0.44.2",
+			update_available: true,
+			stale: true,
+			install_kind: "repo-dev",
+			recommended_action:
+				"Package-release updates do not apply to repository source. Run git pull, pnpm install, and pnpm build in the codemem repository.",
+		});
+
+		renderOverview();
+
+		const banner = updateBannerText();
+		expect(banner).toContain("Running from repository source");
+		expect(banner).toContain("Package metadata version: 0.44.0");
+		expect(banner).toContain("git pull, pnpm install, and pnpm build");
+		expect(banner).not.toMatch(/up to date|outdated|cached update|0\.44\.2 is available/i);
+	});
+
 	it("shows unavailable status for an unsupported installed version", () => {
 		// Arrange
 		setUpdateStatus({

--- a/packages/ui/src/tabs/health/components.ts
+++ b/packages/ui/src/tabs/health/components.ts
@@ -160,6 +160,14 @@ export function renderAutomaticRecall(container: HTMLElement | null, payload: un
 }
 
 function updateBannerCopy(status: UpdateStatus) {
+	if (status.install_kind === "repo-dev") {
+		return {
+			title: "Running from repository source",
+			detail: `Package metadata version: ${status.current_version}. Registry releases do not describe the checked-out source revision.`,
+			tone: "current",
+		};
+	}
+
 	if (!status.latest_version) {
 		return {
 			title: "Update check unavailable",
@@ -209,7 +217,11 @@ function updateBannerCopy(status: UpdateStatus) {
 function UpdateBanner({ status }: { status: UpdateStatus }) {
 	const copy = updateBannerCopy(status);
 	const showGuidance =
-		status.update_available || status.stale || !status.latest_version || !status.channel;
+		status.install_kind === "repo-dev" ||
+		status.update_available ||
+		status.stale ||
+		!status.latest_version ||
+		!status.channel;
 	return h(
 		"section",
 		{


### PR DESCRIPTION
## Description

Detect mise-managed npm installations from resolved executable paths, report and execute exact global mise updates only on explicit request, and verify the resulting global CLI outside project-local overrides. Background auto-update remains npm-global only.

Repository-source viewers now identify themselves as development checkouts instead of comparing package metadata as an installed release.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [x] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (pnpm run tsc, pnpm run lint, pnpm run test)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Full pnpm run check passed: 280 test files, 6,762 passing tests, and 3 todo tests. Lint reported only pre-existing warnings; touched files introduced no new warnings.

## Checklist

- [x] Code follows project style (pnpm run lint passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced