### PR TITLE
feat(core): treat delegated briefs as extraction context

### DIFF
--- a/packages/core/src/capture-context.ts
+++ b/packages/core/src/capture-context.ts
@@ -129,13 +129,13 @@ export const MAX_DELEGATED_CONTEXT_CHARS = 800;
 export function boundedDelegatedBriefs(briefs: readonly string[]): string[] {
 	let remaining = MAX_DELEGATED_CONTEXT_CHARS;
 	const bounded: string[] = [];
-	for (const brief of briefs.slice(-4)) {
+	for (const brief of briefs.slice(-4).reverse()) {
 		// Strip complete private regions before any cut can split their markers.
 		const text = stripPrivate(brief).slice(0, remaining);
 		remaining -= text.length;
 		if (text) bounded.push(text);
 	}
-	return bounded;
+	return bounded.reverse();
 }
 
 export function promptOriginLabel(event: Record<string, unknown>): string {

--- a/packages/core/src/delegated-brief-corrections.test.ts
+++ b/packages/core/src/delegated-brief-corrections.test.ts
@@ -1,0 +1,196 @@
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	boundedDelegatedBriefs,
+	DELEGATED_BRIEF_LABEL,
+	isDelegatedBrief,
+} from "./capture-context.js";
+import { budgetToolEvents } from "./ingest-events.js";
+import type { IngestOptions } from "./ingest-pipeline.js";
+import { buildObserverPrompt, truncateObserverTranscript } from "./ingest-prompts.js";
+import { ObserverClient } from "./observer-client.js";
+import { flushRawEvents } from "./raw-event-flush.js";
+import { ingestRawEvents } from "./raw-event-ingest.js";
+import { MemoryStore } from "./store.js";
+
+const provenance = (text: string) => ({
+	version: 1,
+	host: "opencode-v1",
+	origin: "delegated_brief",
+	parent_session_id: "parent",
+	child_session_id: "child",
+	task_call_id: "task",
+	message_id: "message",
+	requested_agent: "explore",
+	current_agent: "explore",
+	brief_sha256: createHash("sha256").update(text).digest("hex"),
+});
+
+// Exercise the real observe()/clipping path, replacing only the transport. Skipping
+// construction avoids reading any provider credentials or changing configuration.
+function clippingObserver(maxChars: number) {
+	const postClip = vi.fn(async (_system: string, _user: string) => {
+		throw new Error("captured after clipping");
+	});
+	const client = Object.assign(Object.create(ObserverClient.prototype), {
+		maxChars,
+		runtime: "test",
+		_callOnce: postClip,
+		getStatus: () => ({
+			provider: "test",
+			model: "fixture",
+			runtime: "test",
+			auth: { source: "none", type: "none", hasToken: false },
+		}),
+	}) as ObserverClient;
+	return { client, postClip };
+}
+
+describe("prior brief budgets through actual observer clipping", () => {
+	it.each([4000, 12000, 30000])(
+		"preserves the entire baseline evidence prefix at cap %i",
+		async (maxChars) => {
+			const toolEvents = budgetToolEvents(
+				[
+					{
+						toolName: "read",
+						toolInput: { path: "queue.ts" },
+						toolOutput: `NEW_TOOL_EVIDENCE ${"queue entries survive invalidation. ".repeat(300)}`,
+						toolError: null,
+						timestamp: null,
+						cwd: null,
+					},
+				],
+				8000,
+				30,
+			);
+			const input = {
+				project: "fixture",
+				userPrompt: "Report observed queue behavior.",
+				promptNumber: 1,
+				transcript: truncateObserverTranscript("Assistant: inspecting the queue. ".repeat(30), 400),
+				toolEvents,
+				includeSummary: true,
+				lastAssistantMessage: "NEW_ASSISTANT_EVIDENCE",
+				diffSummary: "",
+				recentFiles: "",
+			};
+			const baseline = buildObserverPrompt(input);
+			const withBriefs = buildObserverPrompt({
+				...input,
+				delegatedBriefs: Array(4).fill("old instructions ".repeat(1000)),
+			});
+			expect(withBriefs.system).toBe(baseline.system);
+			expect(withBriefs.user.startsWith(baseline.user)).toBe(true);
+			expect(withBriefs.user.length - baseline.user.length).toBeLessThanOrEqual(800);
+			const { client, postClip } = clippingObserver(maxChars);
+			await expect(client.observe(baseline.system, baseline.user)).rejects.toThrow(
+				"captured after clipping",
+			);
+			await expect(client.observe(withBriefs.system, withBriefs.user)).rejects.toThrow(
+				"captured after clipping",
+			);
+			const original = postClip.mock.calls[0]?.[1] ?? "";
+			const recovered = postClip.mock.calls[1]?.[1] ?? "";
+			expect(original).toContain("NEW_TOOL_EVIDENCE");
+			expect(recovered.startsWith(original)).toBe(true);
+		},
+	);
+
+	it("sanitizes complete private regions before imposing the aggregate cap", () => {
+		const brief = `Inspect queue. <private>${"SYNTHETIC_PRIVATE_MARKER".repeat(200)}</private> VISIBLE_AFTER_PRIVATE`;
+		expect(boundedDelegatedBriefs([brief])).toEqual(["Inspect queue.  VISIBLE_AFTER_PRIVATE"]);
+	});
+});
+
+let directory: string;
+let store: MemoryStore;
+beforeEach(() => {
+	directory = mkdtempSync(join(tmpdir(), "codemem-brief-corrections-"));
+	store = new MemoryStore(join(directory, "test.sqlite"));
+});
+afterEach(() => {
+	store.close();
+	rmSync(directory, { recursive: true, force: true });
+});
+
+async function retainBrief(text: string) {
+	store.recordRawEvent({
+		opencodeSessionId: "child",
+		eventId: "brief",
+		eventType: "user_prompt",
+		payload: { type: "user_prompt", prompt_text: text },
+		captureContext: provenance(text),
+	});
+	await flushRawEvents(store, { observer: { observe: vi.fn() } } as unknown as IngestOptions, {
+		opencodeSessionId: "child",
+	});
+}
+
+function addFinding(stream: string, output: string, eventId = "finding") {
+	store.recordRawEvent({
+		opencodeSessionId: stream,
+		eventId,
+		eventType: "tool.execute.after",
+		payload: {
+			type: "tool.execute.after",
+			tool: "read",
+			args: { path: "queue.ts" },
+			result: output,
+		},
+	});
+}
+
+describe("recovered brief pipeline regressions", () => {
+	it("keeps current evidence through real clipping when the prior brief is large", async () => {
+		await retainBrief("Earlier instructions. ".repeat(1000));
+		const finding = `NEW_TOOL_EVIDENCE ${"Queue entries survive invalidation. ".repeat(400)}`;
+		addFinding("baseline", finding);
+		addFinding("child", finding);
+		addFinding("baseline", `SECOND_TOOL_EVIDENCE ${finding}`, "finding-two");
+		addFinding("child", `SECOND_TOOL_EVIDENCE ${finding}`, "finding-two");
+		const { client, postClip } = clippingObserver(12000);
+		for (const stream of ["baseline", "child"]) {
+			await expect(
+				flushRawEvents(store, { observer: client }, { opencodeSessionId: stream }),
+			).rejects.toThrow("captured after clipping");
+		}
+		expect(postClip.mock.calls[0]?.[1]).toContain("NEW_TOOL_EVIDENCE");
+		expect(postClip.mock.calls[0]?.[1]).toContain("SECOND_TOOL_EVIDENCE");
+		expect(postClip.mock.calls[1]?.[1]).toBe(postClip.mock.calls[0]?.[1]);
+	});
+
+	it("recovers sanitized short context after new evidence while keeping raw history intact", async () => {
+		const text = `Investigate queue. <private>${"SYNTHETIC_PRIVATE_MARKER".repeat(200)}</private> VISIBLE_AFTER_PRIVATE`;
+		await retainBrief(text);
+		addFinding("child", "NEW_TOOL_EVIDENCE: queue entries survive invalidation.");
+		const { client, postClip } = clippingObserver(30000);
+		await expect(
+			flushRawEvents(store, { observer: client }, { opencodeSessionId: "child" }),
+		).rejects.toThrow("captured after clipping");
+		const user = postClip.mock.calls[0]?.[1] ?? "";
+		expect(user).toContain("VISIBLE_AFTER_PRIVATE");
+		expect(user).not.toContain("SYNTHETIC_PRIVATE_MARKER");
+		expect(user.indexOf(DELEGATED_BRIEF_LABEL)).toBeGreaterThan(user.indexOf("NEW_TOOL_EVIDENCE"));
+		expect(store.rawEventsSinceBySeq("child")[0]?.prompt_text).toBe(text);
+	});
+
+	it("keeps sanitizer-induced digest mismatches unknown and retains valid sanitized raw input", () => {
+		const text = "Inspect <private>SYNTHETIC_PRIVATE_MARKER</private> queue.";
+		ingestRawEvents(store, {
+			source: "opencode",
+			session_stream_id: "child",
+			event_id: "sanitized",
+			event_type: "user_prompt",
+			payload: { type: "user_prompt", prompt_text: text },
+			capture_context: provenance(text),
+		});
+		const event = store.rawEventsSinceBySeq("child")[0];
+		expect(event?.prompt_text).toBe("Inspect  queue.");
+		expect(event).not.toHaveProperty("capture_context");
+		expect(isDelegatedBrief(event ?? {})).toBe(false);
+	});
+});

--- a/packages/core/src/delegated-brief-flush.test.ts
+++ b/packages/core/src/delegated-brief-flush.test.ts
@@ -1,0 +1,325 @@
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	DELEGATED_BRIEF_LABEL,
+	isDelegatedBrief,
+	isDelegatedBriefOnlyBatch,
+} from "./capture-context.js";
+import { connect, ensureAdditiveSchemaCompatibility } from "./db.js";
+import type { IngestOptions } from "./ingest-pipeline.js";
+import { flushRawEvents } from "./raw-event-flush.js";
+import { ingestRawEvents } from "./raw-event-ingest.js";
+import { MemoryStore } from "./store.js";
+
+const brief =
+	"Investigate whether the cache invalidation path loses retries; report actual findings.";
+const getStatus = () => ({
+	provider: "test",
+	model: "test",
+	runtime: "test",
+	auth: { source: "none", type: "none", hasToken: false },
+});
+const context = {
+	version: 1,
+	host: "opencode-v1",
+	origin: "delegated_brief",
+	parent_session_id: "parent",
+	child_session_id: "child",
+	task_call_id: "call-1",
+	message_id: "msg-1",
+	requested_agent: "explore",
+	current_agent: "explore",
+	brief_sha256: createHash("sha256").update(brief).digest("hex"),
+};
+const envelope = {
+	source: "opencode",
+	session_stream_id: "child",
+	event_id: "brief-1",
+	event_type: "user_prompt",
+	ts_wall_ms: 100,
+	ts_mono_ms: 5,
+	payload: {
+		type: "user_prompt",
+		prompt_text: brief,
+		_adapter: {
+			schema_version: "1.0",
+			source: "opencode",
+			session_id: "child",
+			event_type: "prompt",
+			payload: { text: brief },
+		},
+	},
+	capture_context: context,
+};
+
+let directory: string;
+let dbPath: string;
+let store: MemoryStore;
+beforeEach(() => {
+	directory = mkdtempSync(join(tmpdir(), "codemem-brief-"));
+	dbPath = join(directory, "test.sqlite");
+	store = new MemoryStore(dbPath);
+});
+afterEach(() => {
+	if (store.db.open) store.close();
+	rmSync(directory, { recursive: true, force: true });
+});
+
+describe("delegated brief raw-event contract", () => {
+	it("adds a nullable column during compatibility migration without changing IDs or payloads", () => {
+		// Arrange
+		ingestRawEvents(store, envelope);
+		store.db.exec("DROP INDEX idx_raw_events_capture_context");
+		store.db.exec("ALTER TABLE raw_events DROP COLUMN capture_context_json");
+		const before = store.db.prepare("SELECT * FROM raw_events").all();
+		store.close();
+		const db = connect(dbPath);
+
+		// Act
+		const after = (() => {
+			try {
+				ensureAdditiveSchemaCompatibility(db);
+				return db.prepare("SELECT * FROM raw_events").all() as Record<string, unknown>[];
+			} finally {
+				if (db.open) db.close();
+			}
+		})();
+
+		// Assert
+		expect(after).toEqual(
+			before.map((row) => ({ ...(row as object), capture_context_json: null })),
+		);
+		store = new MemoryStore(dbPath);
+		expect(store.rawEventsSinceBySeq("child")[0]).not.toHaveProperty("capture_context");
+	});
+
+	it("freezes first accepted provenance on duplicates, including unknown-first retries", () => {
+		ingestRawEvents(store, envelope);
+		const before = store.db.prepare("SELECT * FROM raw_events").all();
+		expect(
+			ingestRawEvents(store, {
+				...envelope,
+				capture_context: { ...context, message_id: "different" },
+			}).skipped,
+		).toBe(1);
+		expect(store.db.prepare("SELECT * FROM raw_events").all()).toEqual(before);
+		ingestRawEvents(store, { ...envelope, event_id: "unknown-first", capture_context: null });
+		ingestRawEvents(store, { ...envelope, event_id: "unknown-first" });
+		expect(store.rawEventsSinceBySeq("child")[1]).not.toHaveProperty("capture_context");
+	});
+
+	it("keeps generated IDs identical with and without optional context", () => {
+		const { event_id: _id, ...withoutId } = envelope;
+		ingestRawEvents(store, { ...withoutId, capture_context: null });
+		const before = store.db
+			.prepare("SELECT event_id, event_seq, payload_json FROM raw_events")
+			.all();
+		expect(ingestRawEvents(store, withoutId).skipped).toBe(1);
+		expect(
+			store.db.prepare("SELECT event_id, event_seq, payload_json FROM raw_events").all(),
+		).toEqual(before);
+	});
+
+	it.each([
+		{ ...context, requested_agent: "review" },
+		{ ...context, child_session_id: "sibling" },
+		{ ...context, brief_sha256: "incorrect" },
+		{ origin: "delegated_brief" },
+		{ version: 1, origin: "human" },
+		"invalid",
+	])("retains valid raw data with invalid optional context %#", (captureContext) => {
+		expect(ingestRawEvents(store, { ...envelope, capture_context: captureContext }).inserted).toBe(
+			1,
+		);
+		expect(store.rawEventsSinceBySeq("child")[0]).not.toHaveProperty("capture_context");
+		expect(store.db.prepare("SELECT payload_json FROM raw_events").get()).toEqual({
+			payload_json: JSON.stringify(envelope.payload),
+		});
+	});
+
+	it("ignores forged similarly named provenance fields on direct ingress", () => {
+		// Arrange
+		const forged = {
+			...envelope,
+			event_id: "forged-fields",
+			capture_context: undefined,
+			captureContext: context,
+			capture_context_json: JSON.stringify(context),
+		};
+
+		// Act
+		ingestRawEvents(store, forged);
+
+		// Assert
+		const row = store.db
+			.prepare("SELECT event_id, event_seq, payload_json, capture_context_json FROM raw_events")
+			.get();
+		expect(row).toEqual({
+			event_id: "forged-fields",
+			event_seq: 0,
+			payload_json: JSON.stringify(envelope.payload),
+			capture_context_json: null,
+		});
+	});
+});
+
+describe("delegated brief classification", () => {
+	it("recognizes only the complete validated provenance shape", () => {
+		// Arrange
+		const validated = { type: "user_prompt", prompt_text: brief, capture_context: context };
+		const callerClaim = {
+			type: "user_prompt",
+			prompt_text: brief,
+			capture_context: { origin: "delegated_brief" },
+		};
+
+		// Act
+		const classification = {
+			validatedEvent: isDelegatedBrief(validated),
+			validatedBatch: isDelegatedBriefOnlyBatch([validated]),
+			callerEvent: isDelegatedBrief(callerClaim),
+			callerBatch: isDelegatedBriefOnlyBatch([callerClaim]),
+		};
+
+		// Assert
+		expect(classification).toEqual({
+			validatedEvent: true,
+			validatedBatch: true,
+			callerEvent: false,
+			callerBatch: false,
+		});
+	});
+});
+
+describe("delegated brief extraction", () => {
+	it("completes brief-only batches without observer, memories, or retry loops", async () => {
+		const observe = vi.fn();
+		ingestRawEvents(store, envelope);
+		store.recordRawEvent({
+			opencodeSessionId: "child",
+			eventId: "idle",
+			eventType: "session.idle",
+			payload: {},
+		});
+		const options = { observer: { observe } } as unknown as IngestOptions;
+		expect(await flushRawEvents(store, options, { opencodeSessionId: "child" })).toEqual({
+			flushed: 2,
+			updatedState: 1,
+		});
+		expect(await flushRawEvents(store, options, { opencodeSessionId: "child" })).toEqual({
+			flushed: 0,
+			updatedState: 0,
+		});
+		expect(observe).not.toHaveBeenCalled();
+		expect(store.db.prepare("SELECT COUNT(*) AS count FROM memory_items").get()).toEqual({
+			count: 0,
+		});
+		expect(store.rawEventsSinceBySeq("child")).toHaveLength(2);
+		expect(
+			store.db.prepare("SELECT status, attempt_count FROM raw_event_flush_batches").get(),
+		).toEqual({ status: "completed", attempt_count: 1 });
+	});
+
+	it("recovers earlier same-stream instructions after restart for actual findings", async () => {
+		ingestRawEvents(store, envelope);
+		await flushRawEvents(store, { observer: { observe: vi.fn() } } as unknown as IngestOptions, {
+			opencodeSessionId: "child",
+		});
+		ingestRawEvents(store, { ...envelope, source: "claude", event_id: "other-host" });
+		store.close();
+		store = new MemoryStore(dbPath);
+		store.recordRawEvent({
+			opencodeSessionId: "child",
+			eventId: "ordinary-user-prompt",
+			eventType: "user_prompt",
+			payload: {
+				type: "user_prompt",
+				prompt_text: "Check the queue implementation and report the observed behavior.",
+			},
+		});
+		store.recordRawEvent({
+			opencodeSessionId: "child",
+			eventId: "finding",
+			eventType: "tool.execute.after",
+			payload: {
+				type: "tool.execute.after",
+				tool: "read",
+				args: { filePath: "src/cache.ts" },
+				result: "Retry entries survive invalidation in the pending queue.",
+			},
+		});
+		const observe = vi.fn(async (_system: string, _user: string) => ({
+			raw: `<observation><type>discovery</type><title>Retry entries survive cache invalidation</title><narrative>The pending queue retains retry entries independently of cache invalidation.</narrative><facts><fact>Invalidation leaves the pending queue intact.</fact></facts><concepts><concept>how-it-works</concept></concepts></observation>`,
+			parsed: null,
+			provider: "test",
+			model: "test",
+		}));
+		await flushRawEvents(store, { observer: { observe, getStatus } } as unknown as IngestOptions, {
+			opencodeSessionId: "child",
+		});
+		expect(observe).toHaveBeenCalledTimes(1);
+		const observerInput = observe.mock.calls[0]?.[1];
+		expect(observerInput).toContain(brief);
+		expect(observerInput).toContain(DELEGATED_BRIEF_LABEL);
+		expect(observerInput).toContain(
+			"User: Check the queue implementation and report the observed behavior.",
+		);
+		expect(observerInput).not.toContain(
+			`${DELEGATED_BRIEF_LABEL}: Check the queue implementation and report the observed behavior.`,
+		);
+		expect(store.db.prepare("SELECT COUNT(*) AS count FROM memory_items").get()).toEqual({
+			count: 1,
+		});
+		expect(store.priorDelegatedBriefEvents("sibling", "opencode", 999)).toEqual([]);
+		expect(store.priorDelegatedBriefEvents("child", "claude", 999)).toEqual([]);
+	});
+
+	it.each([null, { ...context, brief_sha256: "bad" }])(
+		"preserves normal extraction for unknown origin %#",
+		async (captureContext) => {
+			ingestRawEvents(store, { ...envelope, capture_context: captureContext });
+			const observe = vi.fn(async () => {
+				throw new Error("observer reached");
+			});
+			await expect(
+				flushRawEvents(store, { observer: { observe, getStatus } } as unknown as IngestOptions, {
+					opencodeSessionId: "child",
+				}),
+			).rejects.toThrow("observer reached");
+			expect(observe).toHaveBeenCalledTimes(1);
+		},
+	);
+});
+
+describe("mixed delegated batches", () => {
+	it.each([
+		{ type: "user_prompt", prompt_text: "Use a separate pending queue for retry ownership." },
+		{ type: "assistant_message", assistant_text: "The pending queue owns retry entries." },
+		{ type: "tool.execute.after", tool: "read", args: {}, result: "pending queue implementation" },
+		{ type: "assistant_usage", usage: { input_tokens: 12 } },
+		{ type: "session.idle", synthetic: true, result: "injected task result" },
+		{ type: "session.idle", parts: [{ type: "text", text: "synthetic result", synthetic: true }] },
+		{ type: "session.idle", future_result: { text: "unknown result shape" } },
+	])("keeps substantive or synthetic $type batches on the observer path", async (payload) => {
+		ingestRawEvents(store, envelope);
+		store.recordRawEvent({
+			opencodeSessionId: "child",
+			eventId: "substantive",
+			eventType: payload.type,
+			payload,
+		});
+		const observe = vi.fn(async (_system: string, user: string) => {
+			expect(user).toContain(DELEGATED_BRIEF_LABEL);
+			throw new Error("observer reached");
+		});
+		await expect(
+			flushRawEvents(store, { observer: { observe, getStatus } } as unknown as IngestOptions, {
+				opencodeSessionId: "child",
+			}),
+		).rejects.toThrow("observer reached");
+		expect(observe).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/core/src/delegated-context-backfill.regression.test.ts
+++ b/packages/core/src/delegated-context-backfill.regression.test.ts
@@ -1,0 +1,141 @@
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { DELEGATED_BRIEF_LABEL, type DelegatedBriefContext } from "./capture-context.js";
+import { ingestRawEvents } from "./raw-event-ingest.js";
+import { runSessionContextBackfillPass } from "./session-context-backfill.js";
+import { MemoryStore } from "./store.js";
+
+const cleanupPaths: string[] = [];
+
+function provenance(text: string): DelegatedBriefContext {
+	return {
+		version: 1,
+		host: "opencode-v1",
+		origin: "delegated_brief",
+		parent_session_id: "parent",
+		child_session_id: "child",
+		task_call_id: "task",
+		message_id: "message",
+		requested_agent: "explore",
+		current_agent: "explore",
+		brief_sha256: createHash("sha256").update(text).digest("hex"),
+	};
+}
+
+function createStore(): MemoryStore {
+	const directory = mkdtempSync(join(tmpdir(), "codemem-delegated-backfill-"));
+	cleanupPaths.push(directory);
+	return new MemoryStore(join(directory, "test.sqlite"));
+}
+
+function linkBackfillCandidate(store: MemoryStore): number {
+	const now = "2026-09-11T12:00:00.000Z";
+	const metadata = {
+		session_context: {
+			flusher: "raw_events",
+			source: "opencode",
+			streamId: "child",
+			opencodeSessionId: "child",
+			firstPrompt: "stale user classification",
+			promptCount: 0,
+		},
+	};
+	const result = store.db
+		.prepare(
+			`INSERT INTO sessions(started_at, cwd, project, user, tool_version, metadata_json)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+		)
+		.run(now, "/fixture", "fixture", "test", "raw_events", JSON.stringify(metadata));
+	const sessionId = Number(result.lastInsertRowid);
+	store.db
+		.prepare(
+			`INSERT INTO opencode_sessions(
+				source, stream_id, opencode_session_id, session_id, created_at
+			 ) VALUES (?, ?, ?, ?, ?)`,
+		)
+		.run("opencode", "child", "child", sessionId, now);
+	return sessionId;
+}
+
+afterEach(() => {
+	for (const path of cleanupPaths.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe("delegated provenance session-context backfill", () => {
+	it("keeps the validated sidecar and rebuilds a labeled first prompt", async () => {
+		// Arrange
+		const store = createStore();
+		const brief = "Inspect retry ownership and report observed findings.";
+		try {
+			ingestRawEvents(store, {
+				source: "opencode",
+				session_stream_id: "child",
+				event_id: "brief-event",
+				event_type: "user_prompt",
+				payload: { type: "user_prompt", prompt_text: brief },
+				capture_context: provenance(brief),
+			});
+			const sessionId = linkBackfillCandidate(store);
+			const sidecarBefore = store.db
+				.prepare("SELECT capture_context_json FROM raw_events WHERE event_id = ?")
+				.get("brief-event");
+
+			// Act
+			await runSessionContextBackfillPass(store.db, { batchSize: 10 });
+
+			// Assert
+			const row = store.db
+				.prepare("SELECT metadata_json FROM sessions WHERE id = ?")
+				.get(sessionId) as {
+				metadata_json: string;
+			};
+			const metadata = JSON.parse(row.metadata_json) as {
+				session_context: Record<string, unknown>;
+			};
+			const sidecarAfter = store.db
+				.prepare("SELECT capture_context_json FROM raw_events WHERE event_id = ?")
+				.get("brief-event");
+			expect({ firstPrompt: metadata.session_context.firstPrompt, sidecarAfter }).toEqual({
+				firstPrompt: `${DELEGATED_BRIEF_LABEL}: ${brief}`,
+				sidecarAfter: sidecarBefore,
+			});
+		} finally {
+			store.close();
+		}
+	});
+
+	it("keeps an ordinary prompt classified as user input", async () => {
+		// Arrange
+		const store = createStore();
+		const prompt = "Implement the approved retry fix.";
+		try {
+			ingestRawEvents(store, {
+				source: "opencode",
+				session_stream_id: "child",
+				event_id: "ordinary-event",
+				event_type: "user_prompt",
+				payload: { type: "user_prompt", prompt_text: prompt },
+			});
+			const sessionId = linkBackfillCandidate(store);
+
+			// Act
+			await runSessionContextBackfillPass(store.db, { batchSize: 10 });
+
+			// Assert
+			const row = store.db
+				.prepare("SELECT metadata_json FROM sessions WHERE id = ?")
+				.get(sessionId) as {
+				metadata_json: string;
+			};
+			const metadata = JSON.parse(row.metadata_json) as {
+				session_context: Record<string, unknown>;
+			};
+			expect(metadata.session_context.firstPrompt).toBe(prompt);
+		} finally {
+			store.close();
+		}
+	});
+});

--- a/packages/core/src/delegated-context-cap.regression.test.ts
+++ b/packages/core/src/delegated-context-cap.regression.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { DELEGATED_BRIEF_LABEL, MAX_DELEGATED_CONTEXT_CHARS } from "./capture-context.js";
+import { buildObserverPrompt } from "./ingest-prompts.js";
+
+const label = `\n\n[${DELEGATED_BRIEF_LABEL}; earlier in this raw stream]\n`;
+const bodyBudget = MAX_DELEGATED_CONTEXT_CHARS - label.length;
+
+function appendedBody(brief: string): string {
+	const prompt = buildObserverPrompt({
+		project: "fixture",
+		userPrompt: "Report observed behavior.",
+		promptNumber: 1,
+		transcript: "",
+		toolEvents: [],
+		lastAssistantMessage: null,
+		includeSummary: true,
+		diffSummary: "",
+		recentFiles: "",
+		delegatedBriefs: [brief],
+	});
+	return prompt.user.slice(prompt.user.indexOf(label) + label.length);
+}
+
+describe("delegated observer-context XML cap", () => {
+	it("keeps an XML entity complete when it fits before the boundary", () => {
+		// Arrange
+		const brief = `${"x".repeat(bodyBudget - 5)}&`;
+
+		// Act
+		const body = appendedBody(brief);
+
+		// Assert
+		expect(body).toBe(`${"x".repeat(bodyBudget - 5)}&amp;`);
+	});
+
+	it("does not split an escaped XML entity at the boundary", () => {
+		// Arrange
+		const brief = `${"x".repeat(bodyBudget - 1)}&`;
+
+		// Act
+		const body = appendedBody(brief);
+
+		// Assert
+		expect({
+			withinCap: label.length + body.length <= MAX_DELEGATED_CONTEXT_CHARS,
+			body,
+		}).toEqual({
+			withinCap: true,
+			body: "x".repeat(bodyBudget - 1),
+		});
+	});
+
+	it("keeps the newest corrections when an older brief exhausts the cap", () => {
+		const prompt = buildObserverPrompt({
+			project: "fixture",
+			userPrompt: "Report observed behavior.",
+			promptNumber: 1,
+			transcript: "",
+			toolEvents: [],
+			lastAssistantMessage: null,
+			includeSummary: true,
+			diffSummary: "",
+			recentFiles: "",
+			delegatedBriefs: [
+				`STALE_BRIEF ${"x".repeat(MAX_DELEGATED_CONTEXT_CHARS)} STALE_TAIL`,
+				"CORRECTION_BRIEF use the bounded queue",
+				"NEWEST_BRIEF verify the retry owner",
+			],
+		});
+		const body = prompt.user.slice(prompt.user.indexOf(label) + label.length);
+
+		expect({
+			withinCap: label.length + body.length <= MAX_DELEGATED_CONTEXT_CHARS,
+			keepsCompleteStaleBrief: body.includes("STALE_TAIL"),
+			keepsCorrection: body.includes("CORRECTION_BRIEF"),
+			keepsNewest: body.includes("NEWEST_BRIEF"),
+			chronological: body.indexOf("CORRECTION_BRIEF") < body.indexOf("NEWEST_BRIEF"),
+		}).toEqual({
+			withinCap: true,
+			keepsCompleteStaleBrief: false,
+			keepsCorrection: true,
+			keepsNewest: true,
+			chronological: true,
+		});
+	});
+});

--- a/packages/core/src/delegated-context-transience.regression.test.ts
+++ b/packages/core/src/delegated-context-transience.regression.test.ts
@@ -1,0 +1,84 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { DELEGATED_BRIEF_LABEL } from "./capture-context.js";
+import { type IngestOptions, ingest } from "./ingest-pipeline.js";
+import { MemoryStore } from "./store.js";
+
+describe("delegated observer context lifetime", () => {
+	it("passes prior briefs to the observer without persisting them in session metadata", async () => {
+		// Arrange
+		const directory = mkdtempSync(join(tmpdir(), "codemem-delegated-transience-"));
+		const store = new MemoryStore(join(directory, "test.sqlite"));
+		const brief = "Inspect retry ownership; report only observed findings.";
+		const observe = vi.fn(async () => ({
+			raw: `<observation><type>discovery</type><title>Queue ownership is explicit</title><narrative>The pending queue retains retry entries after invalidation.</narrative><facts><fact>Retry entries remain in the pending queue.</fact></facts><concepts><concept>how-it-works</concept></concepts></observation>`,
+			parsed: null,
+			provider: "test",
+			model: "fixture",
+		}));
+		const options = {
+			observer: {
+				observe,
+				getStatus: () => ({
+					provider: "test",
+					model: "fixture",
+					runtime: "test",
+					auth: { source: "none", type: "none", hasToken: false },
+				}),
+			},
+		} as unknown as IngestOptions;
+
+		try {
+			// Act
+			await ingest(
+				{
+					cwd: "/fixture",
+					project: "fixture",
+					events: [
+						{
+							type: "tool.execute.after",
+							tool: "read",
+							args: { filePath: "/fixture/src/queue.ts" },
+							result: "The pending queue retains retry entries after invalidation.",
+						},
+					],
+					sessionContext: {
+						flusher: "raw_events",
+						source: "opencode",
+						streamId: "child",
+						opencodeSessionId: "child",
+						firstPrompt: "Report the queue finding.",
+						promptCount: 1,
+						toolCount: 1,
+						delegatedBriefs: [brief],
+					},
+				},
+				store,
+				options,
+			);
+
+			// Assert
+			const observerInput = observe.mock.calls[0]?.[1] ?? "";
+			const row = store.db.prepare("SELECT metadata_json FROM sessions LIMIT 1").get() as {
+				metadata_json: string;
+			};
+			const metadata = JSON.parse(row.metadata_json) as {
+				session_context?: Record<string, unknown>;
+			};
+			expect({
+				observerHasBrief: observerInput.includes(brief),
+				observerHasLabel: observerInput.includes(DELEGATED_BRIEF_LABEL),
+				durableBriefs: metadata.session_context?.delegatedBriefs,
+			}).toEqual({
+				observerHasBrief: true,
+				observerHasLabel: true,
+				durableBriefs: undefined,
+			});
+		} finally {
+			store.close();
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/core/src/ingest-pipeline.ts
+++ b/packages/core/src/ingest-pipeline.ts
@@ -21,6 +21,7 @@
 
 import { and, eq, isNull, lt } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
+import { boundedDelegatedBriefs } from "./capture-context.js";
 import { normalizeProjectLabel } from "./claude-hooks.js";
 import { fromJson, toJson } from "./db.js";
 import {
@@ -331,6 +332,23 @@ async function observeRawEventOutput(
 	}
 }
 
+function priorDelegatedBriefsForObserver(context: SessionContext): string[] | undefined {
+	if (
+		context.source !== "opencode" ||
+		context.flusher !== "raw_events" ||
+		!context.delegatedBriefs?.length
+	)
+		return undefined;
+	return boundedDelegatedBriefs(context.delegatedBriefs);
+}
+
+function sessionContextForStorage(
+	context: SessionContext,
+): Omit<SessionContext, "delegatedBriefs"> {
+	const { delegatedBriefs: _delegatedBriefs, ...persistent } = context;
+	return persistent;
+}
+
 /**
  * Process a batch of raw coding session events through the full ingest pipeline.
  *
@@ -362,7 +380,7 @@ export async function ingest(
 		source: "plugin",
 		event_count: events.length,
 		started_at: payload.startedAt,
-		session_context: sessionContext,
+		session_context: sessionContextForStorage(sessionContext),
 	};
 	const sessionId =
 		sessionContext.flusher === "raw_events" && sessionContext.opencodeSessionId
@@ -486,6 +504,7 @@ export async function ingest(
 
 		const transcriptBudget = Math.max(1500, Math.min(5000, Math.floor(observerMaxChars * 0.4)));
 		const observerContext: ObserverContext = {
+			delegatedBriefs: priorDelegatedBriefsForObserver(sessionContext),
 			project,
 			userPrompt: observerPrompt,
 			promptNumber,
@@ -962,7 +981,7 @@ function endSession(
 		post: extraPost,
 		source: "plugin",
 		event_count: eventCount,
-		session_context: sessionContext,
+		session_context: sessionContextForStorage(sessionContext),
 	});
 }
 

--- a/packages/core/src/ingest-prompts.ts
+++ b/packages/core/src/ingest-prompts.ts
@@ -5,6 +5,11 @@
  * sent to the observer LLM that extracts memories from session transcripts.
  */
 
+import {
+	boundedDelegatedBriefs,
+	DELEGATED_BRIEF_LABEL,
+	MAX_DELEGATED_CONTEXT_CHARS,
+} from "./capture-context.js";
 import type { ObserverContext, ToolEvent } from "./ingest-types.js";
 import { OBSERVER_CONCEPTS } from "./observer-concepts.js";
 
@@ -332,6 +337,41 @@ function buildObserverSystemPrompt(
 	return systemBlocks.join("\n\n").trim();
 }
 
+function appendPriorDelegatedBriefs(user: string, briefs: readonly string[]): string {
+	const label = `\n\n[${DELEGATED_BRIEF_LABEL}; earlier in this raw stream]\n`;
+	const body = escapedDelegatedBriefsWithinBudget(
+		boundedDelegatedBriefs(briefs),
+		MAX_DELEGATED_CONTEXT_CHARS - label.length,
+	);
+	if (!body) return user;
+	return `${user}${label}${body}`;
+}
+
+function escapedDelegatedBriefsWithinBudget(briefs: readonly string[], budget: number): string {
+	let remaining = budget;
+	const bounded: string[] = [];
+	for (const brief of briefs.slice().reverse()) {
+		const separatorLength = bounded.length === 0 ? 0 : 2;
+		if (remaining <= separatorLength) break;
+		const text = escapeXmlWithinBudget(brief, remaining - separatorLength);
+		if (!text) continue;
+		bounded.push(text);
+		remaining -= separatorLength + text.length;
+	}
+	return bounded.reverse().join("\n\n");
+}
+
+function escapeXmlWithinBudget(text: string, budget: number): string {
+	let escaped = "";
+	// Escape whole code points so neither XML entities nor surrogate pairs are split.
+	for (const character of text.toWellFormed()) {
+		const entity = escapeXml(character);
+		if (escaped.length + entity.length > budget) break;
+		escaped += entity;
+	}
+	return escaped;
+}
+
 /**
  * Build the observer prompt from session context.
  *
@@ -397,7 +437,10 @@ export function buildObserverPrompt(
 		);
 	}
 
-	const user = userBlocks.join("\n\n").trim();
+	const user = appendPriorDelegatedBriefs(
+		userBlocks.join("\n\n").trim(),
+		context.delegatedBriefs ?? [],
+	);
 
 	return { system, user };
 }

--- a/packages/core/src/raw-event-flush.ts
+++ b/packages/core/src/raw-event-flush.ts
@@ -9,6 +9,12 @@
  */
 
 import { extractApplyPatchPaths, MUTATING_TOOL_NAMES } from "./apply-patch.js";
+import {
+	boundedDelegatedBriefs,
+	isDelegatedBrief,
+	isDelegatedBriefOnlyBatch,
+	promptContextText,
+} from "./capture-context.js";
 import { extractAdapterEvent, projectAdapterToolEvent } from "./ingest-events.js";
 import {
 	type IngestOptions,
@@ -223,7 +229,7 @@ export function buildSessionContext(events: Record<string, unknown>[]): SessionC
 		if (e.type !== "user_prompt") continue;
 		const text = e.prompt_text;
 		if (typeof text === "string" && text.trim()) {
-			firstPrompt = text.trim();
+			firstPrompt = promptContextText(e, text.trim());
 			break;
 		}
 	}
@@ -278,6 +284,43 @@ function isTerminalLowSignalSession(
 // Main flush function
 // ---------------------------------------------------------------------------
 
+function buildFlushSessionContext(
+	store: MemoryStore,
+	events: Record<string, unknown>[],
+	{
+		opencodeSessionId,
+		source,
+		startEventSeq,
+		lastEventSeq,
+		batchId,
+	}: {
+		opencodeSessionId: string;
+		source: string;
+		startEventSeq: number;
+		lastEventSeq: number;
+		batchId: number;
+	},
+): SessionContext {
+	const context = buildSessionContext(normalizeEventsForSessionContext(events));
+	context.opencodeSessionId = opencodeSessionId;
+	context.source = source;
+	context.streamId = opencodeSessionId;
+	context.flusher = "raw_events";
+	context.flushBatch = {
+		batch_id: batchId,
+		start_event_seq: startEventSeq,
+		end_event_seq: lastEventSeq,
+	};
+	const priorBriefs = boundedDelegatedBriefs(
+		store
+			.priorDelegatedBriefEvents(opencodeSessionId, source, startEventSeq)
+			.filter(isDelegatedBrief)
+			.map((event) => String(event.prompt_text)),
+	);
+	if (priorBriefs.length) context.delegatedBriefs = priorBriefs;
+	return context;
+}
+
 export interface FlushRawEventsOptions {
 	opencodeSessionId: string;
 	source?: string;
@@ -286,6 +329,28 @@ export interface FlushRawEventsOptions {
 	startedAt?: string | null;
 	maxEvents?: number | null;
 	throughEventSeq?: number | null;
+}
+
+function completeContextOnlyBatch(
+	store: MemoryStore,
+	events: Record<string, unknown>[],
+	{
+		source,
+		opencodeSessionId,
+		batchId,
+		lastEventSeq,
+	}: {
+		source: string;
+		opencodeSessionId: string;
+		batchId: number;
+		lastEventSeq: number;
+	},
+): { flushed: number; updatedState: number } | null {
+	if (source !== "opencode" || !isDelegatedBriefOnlyBatch(events)) return null;
+	if (!store.claimRawEventFlushBatch(batchId)) return { flushed: 0, updatedState: 0 };
+	store.updateRawEventFlushBatchStatus(batchId, "completed");
+	store.updateRawEventFlushState(opencodeSessionId, lastEventSeq, source);
+	return { flushed: events.length, updatedState: 1 };
 }
 
 /**
@@ -370,6 +435,13 @@ export async function flushRawEvents(
 		store.updateRawEventFlushState(opencodeSessionId, lastEventSeq, source);
 		return { flushed: 0, updatedState: 1 };
 	}
+	const contextOnly = completeContextOnlyBatch(store, events, {
+		source,
+		opencodeSessionId,
+		batchId,
+		lastEventSeq,
+	});
+	if (contextOnly) return contextOnly;
 
 	// Give up after too many failed attempts — mark batch as permanently failed
 	// and advance the cursor so the pipeline isn't blocked forever.
@@ -404,21 +476,13 @@ export async function flushRawEvents(
 		return { flushed: 0, updatedState: 0 };
 	}
 
-	// Build session context. Claude Code raw events arrive as `claude.hook`
-	// with an adapter envelope; normalize them to the flat user_prompt /
-	// tool.execute.after shapes before scanning so promptCount, toolCount,
-	// firstPrompt, filesRead, and filesModified are populated correctly.
-	const normalizedForContext = normalizeEventsForSessionContext(events);
-	const sessionContext: SessionContext = buildSessionContext(normalizedForContext);
-	sessionContext.opencodeSessionId = opencodeSessionId;
-	sessionContext.source = source;
-	sessionContext.streamId = opencodeSessionId;
-	sessionContext.flusher = "raw_events";
-	sessionContext.flushBatch = {
-		batch_id: batchId,
-		start_event_seq: startEventSeq,
-		end_event_seq: lastEventSeq,
-	};
+	const sessionContext = buildFlushSessionContext(store, events, {
+		opencodeSessionId,
+		source,
+		startEventSeq,
+		lastEventSeq,
+		batchId,
+	});
 
 	if (isTerminalLowSignalSession(events, sessionContext)) {
 		store.updateRawEventFlushBatchStatus(batchId, "completed");


### PR DESCRIPTION
## Description
Use verified delegated briefs as extraction context. Proven brief-only batches complete without observer calls or durable memories; later substantive findings receive bounded, sanitized prior brief context after new evidence.

This remains inert in production until the final adapter-producer PR lands.

## Type of Change
- [x] 🐛 Bug fix (fixes an issue)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes

Full `pnpm run check`: 6,880 passed, 3 existing TODOs. Covers brief-only, mixed, backfill, transience, clipping, XML safety and observer failure paths.

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] No new warnings introduced