### PR TITLE
feat(update): support pnpm-global installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ npm install -g codemem
 
 For a smaller keyword-only install, use `npm install -g codemem --omit=optional` and set `CODEMEM_EMBEDDING_DISABLED=1` in every Codemem process. The flag is required because npm also omits sqlite-vec's optional platform package; the CLI then remains functional with FTS5.
 
-An npm-capable manager, such as mise's `npm:codemem` backend, can also provide the durable CLI. Ensure `codemem` is on your `PATH`, then run `codemem setup --opencode-only`. For a mise-managed CLI, `codemem update check` reports the exact global update command. An explicit `codemem update install` confirms from bounded `mise ls --json` output that the active tool source matches a global source under the user's home directory and that its install path owns the running entry. It writes the exact release into mise's primary global config, confirms the global configured version, and runs the configured tool through `mise exec` outside the invoking project rather than through a possibly stale or locally overridden `PATH` entry.
+An npm-capable manager, such as pnpm or mise's `npm:codemem` backend, can also provide the durable CLI. Ensure `codemem` is on your `PATH`, then run `codemem setup --opencode-only`. For a pnpm-global CLI, `codemem update check` reports the exact paired `pnpm add -g codemem@<version> @codemem/embeddings@<version>` command. Canonical pnpm virtual-store detection provides guidance but does not prove ownership. An explicit `codemem update install` re-checks the active package and global-root ownership with bounded, neutral-directory `pnpm root -g`, `pnpm bin -g`, and `pnpm list -g --depth 0 --json` calls before it mutates anything; it accepts pnpm 9–11's `<list-root>/node_modules` root and pnpm 12's `<list-root>` root only. It then installs exact matching packages with default and `@codemem` registry pins and verifies registered package state plus the specific pnpm-bin launcher. The updater never runs a build-approval command: pnpm 9 still runs install scripts by default, while newer pnpm releases apply their configured build-script policy. For a mise-managed CLI, `codemem update check` reports the exact global update command. An explicit `codemem update install` confirms from bounded `mise ls --json` output that the active tool source matches a global source under the user's home directory and that its install path owns the running entry. It writes the exact release into mise's primary global config, confirms the global configured version, and runs the configured tool through `mise exec` outside the invoking project rather than through a possibly stale or locally overridden `PATH` entry.
 
 Upgrade a durable CLI with the package manager that installed it, then rerun the corresponding setup command for an existing setup-managed integration. Setup replaces its old managed `npx -y codemem mcp` launcher and codemem MCP entries detected as UV/UVX-based so both packages share one runtime; other custom MCP commands remain unchanged. The host plugin is managed independently. Claude marketplace installs use the plugin's bundled MCP configuration and do not require a separate `setup --claude-only` step.
 
@@ -309,7 +309,11 @@ pass `--refresh` to force a registry request or `--json` for one channel-aware s
 The Viewer Health page reads the same status from `/api/update-status`. The OpenCode plugin
 checks it after startup and shows at most one best-effort notification for each newly discovered
 same-channel release. `notify` is the default. `codemem update install` performs the explicit, fail-closed
-installation for proven npm-global and mise-managed CLIs. Mise updates require matching active and
+installation for proven npm-global, pnpm-global, and mise-managed CLIs. pnpm-global detection uses
+canonical virtual-store evidence only, so the installer re-proves root and active-package ownership
+with bounded neutral-directory pnpm queries before installing exact paired packages from the public npm registry;
+it verifies both package state and the exact pnpm-bin launcher and never approves package builds.
+Mise updates require matching active and
 global machine-readable source records under the user's home directory plus matching install-path
 evidence. A recognized user-level `~/.config/mise.toml` source may instead migrate when the bounded
 global query succeeds with an empty result. Updates pin public default and `@codemem` npm registries, run
@@ -323,7 +327,9 @@ an exact target in the post-update global `version` or `requested_version`, foll
 `@codemem/embeddings` only
 after the CLI reports a fresh, validated same-channel npm release observed for at least 24 hours
 and an installation whose npm-global origin can be proven. Mise is never eligible for background
-auto-update because changing its global tool configuration requires a direct user command. Pinned, cross-channel, unsupported-channel,
+auto-update because changing its global tool configuration requires a direct user command. pnpm-global
+is also never eligible for plugin background auto-install; use the direct `codemem update install`
+command. Pinned, cross-channel, unsupported-channel,
 downgrade, repository-development, stale, Docker, and unknown installs refuse execution. Set
 `CODEMEM_BACKEND_UPDATE_POLICY=off` to disable release checks.
 On Linux, plugin-owned auto-updates preserve the OpenCode environment and set

--- a/docs/plans/2026-09-11-pnpm-global-update-design.md
+++ b/docs/plans/2026-09-11-pnpm-global-update-design.md
@@ -1,0 +1,62 @@
+# pnpm-Global Update Design
+
+**Status:** Approved
+**Date:** 2026-09-11
+
+## Decision
+
+Codemem will recognize evidence-backed pnpm-global installations, notify users of releases, and support only an explicit `codemem update install`. Background installation remains npm-global-only: pnpm-global reports `auto_update_eligible=false`.
+
+## Detection
+
+Status-time detection uses only the resolved JavaScript entry path. It recognizes pnpm 9–11 entries shaped like `pnpm/global/5/.pnpm/codemem@<version>/node_modules/codemem/dist/index.js` and pnpm 12 grouped entries shaped like `pnpm/global/vN/<group>/node_modules/.pnpm/codemem@<version>_<peers>/node_modules/codemem/dist/index.js`, without assuming a group-token format. A configured, normalized `PNPM_HOME` may replace the recognizable `pnpm` directory prefix. Matching this virtual-store evidence is an inexpensive signal, not proof that the running executable belongs to a mutable global installation.
+
+The detector fails closed for `pnpm dlx`, project-local packages, missing paths, or ambiguous layouts. It must not run pnpm during status checks, so status remains fast and does not depend on a working pnpm executable.
+
+## Explicit Update Contract
+
+Immediately before mutation, `codemem update install` re-proves ownership with bounded, no-shell calls:
+
+```text
+pnpm root -g
+pnpm bin -g
+pnpm list -g --depth 0 --json
+```
+
+The bounded list payload is the package-ownership record: before mutation, it must contain `codemem` at the running version with an exact registered path beneath the canonical list root. `pnpm root -g` must equal that list root for pnpm 12 or its `node_modules` directory for pnpm 9–11. The package path must own the resolved running JavaScript entry. The embeddings package may be absent before the paired update, but both packages are mandatory during post-update verification.
+
+The normalized global bin directory supplies the specific pnpm-global launcher to execute after installation, including supported Windows shim forms. `process.argv[1]` is entry-path evidence, not itself the launcher. A missing pnpm executable, non-zero command, oversized output, malformed or ambiguous list payload, or root/package/entry mismatch aborts without updating.
+
+Once ownership is proven, the updater installs the exact paired release without a shell:
+
+```text
+pnpm add -g codemem@<version> @codemem/embeddings@<version>
+```
+
+The command places pnpm options before package operands. It passes `--registry` and pnpm's `--config.@codemem:registry` option, while a sanitized environment supplies the same public default and scoped registry pins. The spawned process also applies the CPU-only ONNX setting on Linux. It never runs a build-approval command or broadens pnpm's configured build-script policy.
+
+## Verification
+
+Verification runs outside the invoking project directory so a local package cannot satisfy it. It repeats bounded `pnpm list -g --depth 0 --json`, requires the list root to remain unchanged, both canonical registered package paths to remain beneath it, and both listed versions to equal the requested version exactly. It then runs the specific launcher from `pnpm bin -g` and requires one unambiguous reported version line to match.
+
+```text
+codemem version
+```
+
+An absent package, stale version, command failure, or executable-version mismatch reports an actionable failure rather than a successful update.
+
+## Build-Script Finding
+
+A disposable pnpm 12.2.1 installation on Node 24 installed matching `codemem@0.44.2` and `@codemem/embeddings@0.44.2` while pnpm ignored native build scripts. The SQLite-backed `codemem status` command still loaded successfully. pnpm 9 runs install scripts by default, while newer releases apply their configured build-script policy.
+
+The updater therefore must not run a build-approval command: the pnpm 12 rehearsal did not need one, and approval would expand the update's trust boundary without a runtime need.
+
+## Alternatives Rejected
+
+- Probing pnpm at status time was rejected because `PATH` can select a manager unrelated to the running executable and makes status dependent on external command execution.
+- Path-only mutation was rejected because pnpm global stores, symlinks, and shims can make a plausible path belong to another installation.
+- Background pnpm updates were rejected because only a direct user command should mutate a pnpm-global installation.
+
+## Validation
+
+Tests cover pnpm 9–11 and pnpm 12 entry layouts, normalized custom `PNPM_HOME`, strict `dlx` and project-local refusal, legacy and current root relationships, real `private: false` list metadata, notice-tolerant path and launcher parsing, setup guidance, bounded probes and post-install verification, Unix and Windows scoped registry arguments, and oversized successful pnpm install output. The core, CLI, UI type mirror, README, user guide, and plugin reference describe notifications and explicit updates without advertising background pnpm updates.

--- a/docs/plans/2026-09-11-pnpm-global-update-implementation.md
+++ b/docs/plans/2026-09-11-pnpm-global-update-implementation.md
@@ -1,0 +1,44 @@
+# pnpm-Global Update Implementation Plan
+
+The implementation adds evidence-backed pnpm-global explicit updates without extending unattended update authority.
+
+## 1. Extend Release Discovery
+
+- Add `pnpm-global` to the installation-kind contract in `packages/core/src/release-discovery.ts` and its UI mirror.
+- Classify only the resolved JavaScript entry path when it provides pnpm global-layout evidence; do not invoke pnpm while calculating status.
+- Return the exact paired-release guidance for pnpm-global installations and set `auto_update_eligible=false`.
+- Refuse `pnpm dlx`, project-local, missing, and ambiguous paths.
+- Add focused cases in `packages/core/src/release-discovery.test.ts` for Unix and Windows normalization, precedence, guidance, and fail-closed classification.
+
+## 2. Gate Explicit Installation on Re-proven Ownership
+
+- Export explicit-install eligibility separately from background eligibility so pnpm-global can run `codemem update install` but never a background installation.
+- In `packages/cli/src/commands/update.ts`, bound stdout and run `pnpm root -g`, `pnpm bin -g`, and `pnpm list -g --depth 0 --json` with argument arrays and `shell: false`.
+- Normalize the roots and parse the list payload as the ownership record. Require `pnpm root -g` to equal the list root for pnpm 12 or `<list-root>/node_modules` for pnpm 9–11. Before mutation, require a listed `codemem` entry at the running version with a canonical registered path beneath the list root, and require that path to own the resolved JavaScript entry. Permit embeddings to be absent before the paired update.
+- Use the normalized bin result to locate the specific pnpm-global launcher for verification, including supported Windows shim variants. Do not treat `process.argv[1]` as that launcher.
+- Abort before mutation if pnpm is missing, any query fails or exceeds its bound, the list payload is malformed or ambiguous, or any root/package/entry ownership check disagrees.
+
+## 3. Run and Verify the Exact Update
+
+- Spawn the exact paired install without a shell:
+
+  ```text
+  pnpm add -g codemem@<version> @codemem/embeddings@<version>
+  ```
+
+- Keep pnpm options before package operands. Pass `--registry` and pnpm's verified `--config.@codemem:registry` option, preserve matching pins in the sanitized environment, and add the Linux CPU-only ONNX setting. Do not add `--allow-build` or any build-script approval.
+- From a neutral directory, repeat bounded `pnpm list -g --depth 0 --json`; require the list root to remain unchanged, both canonical registered paths beneath it, and both `codemem` and `@codemem/embeddings` versions to equal the requested version exactly.
+- Execute the specific launcher supplied by `pnpm bin -g` from that neutral directory and require `codemem version` to equal the requested version.
+- Treat any install, package-state, or executable-version failure as an update failure.
+
+## 4. Cover the Contract and User Surfaces
+
+- Add CLI cases in `packages/cli/src/commands/update.test.ts` for legacy/current list fixtures and root semantics, bounded notice-tolerant root/bin/list probes, registered-path ownership, setup guidance, no-shell execution, mismatches, scoped registry arguments and sanitized environment, Linux ONNX handling, paired exact versions, oversized successful install output, and neutral-directory verification through the pnpm bin launcher.
+- Record the disposable pnpm 12.2.1 plus Node 24 rehearsal: ignored native build scripts still allowed SQLite-backed `codemem status`. Note that pnpm 9 runs install scripts by default, and assert the updater does not request build-script approval on any version.
+- Update `README.md`, `docs/user-guide.md`, and `docs/plugin-reference.md` to distinguish pnpm-global release notifications and explicit updates from npm-global background updates.
+
+## 5. Validate
+
+- Run the release-discovery and update-command test files.
+- Run affected UI and plugin tests when the installation-kind wire contract reaches their fixtures.
+- Run TypeScript, lint, and the repository test gate after the focused tests pass.

