### PR TITLE
feat(cli): report context-only extraction replay outcomes

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -141,6 +141,20 @@ codemem status --db-path ./codemem.sqlite --config ./codemem.json
   2. workspace-scoped config derived from `CODEMEM_RUNTIME_ROOT` or `CODEMEM_WORKSPACE_ID`
   3. legacy global config (`~/.config/codemem/config.json` or `~/.config/codemem/config.jsonc`)
 
+## Extraction replay and benchmarks
+
+Proven delegated brief-only batches produce a context-only outcome instead of an
+observer evaluation. `memory extraction-replay --json` returns
+`status: "context_only"`, `code: "delegated_brief_context_only"`, `evaluated: false`,
+the batch/scenario IDs and an explanatory message, with exit status zero.
+
+`memory extraction-benchmark` continues past context-only batches and records each
+skipped iteration in `summary.contextOnlySkips`. `summary.contextOnlySkipped` counts
+those skips, while `summary.scheduledTotal` counts every scheduled batch/iteration.
+`summary.total`, `runs`, failure counts and quality, stability, output, cost and
+latency metrics cover actual observer attempts only; an all-context-only benchmark
+has no evaluated runs and null rates, rather than a quality pass.
+
 ## Observer auth configuration
 
 - Runtime choices are `api_http`, `claude_sidecar`, and `codex_sidecar`.

--- a/packages/cli/src/commands/memory-context-only.test.ts
+++ b/packages/cli/src/commands/memory-context-only.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const coreMocks = vi.hoisted(() => ({
+	getExtractionBenchmarkProfile: vi.fn(),
+	replayBatchExtraction: vi.fn(),
+	replayBatchExtractionWithTierRouting: vi.fn(),
+}));
+
+vi.mock("@codemem/core", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@codemem/core")>();
+	class ObserverClientStub {
+		provider = "test";
+		model = "fixture";
+		requestedModel = "fixture";
+		openaiUseResponses = false;
+		reasoningEffort = null;
+		reasoningSummary = null;
+		maxOutputTokens = null;
+		temperature = null;
+		maxChars = 12_000;
+
+		getStatus() {
+			return {
+				provider: "test",
+				model: "fixture",
+				runtime: "test",
+				auth: { source: "none", type: "none", hasToken: false },
+				actualModel: "fixture",
+				modelFallbackApplied: false,
+				modelFallbackReason: null,
+			};
+		}
+	}
+	return {
+		...actual,
+		getExtractionBenchmarkProfile: coreMocks.getExtractionBenchmarkProfile,
+		loadObserverConfig: vi.fn(() => ({})),
+		ObserverClient: ObserverClientStub,
+		replayBatchExtraction: coreMocks.replayBatchExtraction,
+		replayBatchExtractionWithTierRouting: coreMocks.replayBatchExtractionWithTierRouting,
+	};
+});
+
+import { ContextOnlyReplayError } from "@codemem/core";
+import { memoryCommand } from "./memory.js";
+
+function command(name: string) {
+	const selected = memoryCommand.commands.find((candidate) => candidate.name() === name);
+	if (!selected) throw new Error(`expected ${name} command`);
+	return selected;
+}
+
+async function captureJson(run: () => Promise<unknown>) {
+	const originalExitCode = process.exitCode;
+	const log = vi.spyOn(console, "log").mockImplementation(() => {});
+	process.exitCode = undefined;
+	try {
+		await run();
+		const output = log.mock.calls.at(-1)?.[0];
+		return {
+			body: JSON.parse(String(output)) as Record<string, unknown>,
+			exitCode: process.exitCode,
+		};
+	} finally {
+		process.exitCode = originalExitCode;
+		log.mockRestore();
+	}
+}
+
+function contextOnlyBenchmark() {
+	const batch = (batchId: number) => ({
+		batchId,
+		sessionId: batchId,
+		label: `Context-only ${batchId}`,
+		purpose: "shape_quality",
+		complexity: "simple",
+		expectedTier: "simple",
+		expectedSummaryDisposition: "required",
+	});
+	return {
+		id: "context-only-fixture",
+		title: "Context-only fixture",
+		description: "Fixture with only delegated instruction batches",
+		scenarioId: "simple-batch-shape",
+		modelCandidates: [],
+		batches: [batch(41), batch(42)],
+	};
+}
+
+afterEach(() => {
+	coreMocks.getExtractionBenchmarkProfile.mockReset();
+	coreMocks.replayBatchExtraction.mockReset();
+	coreMocks.replayBatchExtractionWithTierRouting.mockReset();
+});
+
+describe("memory context-only extraction replay", () => {
+	it("returns a non-error replay outcome with exit code zero", async () => {
+		// Arrange
+		coreMocks.replayBatchExtraction.mockRejectedValueOnce(new ContextOnlyReplayError(41));
+
+		// Act
+		const result = await captureJson(() =>
+			command("extraction-replay").parseAsync(
+				["--batch-id", "41", "--scenario", "simple-batch-shape", "--json"],
+				{ from: "user" },
+			),
+		);
+
+		// Assert
+		expect(result).toMatchObject({
+			exitCode: 0,
+			body: {
+				status: "context_only",
+				code: "delegated_brief_context_only",
+				evaluated: false,
+				batchId: 41,
+				scenarioId: "simple-batch-shape",
+			},
+		});
+		expect(result.body).not.toHaveProperty("error");
+	});
+});
+
+describe("memory context-only extraction benchmark", () => {
+	it("skips every context-only benchmark iteration without counting an evaluation", async () => {
+		// Arrange
+		coreMocks.getExtractionBenchmarkProfile.mockReturnValue(contextOnlyBenchmark());
+		coreMocks.replayBatchExtraction.mockImplementation(async (_db, _observer, options) => {
+			throw new ContextOnlyReplayError(options.batchId);
+		});
+
+		// Act
+		const result = await captureJson(() =>
+			command("extraction-benchmark").parseAsync(
+				["--benchmark", "context-only-fixture", "--json"],
+				{ from: "user" },
+			),
+		);
+
+		// Assert
+		expect(coreMocks.replayBatchExtraction).toHaveBeenCalledTimes(2);
+		expect(coreMocks.replayBatchExtraction.mock.calls.map((call) => call[2].batchId)).toEqual([
+			41, 42,
+		]);
+		expect(result.body).toMatchObject({
+			runs: [],
+			summary: {
+				scheduledTotal: 2,
+				contextOnlySkipped: 2,
+				contextOnlySkips: [
+					{ batchId: 41, iteration: 1, evaluated: false },
+					{ batchId: 42, iteration: 1, evaluated: false },
+				],
+				total: 0,
+				shapeQualityPasses: 0,
+				shapeQualityFails: 0,
+			},
+		});
+	});
+});

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -7,6 +7,7 @@
 
 import * as p from "@clack/prompts";
 import {
+	ContextOnlyReplayError,
 	compareMemoryRoleReports,
 	EXTRACTION_BENCHMARK_QUALITY_WEIGHTS,
 	type ExtractionBenchmarkScore,
@@ -57,6 +58,34 @@ function parseStrictPositiveId(value: string): number | null {
 	if (!/^\d+$/.test(value.trim())) return null;
 	const n = Number(value.trim());
 	return Number.isFinite(n) && n >= 1 && Number.isInteger(n) ? n : null;
+}
+
+interface ContextOnlyReplayOutcome {
+	status: "context_only";
+	code: "delegated_brief_context_only";
+	evaluated: false;
+	batchId: number;
+	scenarioId: string;
+	message: string;
+}
+
+function contextOnlyReplayOutcome(
+	error: ContextOnlyReplayError,
+	target: { batchId: number; scenarioId: string },
+): ContextOnlyReplayOutcome {
+	return {
+		...target,
+		status: "context_only",
+		code: error.code,
+		evaluated: false,
+		message: error.message,
+	};
+}
+
+function emitContextOnlyReplayOutcome(outcome: ContextOnlyReplayOutcome, opts: JsonOpts): void {
+	if (opts.json) console.log(JSON.stringify(outcome, null, 2));
+	else p.log.info(outcome.message);
+	process.exitCode = 0;
 }
 
 export function resolveOpenAIResponsesOverride(
@@ -945,6 +974,16 @@ function createMemoryExtractionReplayCommand(): Command {
 				);
 				p.outro("done");
 			} catch (error) {
+				if (error instanceof ContextOnlyReplayError) {
+					emitContextOnlyReplayOutcome(
+						contextOnlyReplayOutcome(error, {
+							batchId: Number(opts.batchId),
+							scenarioId: opts.scenario.trim(),
+						}),
+						opts,
+					);
+					return;
+				}
 				const message = error instanceof Error ? error.message : "Extraction replay failed";
 				if (opts.json) {
 					emitJsonError("extraction_replay_failed", message);
@@ -1262,6 +1301,11 @@ type ExtractionBenchmarkAttemptStatus = {
 	tier: string | null;
 };
 
+interface ExtractionBenchmarkContextOnlySkip extends ContextOnlyReplayOutcome {
+	iteration: number;
+	purpose: "shape_quality" | "replay_robustness";
+}
+
 export function summarizeExtractionBenchmarkAttempts(
 	attempts: readonly ExtractionBenchmarkAttemptStatus[],
 	batches: readonly Pick<ExtractionBenchmarkAttemptStatus, "batchId" | "purpose">[],
@@ -1558,6 +1602,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 					};
 					quality: ExtractionBenchmarkScore | null;
 				}>;
+				const contextOnlySkips: ExtractionBenchmarkContextOnlySkip[] = [];
 				for (let iteration = 1; iteration <= repetitions; iteration += 1) {
 					for (const batch of benchmark.batches) {
 						const scenarioId = batch.scenarioId ?? benchmark.scenarioId;
@@ -1585,6 +1630,14 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 											transcriptBudget: transcriptBudget ?? undefined,
 										});
 						} catch (error) {
+							if (error instanceof ContextOnlyReplayError) {
+								contextOnlySkips.push({
+									...contextOnlyReplayOutcome(error, { batchId: batch.batchId, scenarioId }),
+									iteration,
+									purpose: batch.purpose,
+								});
+								continue;
+							}
 							if (
 								!(error instanceof ObserverOutputError) &&
 								!(error instanceof ObserverOutputTransportError)
@@ -1785,12 +1838,16 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 					}
 				}
 				const reviewedQualityRuns = runs.filter((run) => run.quality?.weightedQualityScore != null);
+				// Context-only skips never enter evaluation, stability, cost or output-rate denominators.
 				const attempts = [...runs, ...outputFailures];
 				const knownCostRuns = attempts.filter((run) => run.cost.total != null);
 				const attemptSummary = summarizeExtractionBenchmarkAttempts(attempts, benchmark.batches);
 				const knownElapsedRuns = attempts.filter((run) => run.telemetry.totalElapsedMs != null);
 				const summary = {
 					repetitions,
+					scheduledTotal: benchmark.batches.length * repetitions,
+					contextOnlySkipped: contextOnlySkips.length,
+					contextOnlySkips,
 					...attemptSummary,
 					summaryDispositionTotal: runs.filter((run) => run.quality != null).length,
 					summaryDispositionMatches: runs.filter(
@@ -1900,6 +1957,7 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						`Temperature: ${observerSummary.transport === "mixed" ? "mixed" : (observerSummary.temperature ?? "not transmitted")}`,
 						`Transcript budget override: ${transcriptBudget ?? "default"}`,
 						`Repetitions: ${summary.repetitions}`,
+						`Context-only skips: ${summary.contextOnlySkipped} (${summary.scheduledTotal} scheduled; ${summary.total} observer attempts)`,
 						`Shape-quality passes: ${summary.shapeQualityPasses}/${summary.shapeQualityTotal}`,
 						`Shape-quality fails: ${summary.shapeQualityFails}`,
 						`Expected-tier matches: ${summary.expectedTierMatches}/${summary.expectedTierTotal}`,
@@ -1914,6 +1972,11 @@ function createMemoryExtractionBenchmarkCommand(): Command {
 						`Summary disposition matches: ${summary.output.overall.summaryDispositionMatches}/${summary.output.overall.summaryDispositionEvaluated}; contract integrity/semantic quality: ${summary.output.overall.contractIntegrityRate?.toFixed(3) ?? "n/a"}/${summary.output.overall.meanSemanticQuality?.toFixed(3) ?? "n/a"}`,
 					].join("\n"),
 				);
+				for (const skipped of contextOnlySkips) {
+					p.log.message(
+						`  [${skipped.batchId}#${skipped.iteration}] context_only — ${skipped.code}; not evaluated`,
+					);
+				}
 				for (const run of runs) {
 					const qualityLabel =
 						run.quality?.weightedQualityScore == null

--- a/packages/core/src/delegated-extraction-replay.regression.test.ts
+++ b/packages/core/src/delegated-extraction-replay.regression.test.ts
@@ -1,0 +1,180 @@
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DELEGATED_BRIEF_LABEL, type DelegatedBriefContext } from "./capture-context.js";
+import { ContextOnlyReplayError, replayBatchExtraction } from "./extraction-replay.js";
+import type { ObserverClient } from "./observer-client.js";
+import { ingestRawEvents } from "./raw-event-ingest.js";
+import { MemoryStore } from "./store.js";
+
+const cleanupPaths: string[] = [];
+
+function provenance(text: string): DelegatedBriefContext {
+	return {
+		version: 1,
+		host: "opencode-v1",
+		origin: "delegated_brief",
+		parent_session_id: "parent",
+		child_session_id: "child",
+		task_call_id: "task",
+		message_id: "message",
+		requested_agent: "explore",
+		current_agent: "explore",
+		brief_sha256: createHash("sha256").update(text).digest("hex"),
+	};
+}
+
+function createReplayFixture({ includeFinding }: { includeFinding: boolean }): {
+	dbPath: string;
+	batchId: number;
+	brief: string;
+	sidecar: string;
+} {
+	const directory = mkdtempSync(join(tmpdir(), "codemem-delegated-replay-"));
+	cleanupPaths.push(directory);
+	const dbPath = join(directory, "test.sqlite");
+	const store = new MemoryStore(dbPath);
+	const brief = "Inspect retry ownership and report observed findings.";
+	try {
+		const events: Record<string, unknown>[] = [
+			{
+				event_id: "brief-event",
+				event_type: "user_prompt",
+				payload: { type: "user_prompt", prompt_text: brief },
+				capture_context: provenance(brief),
+			},
+		];
+		if (includeFinding) {
+			events.push({
+				event_id: "finding-event",
+				event_type: "tool.execute.after",
+				payload: {
+					type: "tool.execute.after",
+					tool: "read",
+					args: { filePath: "/fixture/src/queue.ts" },
+					result: "The pending queue retains retry entries after invalidation.",
+				},
+			});
+		}
+		ingestRawEvents(store, {
+			source: "opencode",
+			session_stream_id: "child",
+			events,
+		});
+		const now = "2026-09-11T12:00:00.000Z";
+		const session = store.db
+			.prepare(
+				`INSERT INTO sessions(started_at, ended_at, cwd, project, user, tool_version, metadata_json)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			)
+			.run(now, now, "/fixture", "fixture", "test", "raw_events", "{}");
+		const sessionId = Number(session.lastInsertRowid);
+		store.db
+			.prepare(
+				`INSERT INTO opencode_sessions(
+					source, stream_id, opencode_session_id, session_id, created_at
+				 ) VALUES (?, ?, ?, ?, ?)`,
+			)
+			.run("opencode", "child", "child", sessionId, now);
+		const batchId = includeFinding ? 91_002 : 91_001;
+		store.db
+			.prepare(
+				`INSERT INTO raw_event_flush_batches(
+					id, source, stream_id, opencode_session_id, start_event_seq, end_event_seq,
+					extractor_version, status, attempt_count, created_at, updated_at
+				 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			)
+			.run(
+				batchId,
+				"opencode",
+				"child",
+				"child",
+				0,
+				includeFinding ? 1 : 0,
+				"raw_events_v1",
+				"completed",
+				1,
+				now,
+				now,
+			);
+		const row = store.db
+			.prepare("SELECT capture_context_json FROM raw_events WHERE event_id = ?")
+			.get("brief-event") as { capture_context_json: string };
+		return { dbPath, batchId, brief, sidecar: row.capture_context_json };
+	} finally {
+		store.close();
+	}
+}
+
+function observer(observe: ReturnType<typeof vi.fn>): ObserverClient {
+	return {
+		observe,
+		getStatus: () => ({
+			provider: "test",
+			model: "fixture",
+			runtime: "test",
+			auth: { source: "none", type: "none", hasToken: false },
+		}),
+	} as unknown as ObserverClient;
+}
+
+afterEach(() => {
+	for (const path of cleanupPaths.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+describe("delegated provenance extraction replay", () => {
+	it("keeps a delegated brief labeled while replaying mixed evidence", async () => {
+		// Arrange
+		const fixture = createReplayFixture({ includeFinding: true });
+		const observe = vi.fn(async () => ({
+			raw: `<summary><request>Report observed queue behavior</request><completed>Reviewed the queue.</completed><learned>The pending queue retains retries.</learned><investigated>Queue ownership.</investigated><next_steps></next_steps><notes></notes></summary>`,
+			parsed: null,
+			provider: "test",
+			model: "fixture",
+		}));
+
+		// Act
+		const result = await replayBatchExtraction(fixture.dbPath, observer(observe), {
+			batchId: fixture.batchId,
+			scenarioId: "simple-batch-shape",
+		});
+
+		// Assert
+		expect({
+			observerCalls: observe.mock.calls.length,
+			labeledBrief: result.observerContext.transcript.includes(
+				`${DELEGATED_BRIEF_LABEL}: ${fixture.brief}`,
+			),
+			misclassifiedBrief: result.observerContext.transcript.includes(`User: ${fixture.brief}`),
+		}).toEqual({ observerCalls: 1, labeledBrief: true, misclassifiedBrief: false });
+	});
+
+	it("does not send a proven brief-only replay batch to the observer", async () => {
+		// Arrange
+		const fixture = createReplayFixture({ includeFinding: false });
+		const observe = vi.fn();
+
+		// Act
+		const replay = replayBatchExtraction(fixture.dbPath, observer(observe), {
+			batchId: fixture.batchId,
+			scenarioId: "simple-batch-shape",
+		});
+		await expect(replay).rejects.toBeInstanceOf(ContextOnlyReplayError);
+		const inspected = new MemoryStore(fixture.dbPath);
+		const row = inspected.db
+			.prepare("SELECT capture_context_json FROM raw_events WHERE event_id = ?")
+			.get("brief-event") as { capture_context_json: string };
+		inspected.close();
+
+		// Assert
+		expect({
+			observerCalls: observe.mock.calls.length,
+			sidecar: row.capture_context_json,
+		}).toEqual({
+			observerCalls: 0,
+			sidecar: fixture.sidecar,
+		});
+	});
+});

--- a/packages/core/src/extraction-replay.ts
+++ b/packages/core/src/extraction-replay.ts
@@ -1,3 +1,8 @@
+import {
+	boundedDelegatedBriefs,
+	isDelegatedBrief,
+	isDelegatedBriefOnlyBatch,
+} from "./capture-context.js";
 import { connect, resolveDbPath } from "./db.js";
 import {
 	evaluateExtractionStructure,
@@ -50,6 +55,12 @@ import {
 	resolveObserverOutputCapability,
 } from "./observer-output.js";
 import { resolveProject } from "./project.js";
+import {
+	hydrateRawEvent,
+	loadPriorDelegatedBriefEvents,
+	type RawEventContextRow,
+	rawEventCaptureContextProjection,
+} from "./raw-event-context.js";
 import { buildSessionContext } from "./raw-event-flush.js";
 
 function normalizePath(path: string, repoRoot: string | null): string {
@@ -325,6 +336,17 @@ interface PreparedReplayBatch {
 	analysis: ReplayBatchAnalysis;
 }
 
+/** Brief-only batches are retained context, not failed or successful observer evaluations. */
+export class ContextOnlyReplayError extends Error {
+	readonly code = "delegated_brief_context_only";
+	constructor(batchId: number) {
+		super(
+			`Flush batch ${batchId} is context-only delegated instructions; no observer replay is needed`,
+		);
+		this.name = "ContextOnlyReplayError";
+	}
+}
+
 function classifyReplayResult(input: {
 	raw: string | null;
 	evaluation: ReturnType<typeof evaluateSessionExtractionItems>;
@@ -484,13 +506,10 @@ async function prepareReplayBatch(
 			  }
 			| undefined;
 		if (!batch) throw new Error(`Flush batch ${opts.batchId} not found`);
-		if (batch.session_id == null) {
-			throw new Error(`Flush batch ${opts.batchId} is not linked to a local session`);
-		}
-
 		const rawRows = db
 			.prepare(
-				`SELECT event_seq, event_type, ts_wall_ms, ts_mono_ms, payload_json, event_id
+				`SELECT event_seq, event_type, ts_wall_ms, ts_mono_ms, payload_json, event_id,
+				 ${rawEventCaptureContextProjection(db)}
 				 FROM raw_events
 				 WHERE source = ?
 				   AND stream_id = ?
@@ -498,25 +517,23 @@ async function prepareReplayBatch(
 				   AND event_seq <= ?
 				 ORDER BY event_seq ASC`,
 			)
-			.all(batch.source, batch.stream_id, batch.start_event_seq, batch.end_event_seq) as Array<{
-			event_seq: number;
-			event_type: string;
-			ts_wall_ms: number | null;
-			ts_mono_ms: number | null;
-			payload_json: string;
-			event_id: string | null;
-		}>;
-		const events = rawRows.map<Record<string, unknown>>((row) => {
-			const payload = JSON.parse(row.payload_json) as Record<string, unknown>;
-			payload.type = payload.type || row.event_type;
-			payload.timestamp_wall_ms = row.ts_wall_ms;
-			payload.timestamp_mono_ms = row.ts_mono_ms;
-			payload.event_seq = row.event_seq;
-			payload.event_id = row.event_id;
-			return payload;
-		});
+			.all(
+				batch.source,
+				batch.stream_id,
+				batch.start_event_seq,
+				batch.end_event_seq,
+			) as RawEventContextRow[];
+		const events = rawRows.map((row) =>
+			hydrateRawEvent(row, { source: batch.source, streamId: batch.stream_id }),
+		);
 		if (events.length === 0) {
 			throw new Error(`Flush batch ${opts.batchId} has no raw events in range`);
+		}
+		if (batch.source === "opencode" && isDelegatedBriefOnlyBatch(events)) {
+			throw new ContextOnlyReplayError(batch.id);
+		}
+		if (batch.session_id == null) {
+			throw new Error(`Flush batch ${opts.batchId} is not linked to a local session`);
 		}
 
 		// Claude Code raw events arrive as `claude.hook` with an adapter envelope;
@@ -592,7 +609,17 @@ async function prepareReplayBatch(
 		}
 		const transcriptBudget =
 			opts.transcriptBudget ?? Math.max(1500, Math.min(5000, Math.floor(observerMaxChars * 0.4)));
+		const delegatedBriefs = boundedDelegatedBriefs(
+			loadPriorDelegatedBriefEvents(db, {
+				source: batch.source,
+				streamId: batch.stream_id,
+				beforeEventSeq: batch.start_event_seq,
+			})
+				.filter(isDelegatedBrief)
+				.map((event) => String(event.prompt_text)),
+		);
 		const observerContext: ObserverContext = {
+			...(delegatedBriefs.length ? { delegatedBriefs } : {}),
 			project: batch.project ?? resolveProject(batch.cwd ?? process.cwd()) ?? null,
 			userPrompt: observerPrompt,
 			promptNumber,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -407,6 +407,7 @@ export type {
 	ExtractionReplayResult,
 } from "./extraction-replay.js";
 export {
+	ContextOnlyReplayError,
 	extractionReplayObserverIdentity,
 	replayBatchExtraction,
 	replayBatchExtractionWithTierRouting,


### PR DESCRIPTION
## Description
Preserve delegated provenance through extraction replay and expose proven context-only replay as an explicit unevaluated CLI outcome. Benchmarks skip these batches without aborting later work or counting them as successes or failures.

This remains inert in production until the final adapter-producer PR lands.

## Type of Change
- [x] 🐛 Bug fix (fixes an issue)
- [x] 📚 Documentation (docs-only change)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes

Full `pnpm run check`: 6,884 passed, 3 existing TODOs. Covers brief-only and mixed replay plus CLI/benchmark accounting.

## Checklist
- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated
- [x] No new warnings introduced