--- a/docs/plugin-reference.md
+++ b/docs/plugin-reference.md
@@ -474,7 +474,7 @@ If you run multiple adapters for the same project (for example OpenCode + Claude
 | `CODEMEM_PLUGIN_CMD_TIMEOUT` | Milliseconds before a plugin CLI call is aborted (default `20000`). |
 | `CODEMEM_MIN_VERSION` | Minimum required CLI version for plugin compatibility warnings (default `0.9.20`). |
 | `CODEMEM_BACKEND_UPDATE_POLICY` | Compatibility and release-notification policy: `notify` (default), `auto`, or `off`. |
-| `CODEMEM_INSTALL_KIND` | Internal/advanced release-guidance detection override (`npm-global`, `mise`, `npx`, `docker`, `repo-dev`, `pinned`, or `unknown`). This does not prove ownership or enable installation. |
+| `CODEMEM_INSTALL_KIND` | Internal/advanced release-guidance detection override (`npm-global`, `pnpm-global`, `mise`, `npx`, `docker`, `repo-dev`, `pinned`, or `unknown`). Markers do not prove ownership or enable installation. |
 | `CODEMEM_CODEX_ENDPOINT` | Override Codex OAuth endpoint. |
 | `CODEMEM_PLUGIN_DEBUG` | Set to `1`, `true`, or `yes` to log plugin lifecycle events. |
 | `CODEMEM_PLUGIN_IGNORE` | Skip all plugin behavior for this process. |
@@ -532,7 +532,7 @@ Update policy:
 - `CODEMEM_BACKEND_UPDATE_POLICY=auto`: try a best-effort auto-update for eligible compatibility-floor mismatches and fresh same-channel releases observed for at least 24 hours, then warn if still outdated
 	- skipped for `node` dev-mode runners
 	- skipped when `CODEMEM_RUNNER_FROM` is pinned to a fixed package/version
-	- skipped for mise, Docker, unknown, stale, unsupported-channel, cross-channel, or downgrade states
+	- skipped for pnpm-global, mise, Docker, unknown, stale, unsupported-channel, cross-channel, or downgrade states
 - `CODEMEM_BACKEND_UPDATE_POLICY=off`: no compatibility toast (logging still records mismatch)
 
 After its startup delay, the plugin also runs `codemem update check --json` through the same
@@ -559,6 +559,16 @@ command and writes the exact release into mise's primary global config. Verifica
 to move from user `conf.d` or the recognized user-level `~/.config/mise.toml` file to `config.toml` but requires the post-update global
 `version` or `requested_version` before running `mise exec -- codemem version` outside the invoking project; plugin background
 auto-update never treats mise as eligible.
+
+pnpm-global CLIs are recognized from canonical virtual-store path evidence, which can provide release
+notifications and the exact paired package command but cannot prove ownership. Only an explicit
+`codemem update install` may mutate that installation: from a neutral directory it uses bounded,
+no-shell `pnpm root -g`, `pnpm bin -g`, and `pnpm list -g --depth 0 --json` checks to prove the
+root is exactly the list root (pnpm 12) or its `node_modules` directory (pnpm 9–11), and that the list root owns the active Codemem package. It installs exact matching `codemem` and
+`@codemem/embeddings` packages from the public npm registry and verifies both
+registered package state and that launcher. The updater never runs a build-approval command; pnpm 9 still runs install scripts by default,
+while newer releases apply their configured build-script policy. Plugin
+background auto-install never treats pnpm-global as eligible.
 
 Docker images set `CODEMEM_INSTALL_KIND=docker` so release guidance cannot mistake the bundled
 global npm package for a host npm installation. Docker deployments never self-update; rebuild and

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -42,11 +42,20 @@ codemem update check --json
 - Stale validated cache data remains clearly labeled and may provide guidance when the registry is
   unavailable.
 - This command never installs or executes an update. Release installation remains outside this
-  read-only check. For a mise-managed CLI, it reports the exact global mise action; on Linux that
-  action is `env ONNXRUNTIME_NODE_INSTALL=skip mise use -g npm:codemem@<exact-version>`.
+  read-only check. For a pnpm-global CLI, it reports the exact paired
+  `pnpm add -g codemem@<exact-version> @codemem/embeddings@<exact-version>` action. Path-based
+  pnpm-global detection recognizes a canonical global virtual-store entry but does not prove mutable ownership. For a
+  mise-managed CLI, it reports the exact global mise action; on Linux that action is
+  `env ONNXRUNTIME_NODE_INSTALL=skip mise use -g npm:codemem@<exact-version>`.
 - `codemem update install` is the separate, fail-closed installer. Proven npm-global installations
   retain the 24-hour first-seen delay and install exact matching `codemem` and
-  `@codemem/embeddings` versions from the public npm registry. Before a mise mutation, the installer
+  `@codemem/embeddings` versions from the public npm registry. For pnpm-global installations, it
+  first runs bounded, neutral-directory `pnpm root -g`, `pnpm bin -g`, and
+  `pnpm list -g --depth 0 --json` queries without a shell. It accepts only pnpm 9–11's
+  `<list-root>/node_modules` root or pnpm 12's `<list-root>` root. The registered Codemem path and
+  resolved entry must agree before it installs with explicit default and `@codemem` registry pins; it then verifies exact registered
+  package versions and the exact launcher from the reported pnpm bin directory. It never runs a pnpm build-approval
+  command; pnpm 9 still runs install scripts by default, while newer releases apply their configured build-script policy. Before a mise mutation, the installer
   reads bounded JSON from `mise ls --current` and `mise ls --global`, requires the active source
   to match a global source under the user's home directory, and requires its canonical install path
   to own the running CLI entrypoint. System, unresolved, and ambiguous custom sources are refused. It then runs
@@ -60,8 +69,9 @@ codemem update check --json
   development, stale, cross-channel, downgrade, unsupported-channel, and unknown installations. Bare `codemem update`
   remains non-mutating. As with a
   manual npm install, npm runs the packages' installation scripts for native CPU dependencies.
-- Mise installations are never eligible for plugin background auto-update. Changing mise's global
-  tool configuration requires the direct `codemem update install` command or the reported manual action.
+- Mise and pnpm-global installations are never eligible for plugin background auto-install. Changing
+  either global installation requires the direct `codemem update install` command or the reported
+  manual action.
 
 ## Start or restart the viewer
 - `codemem serve` runs the viewer in the foreground.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -86,7 +86,10 @@ backs off failed registry checks for 15 minutes, while `--refresh` bypasses that
 `codemem update check` remains informational. It detects a semver-qualified
 `mise/installs/npm-codemem/<version>/` layout from the resolved CLI entry path, or the equivalent
 layout beneath a normalized `MISE_DATA_DIR`, and reports
-`mise use -g npm:codemem@<exact-version>` for that installation kind.
+`mise use -g npm:codemem@<exact-version>` for that installation kind. It also recognizes canonical
+pnpm global virtual-store entries from resolved paths and reports the exact paired
+`pnpm add -g codemem@<exact-version> @codemem/embeddings@<exact-version>` command. Those path markers
+do not prove pnpm package ownership.
 `codemem update install` separately requires fresh validated status. Proven npm-global installations
 retain the 24-hour first-seen delay and install exact matching `codemem` and
 `@codemem/embeddings` versions with an argv-only npm command. Before mutation, proven mise
@@ -100,6 +103,13 @@ the exact release into the primary global config, so a declaration may move from
 `config.toml`. Mise verification re-reads bounded global state, requires an exact target `version` or
 `requested_version` value, and runs `mise exec -- codemem version` outside the invoking project;
 npm-global verification uses the active CLI.
+For pnpm-global installations, the explicit installer uses bounded, no-shell `pnpm root -g`,
+`pnpm bin -g`, and `pnpm list -g --depth 0 --json` calls from a neutral directory immediately
+before mutation. It requires `pnpm root -g` to equal the list root (pnpm 12) or its `node_modules`
+directory (pnpm 9–11), the canonical registered Codemem package to remain under that list root, and that package
+to own the resolved JavaScript entry. It then installs exact matching paired packages using public default and scoped registry flags
+and verifies exact registered package versions plus the specific pnpm-bin launcher. The updater never runs a build-approval command;
+pnpm 9 still runs install scripts by default, while newer releases apply their configured build-script policy.
 Bare `codemem update` remains non-mutating. Installing an alpha, beta, or release candidate is
 explicit opt-in, so the
 existing auto-update policy may install a delayed eligible update within that installed channel.
@@ -109,7 +119,9 @@ Docker, and unknown states. The npm-global updater always installs exact matchin
 CPU dependencies, just as a manual global install does.
 Mise remains ineligible for background auto-update because its command changes declarative global
 tool configuration; only a direct user install command may authorize that change, and a local source
-that overrides the global source is refused with manual global-update guidance.
+that overrides the global source is refused with manual global-update guidance. pnpm-global is also
+never eligible for plugin background auto-install; it supports notifications and the direct
+`codemem update install` path only.
 
 Release discovery compares the running product version with the latest release on its channel.
 It is separate from the compatibility-floor check below: discovering a newer release does not

--- a/packages/cli/src/commands/update.test.ts
+++ b/packages/cli/src/commands/update.test.ts
@@ -1,7 +1,8 @@
 import { EventEmitter } from "node:events";
+import { realpathSync } from "node:fs";
 import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -27,6 +28,7 @@ const originalHome = process.env.HOME;
 const originalArgv = [...process.argv];
 const originalMiseConfigDir = process.env.MISE_CONFIG_DIR;
 const originalMiseGlobalConfigFile = process.env.MISE_GLOBAL_CONFIG_FILE;
+const originalPnpmHome = process.env.PNPM_HOME;
 const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
 let testHome = "";
 
@@ -60,6 +62,152 @@ const miseStatus = {
 	install_kind: "mise",
 	recommended_action: "mise use -g npm:codemem@0.41.0",
 } as const;
+
+const pnpmStatus = {
+	...availableStatus,
+	install_kind: "pnpm-global",
+	recommended_action: "pnpm add -g codemem@0.41.0 @codemem/embeddings@0.41.0",
+} as const;
+
+function pnpmRoot(): string {
+	return join(testHome, ".local", "share", "pnpm", "global", "v11");
+}
+
+function pnpmGroup(version: string): string {
+	if (version === "0.40.2") return "a".repeat(64);
+	if (version === "0.41.0") return "b".repeat(64);
+	return "c".repeat(64);
+}
+
+function pnpmPackagePath(name: "codemem" | "embeddings", version = "0.40.2"): string {
+	const groupRoot = join(pnpmRoot(), pnpmGroup(version), "node_modules");
+	if (name === "codemem") return join(groupRoot, "codemem");
+	return join(groupRoot, "@codemem", "embeddings");
+}
+
+function canonicalPnpmPackagePath(name: "codemem" | "embeddings", version = "0.40.2"): string {
+	const virtualStore = join(pnpmRoot(), pnpmGroup(version), "node_modules", ".pnpm");
+	if (name === "codemem") {
+		return join(
+			virtualStore,
+			`codemem@${version}_better-sqlite3@12.6.2`,
+			"node_modules",
+			"codemem",
+		);
+	}
+	return join(
+		virtualStore,
+		`@codemem+embeddings@${version}`,
+		"node_modules",
+		"@codemem",
+		"embeddings",
+	);
+}
+
+function pnpmBin(): string {
+	return join(testHome, ".local", "share", "pnpm");
+}
+
+function canonicalPnpmBin(): string {
+	return realpathSync(pnpmBin());
+}
+
+function pnpmUpdateCwd(): string {
+	return join(testHome, ".codemem");
+}
+
+function pnpmListState(
+	options: {
+		codememPath?: string;
+		codememVersion?: string;
+		embeddingsPath?: string;
+		embeddingsVersion?: string;
+		includeEmbeddings?: boolean;
+		private?: boolean;
+		rootPath?: string;
+	} = {},
+): string {
+	const codememVersion = options.codememVersion ?? "0.40.2";
+	const dependencies: Record<string, unknown> = {
+		codemem: {
+			path: options.codememPath ?? pnpmPackagePath("codemem", codememVersion),
+			version: codememVersion,
+		},
+	};
+	if (options.includeEmbeddings ?? true) {
+		const embeddingsVersion = options.embeddingsVersion ?? codememVersion;
+		dependencies["@codemem/embeddings"] = {
+			path: options.embeddingsPath ?? pnpmPackagePath("embeddings", embeddingsVersion),
+			version: embeddingsVersion,
+		};
+	}
+	return JSON.stringify([
+		{
+			path: options.rootPath ?? pnpmRoot(),
+			private: options.private ?? true,
+			dependencies,
+		},
+	]);
+}
+
+function updatedPnpmListState(options: Parameters<typeof pnpmListState>[0] = {}): string {
+	return pnpmListState({
+		codememVersion: "0.41.0",
+		embeddingsVersion: "0.41.0",
+		...options,
+	});
+}
+
+async function usePnpmEntrypoint(): Promise<void> {
+	for (const version of ["0.40.2", "0.41.0"]) {
+		for (const name of ["codemem", "embeddings"] as const) {
+			const listedPath = pnpmPackagePath(name, version);
+			const canonicalPath = canonicalPnpmPackagePath(name, version);
+			await mkdir(canonicalPath, { recursive: true });
+			await mkdir(dirname(listedPath), { recursive: true });
+			await symlink(canonicalPath, listedPath, "dir");
+		}
+	}
+	const entryPath = join(pnpmPackagePath("codemem"), "dist", "index.js");
+	await mkdir(join(canonicalPnpmPackagePath("codemem"), "dist"), { recursive: true });
+	await mkdir(pnpmBin(), { recursive: true });
+	await writeFile(entryPath, "#!/usr/bin/env node\n", "utf8");
+	process.argv[1] = entryPath;
+}
+
+function legacyPnpmListRoot(): string {
+	return join(testHome, ".local", "share", "pnpm", "global", "5");
+}
+
+function legacyPnpmPackagePath(name: "codemem" | "embeddings"): string {
+	const packageSegments = name === "codemem" ? ["codemem"] : ["@codemem", "embeddings"];
+	return join(legacyPnpmListRoot(), "node_modules", ...packageSegments);
+}
+
+function legacyCanonicalPnpmPackagePath(name: "codemem" | "embeddings", version: string): string {
+	const packageSegments = name === "codemem" ? ["codemem"] : ["@codemem", "embeddings"];
+	const storeName = name === "codemem" ? `codemem@${version}` : `@codemem+embeddings@${version}`;
+	return join(legacyPnpmListRoot(), ".pnpm", storeName, "node_modules", ...packageSegments);
+}
+
+async function useLegacyPnpmEntrypoint(): Promise<void> {
+	for (const version of ["0.40.2", "0.41.0"]) {
+		for (const name of ["codemem", "embeddings"] as const) {
+			const listedPath = legacyPnpmPackagePath(name);
+			const canonicalPath = legacyCanonicalPnpmPackagePath(name, version);
+			await mkdir(canonicalPath, { recursive: true });
+			await mkdir(dirname(listedPath), { recursive: true });
+			if (version === "0.40.2") await symlink(canonicalPath, listedPath, "dir");
+		}
+	}
+	const entryPath = join(legacyPnpmPackagePath("codemem"), "dist", "index.js");
+	await mkdir(join(legacyCanonicalPnpmPackagePath("codemem", "0.40.2"), "dist"), {
+		recursive: true,
+	});
+	await mkdir(pnpmBin(), { recursive: true });
+	await writeFile(entryPath, "#!/usr/bin/env node\n", "utf8");
+	process.argv[1] = entryPath;
+}
 
 function miseState(
 	options: {
@@ -118,6 +266,7 @@ beforeEach(async () => {
 	process.env.HOME = testHome;
 	delete process.env.MISE_CONFIG_DIR;
 	delete process.env.MISE_GLOBAL_CONFIG_FILE;
+	delete process.env.PNPM_HOME;
 	delete process.env.XDG_CONFIG_HOME;
 	const miseConfigDirectory = join(testHome, ".config", "mise");
 	await mkdir(miseConfigDirectory, { recursive: true });
@@ -135,6 +284,8 @@ afterEach(async () => {
 	else process.env.MISE_CONFIG_DIR = originalMiseConfigDir;
 	if (originalMiseGlobalConfigFile === undefined) delete process.env.MISE_GLOBAL_CONFIG_FILE;
 	else process.env.MISE_GLOBAL_CONFIG_FILE = originalMiseGlobalConfigFile;
+	if (originalPnpmHome === undefined) delete process.env.PNPM_HOME;
+	else process.env.PNPM_HOME = originalPnpmHome;
 	if (originalXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
 	else process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
 	await rm(testHome, { recursive: true, force: true });
@@ -429,19 +580,23 @@ describe("update install command", () => {
 		expect(process.exitCode).toBeUndefined();
 	});
 
-	it("does not terminate a successful npm install when command output exceeds the capture limit", async () => {
+	it("fails closed when npm install output exceeds the capture limit", async () => {
 		vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
 		getUpdateStatus.mockResolvedValue({ ...availableStatus, auto_update_eligible: true });
 		spawn
 			.mockImplementationOnce(() => commandProcess({ stdout: "x".repeat(65 * 1_024) }))
 			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
-		vi.spyOn(console, "log").mockImplementation(() => {});
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
 
 		await parseUpdateCommand(["install", "--json"]);
 
 		expect(spawn.mock.results[0]?.value.kill).not.toHaveBeenCalled();
-		expect(spawn).toHaveBeenCalledTimes(2);
-		expect(process.exitCode).toBeUndefined();
+		expect(spawn).toHaveBeenCalledTimes(1);
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_failed",
+			message: "command output too large",
+		});
+		expect(process.exitCode).toBe(1);
 	});
 });
 
@@ -904,6 +1059,769 @@ describe("mise update lifecycle safeguards", () => {
 	});
 });
 
+describe("pnpm-global update execution", () => {
+	it("proves ownership, installs the exact pair, and verifies the pnpm-owned Unix shim", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+		await usePnpmEntrypoint();
+		expect(pnpmRoot()).toContain(join("global", "v11"));
+		expect(realpathSync(pnpmPackagePath("codemem"))).toBe(
+			realpathSync(canonicalPnpmPackagePath("codemem")),
+		);
+		expect(realpathSync(pnpmPackagePath("codemem"))).toContain(
+			join(".pnpm", "codemem@0.40.2_better-sqlite3@12.6.2"),
+		);
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		const originalRegistry = process.env.NPM_CONFIG_REGISTRY;
+		const originalScopedRegistry = process.env["npm_config_@codemem:registry"];
+		const originalOnnxPolicy = process.env.OnnxRuntime_Node_Install;
+		process.env.NPM_CONFIG_REGISTRY = "https://untrusted.invalid/";
+		process.env["npm_config_@codemem:registry"] = "https://untrusted-scope.invalid/";
+		process.env.OnnxRuntime_Node_Install = "build";
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmRoot()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: pnpmListState() }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: updatedPnpmListState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		try {
+			await parseUpdateCommand(["install", "--json"]);
+		} finally {
+			if (originalRegistry === undefined) delete process.env.NPM_CONFIG_REGISTRY;
+			else process.env.NPM_CONFIG_REGISTRY = originalRegistry;
+			if (originalScopedRegistry === undefined) {
+				delete process.env["npm_config_@codemem:registry"];
+			} else {
+				process.env["npm_config_@codemem:registry"] = originalScopedRegistry;
+			}
+			if (originalOnnxPolicy === undefined) delete process.env.OnnxRuntime_Node_Install;
+			else process.env.OnnxRuntime_Node_Install = originalOnnxPolicy;
+		}
+
+		expect(spawn.mock.calls.map(([, args]) => args)).toEqual([
+			["root", "-g"],
+			["bin", "-g"],
+			["list", "-g", "--depth", "0", "--json"],
+			[
+				"add",
+				"-g",
+				"--registry",
+				"https://registry.npmjs.org/",
+				"--config.@codemem:registry=https://registry.npmjs.org/",
+				"codemem@0.41.0",
+				"@codemem/embeddings@0.41.0",
+			],
+			["list", "-g", "--depth", "0", "--json"],
+			["version"],
+		]);
+		const installOptions = spawn.mock.calls[3]?.[2];
+		expect(realpathSync(pnpmUpdateCwd())).toContain(".codemem");
+		expect(installOptions).toEqual(
+			expect.objectContaining({
+				cwd: pnpmUpdateCwd(),
+				env: expect.objectContaining({
+					ONNXRUNTIME_NODE_INSTALL: "skip",
+					npm_config_registry: "https://registry.npmjs.org/",
+					"npm_config_@codemem:registry": "https://registry.npmjs.org/",
+				}),
+				shell: false,
+			}),
+		);
+		expect(installOptions?.env).not.toHaveProperty("NPM_CONFIG_REGISTRY");
+		expect(installOptions?.env).not.toHaveProperty("OnnxRuntime_Node_Install");
+		expect(spawn.mock.calls[3]?.[1].join(" ")).not.toMatch(/allow-build|approve-builds/);
+		for (const callIndex of [0, 1, 2, 4]) {
+			expect(spawn.mock.calls[callIndex]?.[2]).toEqual(
+				expect.objectContaining({ cwd: pnpmUpdateCwd(), shell: false }),
+			);
+		}
+		expect(spawn).toHaveBeenNthCalledWith(
+			6,
+			join(canonicalPnpmBin(), "codemem"),
+			["version"],
+			expect.objectContaining({ cwd: pnpmUpdateCwd(), shell: false }),
+		);
+		expect(process.exitCode).toBeUndefined();
+	});
+});
+
+describe("pnpm-global compatibility", () => {
+	it("accepts pnpm 9-11 list metadata and node_modules root semantics", async () => {
+		await useLegacyPnpmEntrypoint();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		const legacyState = (version: string) =>
+			pnpmListState({
+				codememPath: legacyPnpmPackagePath("codemem"),
+				codememVersion: version,
+				embeddingsPath: legacyPnpmPackagePath("embeddings"),
+				embeddingsVersion: version,
+				private: false,
+				rootPath: legacyPnpmListRoot(),
+			});
+		spawn
+			.mockImplementationOnce(() =>
+				commandProcess({ stdout: `${join(legacyPnpmListRoot(), "node_modules")}\n` }),
+			)
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: legacyState("0.40.2") }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: legacyState("0.41.0") }))
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(spawn.mock.calls[2]?.[1]).toEqual(["list", "-g", "--depth", "0", "--json"]);
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("ignores benign notice lines around the one existing root and bin directory", async () => {
+		await usePnpmEntrypoint();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn
+			.mockImplementationOnce(() =>
+				commandProcess({ stdout: `Update available: run pnpm self-update\n${pnpmRoot()}\n` }),
+			)
+			.mockImplementationOnce(() =>
+				commandProcess({ stdout: `WARN using configured global bin\n${pnpmBin()}\n` }),
+			)
+			.mockImplementationOnce(() => commandProcess({ stdout: pnpmListState() }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: updatedPnpmListState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(process.exitCode).toBeUndefined();
+	});
+});
+
+describe("pnpm-global ownership probe validation", () => {
+	it.each([
+		["malformed JSON", "{not-json"],
+		["an empty result", "[]"],
+		[
+			"ambiguous results",
+			JSON.stringify([
+				{ dependencies: { codemem: { path: "/one", version: "0.40.2" } } },
+				{ dependencies: { codemem: { path: "/two", version: "0.40.2" } } },
+			]),
+		],
+		["a missing dependency map", JSON.stringify([{ name: "global" }])],
+		["a relative list root", pnpmListState({ rootPath: "relative/global/5" })],
+		[
+			"an invalid codemem record",
+			JSON.stringify([
+				{
+					path: pnpmRoot(),
+					private: false,
+					dependencies: { codemem: { path: pnpmPackagePath("codemem") } },
+				},
+			]),
+		],
+		["a relative package path", pnpmListState({ codememPath: "relative/node_modules/codemem" })],
+	])("refuses %s from the bounded package-state probe", async (_label, listOutput) => {
+		await usePnpmEntrypoint();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmRoot()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: listOutput }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_refused",
+			message: "pnpm list -g returned malformed or ambiguous global package state",
+		});
+		expect(spawn).toHaveBeenCalledTimes(3);
+	});
+
+	it("accepts real top-level private false metadata", async () => {
+		await usePnpmEntrypoint();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmRoot()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: pnpmListState({ private: false }) }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() =>
+				commandProcess({ stdout: updatedPnpmListState({ private: false }) }),
+			)
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(process.exitCode).toBeUndefined();
+	});
+});
+
+describe("pnpm-global path ownership safeguards", () => {
+	it.each([
+		{ args: ["root", "-g"], label: "root" },
+		{ args: ["bin", "-g"], label: "bin" },
+		{ args: ["list", "-g", "--depth", "0", "--json"], label: "list" },
+	])("reports a failed pnpm $label probe before mutation", async ({ args: failedArgs }) => {
+		await usePnpmEntrypoint();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		const results: Array<Parameters<typeof commandProcess>[0]> = [
+			{ stdout: `${pnpmRoot()}\n` },
+			{ stdout: `${pnpmBin()}\n` },
+			{ stdout: pnpmListState() },
+		];
+		const failedIndex = [
+			["root", "-g"],
+			["bin", "-g"],
+			["list", "-g", "--depth", "0", "--json"],
+		].findIndex((args) => args.join("\0") === failedArgs.join("\0"));
+		results[failedIndex] = { exitCode: 1, stderr: "probe failed\n", stdout: "" };
+		for (const result of results) {
+			spawn.mockImplementationOnce(() => commandProcess(result));
+		}
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_refused",
+			message: `pnpm ${failedArgs.join(" ")} failed: probe failed`,
+		});
+		expect(spawn).toHaveBeenCalledTimes(failedIndex + 1);
+	});
+
+	it("refuses a pnpm package version that differs from the running CLI", async () => {
+		await usePnpmEntrypoint();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmRoot()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+			.mockImplementationOnce(() =>
+				commandProcess({ stdout: pnpmListState({ codememVersion: "0.39.0" }) }),
+			);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_refused",
+			message: "pnpm global codemem is 0.39.0, but the running CLI is 0.40.2",
+		});
+		expect(spawn).toHaveBeenCalledTimes(3);
+	});
+
+	it("refuses ambiguous root output containing two existing absolute directories", async () => {
+		await usePnpmEntrypoint();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmRoot()}\n${pnpmBin()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: pnpmListState() }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_refused",
+			message: "pnpm root -g did not return one absolute non-root path",
+		});
+		expect(spawn).toHaveBeenCalledTimes(3);
+	});
+
+	it("returns pnpm setup guidance for a missing global bin directory", async () => {
+		await usePnpmEntrypoint();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn.mockImplementationOnce(() =>
+			commandProcess({
+				exitCode: 1,
+				stderr:
+					' ERROR  The configured global bin directory "/home/user/.local/share/pnpm" is not in PATH\nFor help, run: pnpm help root\n',
+			}),
+		);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_refused",
+			message: "Run pnpm setup, then retry codemem update install",
+		});
+		expect(spawn).toHaveBeenCalledTimes(1);
+	});
+
+	it("bounds pnpm ownership output before parsing", async () => {
+		await usePnpmEntrypoint();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmRoot()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: "x".repeat(65 * 1_024) }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_refused",
+			message: "pnpm list -g --depth 0 --json returned too much output; inspect pnpm global state",
+		});
+		expect(spawn).toHaveBeenCalledTimes(3);
+	});
+});
+
+describe("pnpm-global package ownership safeguards", () => {
+	it.each([
+		{
+			bin: "/",
+			expectedMessage: "pnpm bin -g did not return one absolute non-root path",
+			label: "root bin directory",
+			list: () => pnpmListState(),
+			root: (): string => pnpmRoot(),
+		},
+		{
+			bin: () => pnpmBin(),
+			expectedMessage: "pnpm list -g root does not own the listed codemem package path",
+			label: "package outside root",
+			list: () => pnpmListState({ codememPath: join(testHome, "other", "codemem") }),
+			root: (): string => pnpmRoot(),
+			setup: () => mkdir(join(testHome, "other", "codemem"), { recursive: true }),
+		},
+		{
+			bin: () => pnpmBin(),
+			expectedMessage: "pnpm root -g did not return one absolute non-root path",
+			label: "root path",
+			list: () => pnpmListState(),
+			root: (): string => "/",
+		},
+		{
+			bin: () => pnpmBin(),
+			expectedMessage:
+				"pnpm root -g is neither the pnpm list -g root nor its node_modules directory",
+			label: "listed root",
+			list: () => pnpmListState({ rootPath: join(testHome, "other-root") }),
+			root: (): string => pnpmRoot(),
+			setup: () => mkdir(join(testHome, "other-root"), { recursive: true }),
+		},
+	])("refuses a $label mismatch", async ({ bin, expectedMessage, list, root, setup }) => {
+		await usePnpmEntrypoint();
+		await setup?.();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		const binOutput = typeof bin === "function" ? bin() : bin;
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${root()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: `${binOutput}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: list() }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_refused",
+			message: expectedMessage,
+		});
+		expect(spawn).toHaveBeenCalledTimes(3);
+		expect(process.exitCode).toBe(1);
+	});
+});
+
+describe("pnpm-global entry ownership safeguards", () => {
+	it("refuses when pnpm package ownership does not include the running entry", async () => {
+		await usePnpmEntrypoint();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmRoot()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+			.mockImplementationOnce(() =>
+				commandProcess({ stdout: pnpmListState({ codememPath: pnpmPackagePath("embeddings") }) }),
+			);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_refused",
+			message: "the pnpm global codemem package does not own the running JavaScript entry",
+		});
+		expect(spawn).toHaveBeenCalledTimes(3);
+	});
+
+	it("does not trust a pnpm-global environment marker without entry-path ownership", async () => {
+		await usePnpmEntrypoint();
+		const outsideEntry = join(testHome, "other", "index.js");
+		await mkdir(join(testHome, "other"), { recursive: true });
+		await writeFile(outsideEntry, "#!/usr/bin/env node\n", "utf8");
+		process.argv[1] = outsideEntry;
+		const originalInstallKind = process.env.CODEMEM_INSTALL_KIND;
+		process.env.CODEMEM_INSTALL_KIND = "pnpm-global";
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmRoot()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: pnpmListState() }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		try {
+			await parseUpdateCommand(["install", "--json"]);
+		} finally {
+			if (originalInstallKind === undefined) delete process.env.CODEMEM_INSTALL_KIND;
+			else process.env.CODEMEM_INSTALL_KIND = originalInstallKind;
+		}
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_refused",
+			message: "the pnpm global codemem package does not own the running JavaScript entry",
+		});
+		expect(spawn).toHaveBeenCalledTimes(3);
+	});
+
+	it("reports a missing pnpm executable before mutation", async () => {
+		await usePnpmEntrypoint();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		const missingPnpm = Object.assign(new Error("spawn pnpm ENOENT"), { code: "ENOENT" });
+		spawn.mockImplementationOnce(() => commandProcess({ error: missingPnpm }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_refused",
+			message: "pnpm was not found on PATH; install pnpm, then retry codemem update install",
+		});
+		expect(spawn).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("pnpm-global install and verification failures", () => {
+	it("reports pnpm install failure without attempting verification", async () => {
+		await usePnpmEntrypoint();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmRoot()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: pnpmListState() }))
+			.mockImplementationOnce(() => commandProcess({ exitCode: 1, stderr: "pnpm add failed\n" }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_failed",
+			message: "pnpm add failed",
+		});
+		expect(spawn).toHaveBeenCalledTimes(4);
+	});
+
+	it("verifies state after an oversized successful pnpm install", async () => {
+		await usePnpmEntrypoint();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmRoot()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: pnpmListState() }))
+			.mockImplementationOnce(() => commandProcess({ exitCode: 0, stdout: "x".repeat(65 * 1_024) }))
+			.mockImplementationOnce(() => commandProcess({ stdout: updatedPnpmListState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			installed_version: "0.41.0",
+			previous_version: "0.40.2",
+		});
+		expect(spawn).toHaveBeenCalledTimes(6);
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("returns pnpm setup guidance when installation reports a missing global bin directory", async () => {
+		await usePnpmEntrypoint();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmRoot()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: pnpmListState() }))
+			.mockImplementationOnce(() =>
+				commandProcess({
+					exitCode: 1,
+					stderr: "ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH Configure PNPM_HOME first\n",
+				}),
+			);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_failed",
+			message: "Run pnpm setup, then retry codemem update install",
+		});
+		expect(spawn).toHaveBeenCalledTimes(4);
+	});
+});
+
+describe("pnpm-global post-install package verification", () => {
+	it.each([
+		{
+			expectedMessage:
+				"pnpm update completed, but global package versions do not both equal 0.41.0",
+			label: "stale package versions",
+			state: () => pnpmListState({ codememVersion: "0.40.2", embeddingsVersion: "0.40.2" }),
+		},
+		{
+			expectedMessage:
+				"pnpm update completed, but @codemem/embeddings is absent from global package state",
+			label: "a missing paired package",
+			state: () => updatedPnpmListState({ includeEmbeddings: false }),
+		},
+		{
+			expectedMessage:
+				"pnpm update completed, but the pnpm list -g root does not own both package paths",
+			label: "a package path outside the proven root",
+			setup: () => mkdir(join(testHome, "other", "embeddings"), { recursive: true }),
+			state: () => updatedPnpmListState({ embeddingsPath: join(testHome, "other", "embeddings") }),
+		},
+		{
+			expectedMessage:
+				"pnpm update completed, but the pnpm list -g root changed after ownership was proven",
+			label: "a changed listed root",
+			setup: () => mkdir(join(testHome, "other-root"), { recursive: true }),
+			state: () => updatedPnpmListState({ rootPath: join(testHome, "other-root") }),
+		},
+	])(
+		"fails post-install verification for $label",
+		async ({ expectedMessage, setup, state: postInstallState }) => {
+			await usePnpmEntrypoint();
+			await setup?.();
+			getUpdateStatus.mockResolvedValue(pnpmStatus);
+			spawn
+				.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmRoot()}\n` }))
+				.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+				.mockImplementationOnce(() => commandProcess({ stdout: pnpmListState() }))
+				.mockImplementationOnce(() => commandProcess())
+				.mockImplementationOnce(() => commandProcess({ stdout: postInstallState() }));
+			const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+			await parseUpdateCommand(["install", "--json"]);
+
+			expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+				error: "update_verification_failed",
+				message: expectedMessage,
+			});
+			expect(spawn).toHaveBeenCalledTimes(5);
+		},
+	);
+
+	it.each([
+		{
+			expectedMessage:
+				"pnpm update completed, but package-state verification failed: pnpm list -g --depth 0 --json failed: post-install list failed",
+			label: "fails",
+			result: { exitCode: 1, stderr: "post-install list failed\n" },
+		},
+		{
+			expectedMessage:
+				"pnpm update completed, but package-state verification failed: pnpm list -g --depth 0 --json returned too much output; inspect pnpm global state",
+			label: "exceeds the output bound",
+			result: { stdout: "x".repeat(65 * 1_024) },
+		},
+	])(
+		"fails verification when the post-install package probe $label",
+		async ({ expectedMessage, result }) => {
+			await usePnpmEntrypoint();
+			getUpdateStatus.mockResolvedValue(pnpmStatus);
+			spawn
+				.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmRoot()}\n` }))
+				.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+				.mockImplementationOnce(() => commandProcess({ stdout: pnpmListState() }))
+				.mockImplementationOnce(() => commandProcess())
+				.mockImplementationOnce(() => commandProcess(result));
+			const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+			await parseUpdateCommand(["install", "--json"]);
+
+			expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+				error: "update_verification_failed",
+				message: expectedMessage,
+			});
+			expect(spawn).toHaveBeenCalledTimes(5);
+		},
+	);
+});
+
+describe("pnpm-global launcher verification", () => {
+	it("accepts benign launcher notices around one target-version line", async () => {
+		await usePnpmEntrypoint();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmRoot()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: pnpmListState() }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: updatedPnpmListState() }))
+			.mockImplementationOnce(() =>
+				commandProcess({ stdout: "A newer pnpm is available\n0.41.0\nRun pnpm self-update\n" }),
+			);
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("fails when the exact pnpm-owned shim reports another version", async () => {
+		await usePnpmEntrypoint();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmRoot()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: pnpmListState() }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: updatedPnpmListState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.40.2\n" }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_verification_failed",
+			message: "pnpm-owned codemem launcher did not report 0.41.0",
+		});
+		expect(spawn.mock.calls[5]?.[0]).toBe(join(canonicalPnpmBin(), "codemem"));
+	});
+
+	it("refuses launcher output containing more than one version line", async () => {
+		await usePnpmEntrypoint();
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmRoot()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: pnpmListState() }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: updatedPnpmListState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.40.2\n0.41.0\n" }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		await parseUpdateCommand(["install", "--json"]);
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_verification_failed",
+			message: "pnpm-owned codemem launcher did not report 0.41.0",
+		});
+	});
+});
+
+describe("pnpm-global update execution on Windows", () => {
+	it("uses the bounded pnpm.cmd wrapper and the exact bin-directory codemem.cmd shim", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+		await usePnpmEntrypoint();
+		const originalSystemRoot = process.env.SystemRoot;
+		const systemRoot = join(tmpdir(), "Windows");
+		const system32 = join(systemRoot, "System32");
+		const pnpmShim = join(system32, "pnpm.cmd");
+		process.env.SystemRoot = systemRoot;
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmShim}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmRoot()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: `${pnpmBin()}\n` }))
+			.mockImplementationOnce(() => commandProcess({ stdout: pnpmListState() }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() => commandProcess({ stdout: updatedPnpmListState() }))
+			.mockImplementationOnce(() => commandProcess({ stdout: "0.41.0\n" }));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+
+		try {
+			await parseUpdateCommand(["install", "--json"]);
+		} finally {
+			if (originalSystemRoot === undefined) delete process.env.SystemRoot;
+			else process.env.SystemRoot = originalSystemRoot;
+		}
+
+		expect(spawn.mock.calls.slice(1, 4).map(([, args]) => args)).toEqual([
+			["/d", "/s", "/c", `""${pnpmShim}" root -g"`],
+			["/d", "/s", "/c", `""${pnpmShim}" bin -g"`],
+			["/d", "/s", "/c", `""${pnpmShim}" list -g --depth 0 --json"`],
+		]);
+		for (const callIndex of [1, 2, 3, 4, 5, 6]) {
+			expect(spawn.mock.calls[callIndex]?.[2]).toEqual(
+				expect.objectContaining({ cwd: pnpmUpdateCwd(), shell: false }),
+			);
+		}
+		expect(spawn).toHaveBeenNthCalledWith(
+			5,
+			join(system32, "cmd.exe"),
+			[
+				"/d",
+				"/s",
+				"/c",
+				`""${pnpmShim}" add -g --registry https://registry.npmjs.org/ --config.@codemem:registry=https://registry.npmjs.org/ codemem@0.41.0 @codemem/embeddings@0.41.0"`,
+			],
+			expect.objectContaining({ shell: false, windowsVerbatimArguments: true }),
+		);
+		expect(spawn).toHaveBeenNthCalledWith(
+			7,
+			join(system32, "cmd.exe"),
+			["/d", "/s", "/c", `""${join(canonicalPnpmBin(), "codemem.cmd")}" version"`],
+			expect.objectContaining({ shell: false, windowsVerbatimArguments: true }),
+		);
+		expect(process.exitCode).toBeUndefined();
+	});
+});
+
+describe("pnpm-global Windows shim resolution safeguards", () => {
+	it("maps a missing pnpm.cmd shim to the pnpm recovery error", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+		await usePnpmEntrypoint();
+		const originalSystemRoot = process.env.SystemRoot;
+		process.env.SystemRoot = join(tmpdir(), "Windows");
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn.mockImplementationOnce(() => commandProcess({ exitCode: 1 }));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		try {
+			await parseUpdateCommand(["install", "--json"]);
+		} finally {
+			if (originalSystemRoot === undefined) delete process.env.SystemRoot;
+			else process.env.SystemRoot = originalSystemRoot;
+		}
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_refused",
+			message: "pnpm was not found on PATH; install pnpm, then retry codemem update install",
+		});
+		expect(spawn).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects oversized where.exe output before accepting a pnpm.cmd shim", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+		await usePnpmEntrypoint();
+		const originalSystemRoot = process.env.SystemRoot;
+		const systemRoot = join(tmpdir(), "Windows");
+		const pnpmShim = join(systemRoot, "System32", "pnpm.cmd");
+		process.env.SystemRoot = systemRoot;
+		getUpdateStatus.mockResolvedValue(pnpmStatus);
+		spawn.mockImplementationOnce(() =>
+			commandProcess({ stdoutChunks: [`${pnpmShim}\n`, "x".repeat(65 * 1_024)] }),
+		);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		try {
+			await parseUpdateCommand(["install", "--json"]);
+		} finally {
+			if (originalSystemRoot === undefined) delete process.env.SystemRoot;
+			else process.env.SystemRoot = originalSystemRoot;
+		}
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_refused",
+			message: "unable to resolve pnpm.cmd: where.exe output too large",
+		});
+		expect(spawn).toHaveBeenCalledTimes(1);
+	});
+});
+
 describe("update install command on Windows", () => {
 	it("pins the public default and scoped registries in the Windows install command", async () => {
 		vi.spyOn(process, "platform", "get").mockReturnValue("win32");
@@ -940,6 +1858,65 @@ describe("update install command on Windows", () => {
 			expect.objectContaining({ shell: false, windowsVerbatimArguments: true }),
 		);
 		expect(process.exitCode).toBeUndefined();
+	});
+});
+
+describe("Windows updater shim output safeguards", () => {
+	it("rejects oversized where.exe output before accepting an npm.cmd shim", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+		const originalSystemRoot = process.env.SystemRoot;
+		const systemRoot = join(tmpdir(), "Windows");
+		const npmShim = join(systemRoot, "System32", "npm.cmd");
+		process.env.SystemRoot = systemRoot;
+		getUpdateStatus.mockResolvedValue({ ...availableStatus, auto_update_eligible: true });
+		spawn.mockImplementationOnce(() =>
+			commandProcess({ stdoutChunks: [`${npmShim}\n`, "x".repeat(65 * 1_024)] }),
+		);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		try {
+			await parseUpdateCommand(["install", "--json"]);
+		} finally {
+			if (originalSystemRoot === undefined) delete process.env.SystemRoot;
+			else process.env.SystemRoot = originalSystemRoot;
+		}
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_failed",
+			message: "unable to resolve npm.cmd: where.exe output too large",
+		});
+		expect(spawn).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects oversized where.exe output before accepting a codemem.cmd shim", async () => {
+		vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+		const originalSystemRoot = process.env.SystemRoot;
+		const systemRoot = join(tmpdir(), "Windows");
+		const system32 = join(systemRoot, "System32");
+		const npmShim = join(system32, "npm.cmd");
+		const codememShim = join(system32, "codemem.cmd");
+		process.env.SystemRoot = systemRoot;
+		getUpdateStatus.mockResolvedValue({ ...availableStatus, auto_update_eligible: true });
+		spawn
+			.mockImplementationOnce(() => commandProcess({ stdout: `${npmShim}\n` }))
+			.mockImplementationOnce(() => commandProcess())
+			.mockImplementationOnce(() =>
+				commandProcess({ stdoutChunks: [`${codememShim}\n`, "x".repeat(65 * 1_024)] }),
+			);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+		try {
+			await parseUpdateCommand(["install", "--json"]);
+		} finally {
+			if (originalSystemRoot === undefined) delete process.env.SystemRoot;
+			else process.env.SystemRoot = originalSystemRoot;
+		}
+
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+			error: "update_install_failed",
+			message: "unable to resolve codemem.cmd: where.exe output too large",
+		});
+		expect(spawn).toHaveBeenCalledTimes(3);
 	});
 });
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,4 +1,5 @@
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
+import { realpathSync } from "node:fs";
 import { mkdir, open, readFile, stat, unlink } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, win32 } from "node:path";
@@ -57,6 +58,23 @@ interface MiseStateQuery {
 	state: MiseToolState | null;
 }
 
+interface PnpmPackageState {
+	path: string;
+	version: string;
+}
+
+interface PnpmGlobalState {
+	codemem: PnpmPackageState;
+	embeddings: PnpmPackageState | null;
+	listRootPath: string;
+}
+
+interface PnpmGlobalOwnership {
+	binPath: string;
+	command: ResolvedCommand;
+	listRootPath: string;
+}
+
 interface CommandOptions {
 	cwd?: string;
 	env?: NodeJS.ProcessEnv;
@@ -71,6 +89,7 @@ const UPDATE_LOCK_FILE = "update-install.lock";
 const UPDATE_COMMAND_MAX_OUTPUT_BYTES = 64 * 1_024;
 
 class UpdateInstallLockedError extends Error {}
+class PnpmOwnershipError extends Error {}
 
 function commandStderr(outputExceeded: boolean, timedOut: boolean, stderr: string): string {
 	if (outputExceeded) return "command output too large";
@@ -234,18 +253,24 @@ function runCommand(
 	});
 }
 
-async function resolveWindowsShim(name: "npm.cmd" | "codemem.cmd"): Promise<string> {
+async function resolveWindowsShim(name: "npm.cmd" | "codemem.cmd" | "pnpm.cmd"): Promise<string> {
 	const systemRoot = process.env.SystemRoot?.trim();
 	if (!systemRoot || !isAbsolute(systemRoot)) throw new Error("Windows SystemRoot is unavailable");
 	const result = await runCommand(join(systemRoot, "System32", "where.exe"), [name], 10_000, {
 		cwd: join(systemRoot, "System32"),
 		maxOutputBytes: UPDATE_COMMAND_MAX_OUTPUT_BYTES,
 	});
+	if (result.outputExceeded) {
+		throw new Error(`unable to resolve ${name}: where.exe output too large`);
+	}
 	const shim = result.stdout
 		.split(/\r?\n/)
 		.map((value) => value.trim())
 		.find((value) => isAbsolute(value));
-	if (result.exitCode !== 0 || !shim) throw new Error(`unable to resolve ${name} from PATH`);
+	if (!shim) {
+		throw Object.assign(new Error(`unable to resolve ${name} from PATH`), { code: "ENOENT" });
+	}
+	if (result.exitCode !== 0) throw new Error(`where.exe failed while resolving ${name}`);
 	return shim;
 }
 
@@ -266,6 +291,25 @@ async function resolveNpmInstallCommand(): Promise<{
 		args: ["/d", "/s", "/c", await resolveWindowsShim("npm.cmd")],
 		cwd: join(systemRoot, "System32"),
 	};
+}
+
+async function resolvePnpmCommand(): Promise<ResolvedCommand> {
+	if (process.platform !== "win32") return { command: "pnpm", args: [] };
+	const systemRoot = process.env.SystemRoot?.trim();
+	if (!systemRoot || !isAbsolute(systemRoot)) throw new Error("Windows SystemRoot is unavailable");
+	return {
+		command: join(systemRoot, "System32", "cmd.exe"),
+		args: ["/d", "/s", "/c", await resolveWindowsShim("pnpm.cmd")],
+		cwd: join(systemRoot, "System32"),
+		windowsVerbatimArguments: true,
+	};
+}
+
+function resolvedCommandArgs(command: ResolvedCommand, args: string[]): string[] {
+	if (process.platform !== "win32") return args;
+	const shim = command.args[3];
+	if (!shim) throw new Error("Windows command shim is unavailable");
+	return [...command.args.slice(0, 3), windowsCommandLine(shim, args)];
 }
 
 async function resolveVerificationCommand(): Promise<{
@@ -367,7 +411,7 @@ function updateInstallArgs(npmArgs: string[], targetVersion: string): string[] {
 	return [...npmArgs.slice(0, 3), windowsCommandLine(npmArgs[3] ?? "", installArgs)];
 }
 
-function miseCommandEnvironment(): NodeJS.ProcessEnv {
+function packageManagerEnvironment(): NodeJS.ProcessEnv {
 	const env = { ...process.env };
 	const protectedKeys = new Set(["npm_config_registry", "npm_config_@codemem:registry"]);
 	if (process.platform === "linux") protectedKeys.add("onnxruntime_node_install");
@@ -390,16 +434,38 @@ function miseGlobalCwd(): string {
 	return process.env.HOME?.trim() || homedir();
 }
 
+function updateInstallCwd(): string {
+	return dirname(updateInstallLockPath());
+}
+
 async function resolveUpdateInstallCommand(
 	installKind: InstallKind,
 	targetVersion: string,
+	pnpmCommand?: ResolvedCommand,
 ): Promise<ResolvedCommand> {
 	if (installKind === "mise") {
 		return {
 			command: "mise",
 			args: ["use", "-g", `npm:codemem@${targetVersion}`],
 			cwd: miseGlobalCwd(),
-			env: miseCommandEnvironment(),
+			env: packageManagerEnvironment(),
+		};
+	}
+	if (installKind === "pnpm-global") {
+		const pnpm = pnpmCommand ?? (await resolvePnpmCommand());
+		return {
+			...pnpm,
+			args: resolvedCommandArgs(pnpm, [
+				"add",
+				"-g",
+				"--registry",
+				PUBLIC_NPM_REGISTRY,
+				`--config.@codemem:registry=${PUBLIC_NPM_REGISTRY}`,
+				`codemem@${targetVersion}`,
+				`@codemem/embeddings@${targetVersion}`,
+			]),
+			cwd: updateInstallCwd(),
+			env: packageManagerEnvironment(),
 		};
 	}
 
@@ -422,24 +488,30 @@ function installLaunchErrorMessage(
 	error: unknown,
 ): string {
 	if (
-		installKind === "mise" &&
+		(installKind === "mise" || installKind === "pnpm-global") &&
 		error instanceof Error &&
 		(error as NodeJS.ErrnoException).code === "ENOENT"
 	) {
+		if (installKind === "pnpm-global") {
+			return "pnpm was not found on PATH; install pnpm, then retry codemem update install";
+		}
 		return `mise was not found on PATH; install mise, then run mise use -g npm:codemem@${targetVersion}`;
 	}
 	return error instanceof Error ? error.message : "update installation failed";
 }
 
 function failedInstallMessage(installKind: InstallKind): string {
-	return installKind === "mise" ? "mise installation failed" : "npm installation failed";
+	if (installKind === "mise") return "mise installation failed";
+	if (installKind === "pnpm-global") return "pnpm installation failed";
+	return "npm installation failed";
 }
 
 async function runUpdateInstallCommand(
 	installKind: InstallKind,
 	targetVersion: string,
+	pnpmCommand?: ResolvedCommand,
 ): Promise<CommandResult> {
-	const install = await resolveUpdateInstallCommand(installKind, targetVersion);
+	const install = await resolveUpdateInstallCommand(installKind, targetVersion, pnpmCommand);
 	try {
 		return await runCommand(install.command, install.args, INSTALL_TIMEOUT_MS, {
 			cwd: install.cwd,
@@ -509,7 +581,7 @@ async function readMiseState(
 	try {
 		const result = await runCommand("mise", args, VERIFY_TIMEOUT_MS, {
 			cwd: options.cwd,
-			env: miseCommandEnvironment(),
+			env: packageManagerEnvironment(),
 			maxOutputBytes: UPDATE_COMMAND_MAX_OUTPUT_BYTES,
 		});
 		if (result.exitCode !== 0 || result.outputExceeded) return null;
@@ -523,8 +595,187 @@ function isPathWithin(path: string, root: string): boolean {
 	return path === root || path.startsWith(`${root}/`);
 }
 
+function isPathBelow(path: string, root: string): boolean {
+	return path.startsWith(`${root}/`);
+}
+
 function isPortableAbsolutePath(value: string): boolean {
 	return value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value);
+}
+
+function isSafeAbsoluteDirectory(value: string): boolean {
+	if (!isPortableAbsolutePath(value)) return false;
+	const normalized = resolveComparablePath(value);
+	return normalized !== "/" && !/^[a-z]:$/i.test(normalized);
+}
+
+function resolveExistingComparablePath(value: string): string | null {
+	try {
+		return resolveComparablePath(realpathSync(value));
+	} catch {
+		return null;
+	}
+}
+
+function parsePnpmPackageState(value: unknown): PnpmPackageState | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	const record = value as Record<string, unknown>;
+	if (
+		typeof record.path !== "string" ||
+		!isPortableAbsolutePath(record.path) ||
+		typeof record.version !== "string" ||
+		!record.version
+	) {
+		return null;
+	}
+	return { path: record.path, version: record.version };
+}
+
+function parsePnpmGlobalState(raw: string): PnpmGlobalState | null {
+	if (Buffer.byteLength(raw) > UPDATE_COMMAND_MAX_OUTPUT_BYTES) return null;
+	let payload: unknown;
+	try {
+		payload = JSON.parse(raw);
+	} catch {
+		return null;
+	}
+	if (!Array.isArray(payload) || payload.length !== 1) return null;
+	const topLevel = payload[0];
+	if (!topLevel || typeof topLevel !== "object" || Array.isArray(topLevel)) return null;
+	const topLevelRecord = topLevel as Record<string, unknown>;
+	if (
+		typeof topLevelRecord.private !== "boolean" ||
+		typeof topLevelRecord.path !== "string" ||
+		!isPortableAbsolutePath(topLevelRecord.path)
+	) {
+		return null;
+	}
+	const dependencies = topLevelRecord.dependencies;
+	if (!dependencies || typeof dependencies !== "object" || Array.isArray(dependencies)) return null;
+	const records = dependencies as Record<string, unknown>;
+	if (!Object.hasOwn(records, "codemem")) return null;
+	const codemem = parsePnpmPackageState(records.codemem);
+	if (!codemem) return null;
+	if (!Object.hasOwn(records, "@codemem/embeddings")) {
+		return { codemem, embeddings: null, listRootPath: topLevelRecord.path };
+	}
+	const embeddings = parsePnpmPackageState(records["@codemem/embeddings"]);
+	return embeddings ? { codemem, embeddings, listRootPath: topLevelRecord.path } : null;
+}
+
+function parsePnpmDirectory(raw: string): string | null {
+	if (Buffer.byteLength(raw) > UPDATE_COMMAND_MAX_OUTPUT_BYTES) return null;
+	const lines = raw
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean);
+	const directories = lines
+		.filter(isSafeAbsoluteDirectory)
+		.map(resolveExistingComparablePath)
+		.filter((directory): directory is string => directory !== null);
+	return directories.length === 1 ? (directories[0] ?? null) : null;
+}
+
+const PNPM_SETUP_GUIDANCE = "Run pnpm setup, then retry codemem update install";
+
+function isMissingPnpmGlobalBinDirectory(
+	result: Pick<CommandResult, "stderr" | "stdout">,
+): boolean {
+	const output = `${result.stdout}\n${result.stderr}`.toLowerCase();
+	return (
+		output.includes("err_pnpm_global_bin_dir_not_in_path") ||
+		(output.includes("configured global bin directory") && output.includes("is not in path"))
+	);
+}
+
+async function runPnpmQuery(command: ResolvedCommand, args: string[]): Promise<CommandResult> {
+	try {
+		return await runCommand(
+			command.command,
+			resolvedCommandArgs(command, args),
+			VERIFY_TIMEOUT_MS,
+			{
+				cwd: updateInstallCwd(),
+				maxOutputBytes: UPDATE_COMMAND_MAX_OUTPUT_BYTES,
+				windowsVerbatimArguments: command.windowsVerbatimArguments,
+			},
+		);
+	} catch (error) {
+		if (error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT") {
+			throw new PnpmOwnershipError(
+				"pnpm was not found on PATH; install pnpm, then retry codemem update install",
+			);
+		}
+		throw error;
+	}
+}
+
+async function requirePnpmQuery(command: ResolvedCommand, args: string[]): Promise<string> {
+	const result = await runPnpmQuery(command, args);
+	const label = `pnpm ${args.join(" ")}`;
+	if (isMissingPnpmGlobalBinDirectory(result)) {
+		throw new PnpmOwnershipError(PNPM_SETUP_GUIDANCE);
+	}
+	if (result.outputExceeded) {
+		throw new PnpmOwnershipError(`${label} returned too much output; inspect pnpm global state`);
+	}
+	if (result.exitCode !== 0) {
+		throw new PnpmOwnershipError(
+			`${label} failed${result.stderr.trim() ? `: ${result.stderr.trim()}` : "; inspect pnpm global configuration"}`,
+		);
+	}
+	return result.stdout;
+}
+
+async function provePnpmGlobalOwnership(plan: ExplicitUpdatePlan): Promise<PnpmGlobalOwnership> {
+	let command: ResolvedCommand;
+	try {
+		command = await resolvePnpmCommand();
+	} catch (error) {
+		const message = installLaunchErrorMessage("pnpm-global", plan.targetVersion, error);
+		throw new PnpmOwnershipError(message);
+	}
+	const rootRaw = await requirePnpmQuery(command, ["root", "-g"]);
+	const binRaw = await requirePnpmQuery(command, ["bin", "-g"]);
+	const listRaw = await requirePnpmQuery(command, ["list", "-g", "--depth", "0", "--json"]);
+	const rootPath = parsePnpmDirectory(rootRaw);
+	if (!rootPath)
+		throw new PnpmOwnershipError("pnpm root -g did not return one absolute non-root path");
+	const binPath = parsePnpmDirectory(binRaw);
+	if (!binPath)
+		throw new PnpmOwnershipError("pnpm bin -g did not return one absolute non-root path");
+	const state = parsePnpmGlobalState(listRaw);
+	if (!state) {
+		throw new PnpmOwnershipError(
+			"pnpm list -g returned malformed or ambiguous global package state",
+		);
+	}
+	if (state.codemem.version !== VERSION) {
+		throw new PnpmOwnershipError(
+			`pnpm global codemem is ${state.codemem.version}, but the running CLI is ${VERSION}`,
+		);
+	}
+	const listRootPath = resolveExistingComparablePath(state.listRootPath);
+	const legacyModulesPath = listRootPath
+		? resolveExistingComparablePath(join(listRootPath, "node_modules"))
+		: null;
+	if (!listRootPath || (rootPath !== listRootPath && rootPath !== legacyModulesPath)) {
+		throw new PnpmOwnershipError(
+			"pnpm root -g is neither the pnpm list -g root nor its node_modules directory",
+		);
+	}
+	const packagePath = resolveExistingComparablePath(state.codemem.path);
+	if (!packagePath || !isPathBelow(packagePath, listRootPath)) {
+		throw new PnpmOwnershipError("pnpm list -g root does not own the listed codemem package path");
+	}
+	const entryPath = plan.runningEntryPath;
+	const canonicalEntryPath = entryPath ? resolveExistingComparablePath(entryPath) : null;
+	if (!canonicalEntryPath || !isPathWithin(canonicalEntryPath, packagePath)) {
+		throw new PnpmOwnershipError(
+			"the pnpm global codemem package does not own the running JavaScript entry",
+		);
+	}
+	return { binPath, command, listRootPath };
 }
 
 function isUserOwnedMiseSource(state: MiseToolState): boolean {
@@ -602,7 +853,9 @@ async function resolveExplicitUpdatePlan(
 		installKind: status.install_kind,
 		manualGuidance: status.recommended_action,
 		runningEntryPath:
-			detectedInstallKind === "mise" ? resolveRunningEntryPath(process.argv[1] ?? "") : null,
+			detectedInstallKind === "mise" || detectedInstallKind === "pnpm-global"
+				? resolveRunningEntryPath(process.argv[1] ?? "")
+				: null,
 		targetVersion: status.latest_version,
 	};
 }
@@ -631,7 +884,7 @@ async function verifyMiseInstalledVersion(plan: ExplicitUpdatePlan): Promise<boo
 		VERIFY_TIMEOUT_MS,
 		{
 			cwd: miseGlobalCwd(),
-			env: miseCommandEnvironment(),
+			env: packageManagerEnvironment(),
 			maxOutputBytes: UPDATE_COMMAND_MAX_OUTPUT_BYTES,
 		},
 	);
@@ -640,6 +893,102 @@ async function verifyMiseInstalledVersion(plan: ExplicitUpdatePlan): Promise<boo
 		verification.exitCode === 0 &&
 		verification.stdout.trim() === plan.targetVersion
 	);
+}
+
+function pnpmPackageStateError(
+	state: PnpmGlobalState,
+	ownership: PnpmGlobalOwnership,
+	targetVersion: string,
+): string | null {
+	if (!state.embeddings) {
+		return "pnpm update completed, but @codemem/embeddings is absent from global package state";
+	}
+	if (state.codemem.version !== targetVersion || state.embeddings.version !== targetVersion) {
+		return `pnpm update completed, but global package versions do not both equal ${targetVersion}`;
+	}
+	const listedRootPath = resolveExistingComparablePath(state.listRootPath);
+	if (listedRootPath !== ownership.listRootPath) {
+		return "pnpm update completed, but the pnpm list -g root changed after ownership was proven";
+	}
+	const packagePaths = [state.codemem.path, state.embeddings.path].map(
+		resolveExistingComparablePath,
+	);
+	if (
+		packagePaths.some(
+			(packagePath) => !packagePath || !isPathBelow(packagePath, ownership.listRootPath),
+		)
+	) {
+		return "pnpm update completed, but the pnpm list -g root does not own both package paths";
+	}
+	return null;
+}
+
+async function verifyPnpmOwnedLauncher(
+	plan: ExplicitUpdatePlan,
+	ownership: PnpmGlobalOwnership,
+): Promise<string | null> {
+	const shimName = process.platform === "win32" ? "codemem.cmd" : "codemem";
+	const shimPath = join(ownership.binPath, shimName);
+	let verification: CommandResult;
+	try {
+		if (process.platform === "win32") {
+			verification = await runCommand(
+				ownership.command.command,
+				["/d", "/s", "/c", windowsCommandLine(shimPath, ["version"])],
+				VERIFY_TIMEOUT_MS,
+				{
+					cwd: updateInstallCwd(),
+					maxOutputBytes: UPDATE_COMMAND_MAX_OUTPUT_BYTES,
+					windowsVerbatimArguments: true,
+				},
+			);
+		} else {
+			verification = await runCommand(shimPath, ["version"], VERIFY_TIMEOUT_MS, {
+				cwd: updateInstallCwd(),
+				maxOutputBytes: UPDATE_COMMAND_MAX_OUTPUT_BYTES,
+			});
+		}
+	} catch (error) {
+		const detail = error instanceof Error ? `: ${error.message}` : "";
+		return `pnpm-owned codemem launcher could not be executed${detail}`;
+	}
+	if (verification.outputExceeded) {
+		return "pnpm-owned codemem launcher returned too much output during version verification";
+	}
+	if (verification.exitCode !== 0) {
+		return "pnpm-owned codemem launcher failed during version verification";
+	}
+	const versionLines = verification.stdout
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter((line) =>
+			/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
+				line,
+			),
+		);
+	if (versionLines.length !== 1 || versionLines[0] !== plan.targetVersion) {
+		return `pnpm-owned codemem launcher did not report ${plan.targetVersion}`;
+	}
+	return null;
+}
+
+async function verifyPnpmInstalledVersion(
+	plan: ExplicitUpdatePlan,
+	ownership: PnpmGlobalOwnership,
+): Promise<string | null> {
+	let listRaw: string;
+	try {
+		listRaw = await requirePnpmQuery(ownership.command, ["list", "-g", "--depth", "0", "--json"]);
+	} catch (error) {
+		return error instanceof Error
+			? `pnpm update completed, but package-state verification failed: ${error.message}`
+			: "pnpm update completed, but package-state verification failed";
+	}
+	const state = parsePnpmGlobalState(listRaw);
+	if (!state) return "pnpm update completed, but global package state is malformed or ambiguous";
+	const packageStateError = pnpmPackageStateError(state, ownership, plan.targetVersion);
+	if (packageStateError) return packageStateError;
+	return verifyPnpmOwnedLauncher(plan, ownership);
 }
 
 async function verifyInstalledVersion(plan: ExplicitUpdatePlan): Promise<boolean> {
@@ -669,6 +1018,22 @@ function emitInstallSuccess(options: UpdateInstallOptions, targetVersion: string
 	else console.log(`Updated codemem from ${VERSION} to ${targetVersion}.`);
 }
 
+async function resolvePnpmOwnershipForExecution(
+	options: UpdateInstallOptions,
+	plan: ExplicitUpdatePlan,
+): Promise<PnpmGlobalOwnership | null> {
+	try {
+		return await provePnpmGlobalOwnership(plan);
+	} catch (error) {
+		failInstall(
+			options,
+			"update_install_refused",
+			error instanceof Error ? error.message : "could not prove pnpm global ownership",
+		);
+		return null;
+	}
+}
+
 async function executeExplicitUpdate(
 	options: UpdateInstallOptions,
 	plan: ExplicitUpdatePlan,
@@ -682,8 +1047,17 @@ async function executeExplicitUpdate(
 		);
 		return;
 	}
+	const pnpmOwnership =
+		plan.installKind === "pnpm-global"
+			? await resolvePnpmOwnershipForExecution(options, plan)
+			: null;
+	if (plan.installKind === "pnpm-global" && !pnpmOwnership) return;
+	if (pnpmOwnership) {
+		await executePnpmUpdate(options, plan, pnpmOwnership);
+		return;
+	}
 	const installation = await runUpdateInstallCommand(plan.installKind, plan.targetVersion);
-	if (installation.exitCode !== 0) {
+	if (installation.exitCode !== 0 || installation.outputExceeded) {
 		failInstall(
 			options,
 			"update_install_failed",
@@ -697,6 +1071,31 @@ async function executeExplicitUpdate(
 				? "mise updated global configuration, but installed version verification failed; inspect the global mise codemem state before retrying"
 				: "installed version verification failed";
 		failInstall(options, "update_verification_failed", message);
+		return;
+	}
+	emitInstallSuccess(options, plan.targetVersion);
+}
+
+async function executePnpmUpdate(
+	options: UpdateInstallOptions,
+	plan: ExplicitUpdatePlan,
+	ownership: PnpmGlobalOwnership,
+): Promise<void> {
+	const installation = await runUpdateInstallCommand(
+		plan.installKind,
+		plan.targetVersion,
+		ownership.command,
+	);
+	if (installation.exitCode !== 0) {
+		const message = isMissingPnpmGlobalBinDirectory(installation)
+			? PNPM_SETUP_GUIDANCE
+			: installation.stderr.trim() || failedInstallMessage(plan.installKind);
+		failInstall(options, "update_install_failed", message);
+		return;
+	}
+	const verificationError = await verifyPnpmInstalledVersion(plan, ownership);
+	if (verificationError) {
+		failInstall(options, "update_verification_failed", verificationError);
 		return;
 	}
 	emitInstallSuccess(options, plan.targetVersion);

--- a/packages/core/src/release-discovery.test.ts
+++ b/packages/core/src/release-discovery.test.ts
@@ -559,6 +559,35 @@ describe("explicit mise update eligibility", () => {
 	});
 });
 
+describe("explicit pnpm-global update eligibility", () => {
+	it("keeps a fresh pnpm-global update explicit-only", async () => {
+		const status = await check(dependencies(), { installKind: "pnpm-global" });
+
+		expect(status.auto_update_eligible).toBe(false);
+		expect(isExplicitUpdateInstallEligible(status)).toBe(true);
+	});
+
+	it.each([
+		{ error: "registry request failed", stale: false },
+		{ error: null, stale: true },
+		{ error: null, stale: false, updateAvailable: false },
+	])(
+		"refuses pnpm-global when stale=$stale, error=$error, and updateAvailable=$updateAvailable",
+		async ({ error, stale, updateAvailable = true }) => {
+			const status = await check(dependencies(), { installKind: "pnpm-global" });
+
+			expect(
+				isExplicitUpdateInstallEligible({
+					...status,
+					error,
+					stale,
+					update_available: updateAvailable,
+				}),
+			).toBe(false);
+		},
+	);
+});
+
 describe("release discovery cache contract", () => {
 	it("uses cache younger than six hours without registry access", async () => {
 		// Arrange
@@ -1149,6 +1178,159 @@ describe("mise installation-kind detection", () => {
 	});
 });
 
+describe("pnpm-global installation-kind detection", () => {
+	it.each([
+		{
+			label: "current isolated global virtual-store package",
+			entryPath:
+				"/opt/pnpm/global/v11/group-token/node_modules/.pnpm/codemem@0.44.2_better-sqlite3@13.0.3_hono@4.13.7/node_modules/codemem/dist/index.js",
+		},
+		{
+			label: "current normalized Windows isolated global virtual-store package",
+			entryPath:
+				"C:\\pnpm\\global\\v11\\short-group\\node_modules\\.pnpm\\codemem@0.44.2_peer@1.0.0\\node_modules\\codemem\\dist\\..\\dist\\index.js",
+		},
+		{
+			label: "legacy Unix virtual-store package",
+			entryPath: "/opt/pnpm/global/5/.pnpm/codemem@0.44.2/node_modules/codemem/dist/index.js",
+		},
+		{
+			label: "legacy Windows virtual-store package",
+			entryPath:
+				"C:\\pnpm\\global\\5\\.pnpm\\codemem@0.44.2\\node_modules\\codemem\\dist\\index.js",
+		},
+	])("detects a $label", ({ entryPath }) => {
+		expect(detectInstallKind({ entryPath })).toBe("pnpm-global");
+	});
+
+	it("classifies an unresolved group alias from its canonical virtual-store entry", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "codemem-pnpm-global-link-"));
+		temporaryDirectories.push(directory);
+		const shortGroupPath = join(directory, "global", "v11", "7fe-18d46352ecbd2b50-0");
+		const packageDirectoryName = "codemem@0.44.2_better-sqlite3@13.0.3_hono@4.13.7";
+		const canonicalPackagePath = join(
+			shortGroupPath,
+			"node_modules",
+			".pnpm",
+			packageDirectoryName,
+			"node_modules",
+			"codemem",
+		);
+		const canonicalEntryPath = join(canonicalPackagePath, "dist", "index.js");
+		const topLevelPackagePath = join(shortGroupPath, "node_modules", "codemem");
+		const aliasGroupPath = join(directory, "global", "v11", "a".repeat(64));
+		const aliasEntryPath = join(aliasGroupPath, "node_modules", "codemem", "dist", "index.js");
+		const directoryLinkType = process.platform === "win32" ? "junction" : "dir";
+		await mkdir(dirname(canonicalEntryPath), { recursive: true });
+		await writeFile(canonicalEntryPath, "");
+		await symlink(canonicalPackagePath, topLevelPackagePath, directoryLinkType);
+		await symlink(shortGroupPath, aliasGroupPath, directoryLinkType);
+
+		expect(detectInstallKind({ entryPath: aliasEntryPath, env: { PNPM_HOME: directory } })).toBe(
+			"pnpm-global",
+		);
+	});
+
+	it("detects a legacy global entry beneath a custom normalized PNPM_HOME", () => {
+		expect(
+			detectInstallKind({
+				entryPath:
+					"/srv/tools/pnpm-home/../pnpm-home/global/5/.pnpm/codemem@0.44.2/node_modules/codemem/dist/index.js",
+				env: { PNPM_HOME: "/srv/tools/pnpm-home" },
+			}),
+		).toBe("pnpm-global");
+	});
+
+	it("treats PNPM_HOME as authoritative when it is configured", () => {
+		expect(
+			detectInstallKind({
+				entryPath: "/opt/pnpm/global/5/.pnpm/codemem@0.44.2/node_modules/codemem/dist/index.js",
+				env: { PNPM_HOME: "/srv/tools/pnpm-home" },
+			}),
+		).toBe("unknown");
+	});
+});
+
+describe("pnpm-global installation-kind refusals", () => {
+	it.each([
+		{
+			label: "pnpm dlx package",
+			entryPath:
+				"/opt/pnpm-cache/pnpm/dlx/abc/def/node_modules/.pnpm/codemem@0.44.2/node_modules/codemem/dist/index.js",
+			expected: "npx",
+		},
+		{
+			label: "legacy .pnpm dlx package",
+			entryPath:
+				"/opt/pnpm-cache/.pnpm/dlx/abc/node_modules/.pnpm/codemem@0.44.2/node_modules/codemem/dist/index.js",
+			expected: "npx",
+		},
+		{
+			label: "project-local virtual-store package",
+			entryPath:
+				"/workspace/app/node_modules/.pnpm/codemem@0.44.2/node_modules/codemem/dist/index.js",
+			expected: "unknown",
+		},
+		{
+			label: "legacy global package without an exact version",
+			entryPath: "/opt/pnpm/global/5/.pnpm/codemem@latest/node_modules/codemem/dist/index.js",
+			expected: "unknown",
+		},
+		{
+			label: "global package with a malformed version segment",
+			entryPath:
+				"/opt/pnpm/global/latest/group/node_modules/.pnpm/codemem@0.44.2/node_modules/codemem/dist/index.js",
+			expected: "unknown",
+		},
+		{
+			label: "global virtual-store package with an invalid semver",
+			entryPath:
+				"/opt/pnpm/global/v11/group/node_modules/.pnpm/codemem@01.2.3_peer@1/node_modules/codemem/dist/index.js",
+			expected: "unknown",
+		},
+		{
+			label: "global virtual-store package with an empty peer suffix",
+			entryPath:
+				"/opt/pnpm/global/v11/group/node_modules/.pnpm/codemem@0.44.2_/node_modules/codemem/dist/index.js",
+			expected: "unknown",
+		},
+		{
+			label: "generic package-manager global path",
+			entryPath: "/opt/package-manager/global/node_modules/codemem/dist/index.js",
+			expected: "unknown",
+		},
+		{
+			label: "ambiguous versioned global package path",
+			entryPath: "/srv/app/global/v1/group/node_modules/codemem/dist/index.js",
+			expected: "unknown",
+		},
+		{
+			label: "project-local versioned global virtual store",
+			entryPath:
+				"/srv/app/global/v11/group/node_modules/.pnpm/codemem@0.44.2/node_modules/codemem/dist/index.js",
+			expected: "unknown",
+		},
+		{
+			label: "project path merely containing pnpm dlx segments",
+			entryPath:
+				"/workspace/pnpm/dlx/cache/node_modules/.pnpm/codemem@0.44.2/node_modules/codemem/dist/index.js",
+			expected: "unknown",
+		},
+		{ label: "missing entry path", entryPath: "", expected: "unknown" },
+	] as const)("refuses a $label", ({ entryPath, expected }) => {
+		expect(detectInstallKind({ entryPath })).toBe(expected);
+	});
+
+	it("preserves mise precedence over a pnpm-global environment marker", () => {
+		expect(
+			detectInstallKind({
+				entryPath: "/opt/mise/installs/npm-codemem/0.44.2/lib/node_modules/codemem/dist/index.js",
+				env: { CODEMEM_INSTALL_KIND: "pnpm-global" },
+			}),
+		).toBe("mise");
+	});
+});
+
 describe("custom mise data directory detection", () => {
 	it.each([
 		{
@@ -1274,6 +1456,7 @@ describe("installation guidance", () => {
 
 	it.each([
 		["npm-global", "npm install -g codemem@0.41.0"],
+		["pnpm-global", "pnpm add -g codemem@0.41.0 @codemem/embeddings@0.41.0"],
 		["npx", "codemem@0.41.0 and @codemem/embeddings@0.41.0"],
 		["docker", "CODEMEM_VERSION=0.41.0 docker compose build --pull"],
 		["repo-dev", "git pull"],
@@ -1312,6 +1495,26 @@ describe("installation guidance", () => {
 		);
 
 		expect(status.recommended_action).toBe("npm install -g codemem@0.41.0");
+	});
+
+	it("returns exact paired pnpm-global guidance off Linux", async () => {
+		const platform = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+		const status = await check(dependencies(), { installKind: "pnpm-global" }).finally(() =>
+			platform.mockRestore(),
+		);
+
+		expect(status.recommended_action).toBe("pnpm add -g codemem@0.41.0 @codemem/embeddings@0.41.0");
+	});
+
+	it("prefixes pnpm-global guidance with the Linux CPU-only ONNX policy", async () => {
+		const platform = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+		const status = await check(dependencies(), { installKind: "pnpm-global" }).finally(() =>
+			platform.mockRestore(),
+		);
+
+		expect(status.recommended_action).toBe(
+			"env ONNXRUNTIME_NODE_INSTALL=skip pnpm add -g codemem@0.41.0 @codemem/embeddings@0.41.0",
+		);
 	});
 
 	it("returns no-upgrade guidance when the installation is current", async () => {

--- a/packages/core/src/release-discovery.ts
+++ b/packages/core/src/release-discovery.ts
@@ -2,9 +2,13 @@ import { randomUUID } from "node:crypto";
 import { mkdir, open, readFile, rename, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { codememHomeDir } from "./home.js";
-import { miseInstallVersionFromPath, normalizeInstallEntryPath } from "./mise-install-path.js";
+import {
+	miseInstallVersionFromPath,
+	normalizeInstallEntryPath,
+	resolveComparablePath,
+} from "./mise-install-path.js";
 
-export { resolveComparablePath } from "./mise-install-path.js";
+export { resolveComparablePath };
 
 const REGISTRY_URL_PREFIX = "https://registry.npmjs.org/codemem/";
 const REQUEST_TIMEOUT_MS = 2_000;
@@ -20,6 +24,7 @@ const SEMVER =
 
 export type InstallKind =
 	| "npm-global"
+	| "pnpm-global"
 	| "mise"
 	| "npx"
 	| "docker"
@@ -30,6 +35,7 @@ export type ReleaseChannel = "alpha" | "beta" | "rc" | "latest";
 
 const KNOWN_INSTALL_KINDS: readonly InstallKind[] = [
 	"npm-global",
+	"pnpm-global",
 	"mise",
 	"npx",
 	"docker",
@@ -55,7 +61,7 @@ export interface UpdateStatus {
 export function isExplicitUpdateInstallEligible(status: UpdateStatus): boolean {
 	if (status.install_kind === "npm-global") return status.auto_update_eligible;
 	return (
-		status.install_kind === "mise" &&
+		(status.install_kind === "mise" || status.install_kind === "pnpm-global") &&
 		status.update_available &&
 		!status.stale &&
 		status.error === null
@@ -342,6 +348,8 @@ function recommendedAction(
 	switch (installKind) {
 		case "npm-global":
 			return `${process.platform === "linux" ? "env ONNXRUNTIME_NODE_INSTALL=skip " : ""}npm install -g codemem@${latestVersion}`;
+		case "pnpm-global":
+			return `${process.platform === "linux" ? "env ONNXRUNTIME_NODE_INSTALL=skip " : ""}pnpm add -g codemem@${latestVersion} @codemem/embeddings@${latestVersion}`;
 		case "mise":
 			return process.platform === "linux"
 				? `env ONNXRUNTIME_NODE_INSTALL=skip mise use -g npm:codemem@${latestVersion}`
@@ -604,14 +612,56 @@ function runnerInstallKind(runner: string): InstallKind | null {
 	return runner === "node" || runner === "uv" ? "repo-dev" : null;
 }
 
+function pnpmVirtualStoreVersion(packagePath: string): string | null {
+	const match =
+		/^\.pnpm\/codemem@([^/_]+)(?:_[^/]+)?\/node_modules\/codemem\/dist\/index\.js$/i.exec(
+			packagePath,
+		);
+	return match?.[1] && parseSemver(match[1]) !== null ? match[1] : null;
+}
+
+function pnpmGlobalRelativePath(
+	entryPath: string,
+	env: Record<string, string | undefined>,
+): string | null {
+	const pnpmHome = env.PNPM_HOME?.trim();
+	if (pnpmHome) {
+		const prefix = `${resolveComparablePath(pnpmHome)}/global/`;
+		return entryPath.startsWith(prefix) ? entryPath.slice(prefix.length) : null;
+	}
+	const marker = "/pnpm/global/";
+	const markerIndex = entryPath.indexOf(marker);
+	return markerIndex >= 0 ? entryPath.slice(markerIndex + marker.length) : null;
+}
+
+function isPnpmGlobalEntryPath(
+	entryPath: string,
+	env: Record<string, string | undefined>,
+): boolean {
+	const relativePath = pnpmGlobalRelativePath(entryPath, env);
+	if (!relativePath) return false;
+	const layout = /^(?:[1-9]\d*\/|v[1-9]\d*\/[^/]+\/node_modules\/)/i.exec(relativePath);
+	if (!layout) return false;
+	return pnpmVirtualStoreVersion(relativePath.slice(layout[0].length)) !== null;
+}
+
+function isPnpmDlxEntryPath(entryPath: string): boolean {
+	const match =
+		/\/(?:pnpm\/dlx\/[^/]+\/[^/]+|\.pnpm\/dlx\/[^/]+)\/node_modules\/(\.pnpm\/codemem@.+)$/i.exec(
+			entryPath,
+		);
+	return match?.[1] !== undefined && pnpmVirtualStoreVersion(match[1]) !== null;
+}
+
 function installKindForEntryPath(
 	entryPath: string,
 	env: Record<string, string | undefined>,
 ): InstallKind {
 	const miseInstallKind = miseInstallKindForPath(entryPath, env);
 	if (miseInstallKind) return miseInstallKind;
-	if (/\/(?:_npx|\.pnpm\/dlx)\//.test(entryPath)) return "npx";
+	if (/\/_npx\//.test(entryPath) || isPnpmDlxEntryPath(entryPath)) return "npx";
 	if (/\/installs\/npm-codemem\/[^/]+\//.test(entryPath)) return "unknown";
+	if (isPnpmGlobalEntryPath(resolveComparablePath(entryPath), env)) return "pnpm-global";
 	if (/\/lib\/node_modules\/codemem\/dist\/index\.js$/.test(entryPath)) return "npm-global";
 	if (/\/AppData\/Roaming\/npm\/node_modules\/codemem\/dist\/index\.js$/i.test(entryPath)) {
 		return "npm-global";

--- a/packages/ui/src/lib/api/types.ts
+++ b/packages/ui/src/lib/api/types.ts
@@ -64,7 +64,15 @@ export interface UpdateStatus {
 	first_seen_at: string | null;
 	checked_at: string | null;
 	stale: boolean;
-	install_kind: "npm-global" | "mise" | "npx" | "docker" | "repo-dev" | "pinned" | "unknown";
+	install_kind:
+		| "npm-global"
+		| "pnpm-global"
+		| "mise"
+		| "npx"
+		| "docker"
+		| "repo-dev"
+		| "pinned"
+		| "unknown";
 	auto_update_eligible: boolean;
 	recommended_action: string;
 	error: string | null;


### PR DESCRIPTION
## Description
Adds evidence-backed pnpm-global release detection and explicit `codemem update install` support for pnpm 9 through 12. The installer re-proves global ownership before mutation, pins both public registries, installs exact matching Codemem packages, and verifies package state plus the pnpm-owned launcher. Background auto-install remains npm-global-only.

## Type of Change

- [x] 🚀 Feature (new functionality)
- [ ] 🐛 Bug fix (fixes an issue)
- [ ] 📚 Documentation (docs-only change)
- [ ] 🔧 Maintenance (refactor, chore, CI, etc.)
- [ ] 🧪 Testing (test-only changes)

## Testing

- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes
- [x] Manually verified changes work as expected

Also ran `pnpm run build`, release tests, adapter-normalizer tests, CI workflow tests, and disposable pnpm-global upgrade rehearsals. Full Vitest result: 280 files passed, 6,838 tests passed, 3 todo.

## Checklist

- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] No new warnings introduced