### PR TITLE
fix(core): reject invalid payloads during context backfill

### DIFF
--- a/packages/core/src/raw-event-context.ts
+++ b/packages/core/src/raw-event-context.ts
@@ -1,5 +1,5 @@
 import { readCaptureContext } from "./capture-context.js";
-import { columnExists, type Database, fromJson } from "./db.js";
+import { columnExists, type Database, fromJson, fromJsonStrict } from "./db.js";
 
 export interface RawEventContextRow {
 	event_seq: number;
@@ -17,6 +17,25 @@ export function hydrateRawEvent(
 	identity: { source: string; streamId: string },
 ): Record<string, unknown> {
 	const payload = fromJson(row.payload_json) as Record<string, unknown>;
+	return hydrateRawEventPayload(row, identity, payload);
+}
+
+/** Reject invalid payloads before a maintenance path can persist derived data. */
+export function hydrateRawEventStrict(
+	row: RawEventContextRow,
+	identity: { source: string; streamId: string },
+): Record<string, unknown> {
+	if (row.payload_json.length === 0) {
+		throw new Error(`hydrateRawEventStrict: empty payload_json for event_seq ${row.event_seq}`);
+	}
+	return hydrateRawEventPayload(row, identity, fromJsonStrict(row.payload_json));
+}
+
+function hydrateRawEventPayload(
+	row: RawEventContextRow,
+	identity: { source: string; streamId: string },
+	payload: Record<string, unknown>,
+): Record<string, unknown> {
 	payload.type = payload.type || row.event_type;
 	payload.timestamp_wall_ms = row.ts_wall_ms;
 	payload.timestamp_mono_ms = row.ts_mono_ms;

--- a/packages/core/src/session-context-backfill.test.ts
+++ b/packages/core/src/session-context-backfill.test.ts
@@ -59,6 +59,21 @@ function insertRawEvent(
 	);
 }
 
+function insertRawEventJson(
+	db: Database,
+	streamId: string,
+	payloadJson: string,
+	eventSeq = 1,
+): void {
+	const now = new Date().toISOString();
+	db.prepare(
+		`INSERT INTO raw_events(
+			source, stream_id, opencode_session_id, event_id, event_seq,
+			event_type, ts_wall_ms, payload_json, created_at
+		) VALUES ('opencode', ?, ?, ?, ?, 'user_prompt', 1700000000000, ?, ?)`,
+	).run(streamId, streamId, `${streamId}-event-${eventSeq}`, eventSeq, payloadJson, now);
+}
+
 function insertSessionRow(
 	db: Database,
 	source: string | null,
@@ -319,6 +334,72 @@ describe("session-context backfill maintenance", () => {
 			rewritten_sessions: 0,
 		});
 	});
+
+	it.each([
+		{ label: "malformed JSON", payloadJson: "not-json" },
+		{ label: "empty text", payloadJson: "" },
+		{ label: "array", payloadJson: "[]" },
+		{ label: "null", payloadJson: "null" },
+		{ label: "scalar", payloadJson: '"scalar"' },
+	])(
+		"skips $label raw-event payload without overwriting metadata",
+		async ({ label, payloadJson }) => {
+			const invalidStreamId = `ses-invalid-${label.replaceAll(" ", "-")}`;
+			const validStreamId = `ses-valid-${label.replaceAll(" ", "-")}`;
+			const now = new Date().toISOString();
+			insertRawEventSession(db, "opencode", invalidStreamId, now);
+			insertRawEvent(
+				db,
+				"opencode",
+				invalidStreamId,
+				1,
+				`${invalidStreamId}-valid-event`,
+				"user_prompt",
+				{ type: "user_prompt", prompt_text: "Do not partially rebuild" },
+				1_700_000_000_000,
+			);
+			insertRawEventJson(db, invalidStreamId, payloadJson, 2);
+			const invalidSessionId = insertSessionRow(db, "opencode", invalidStreamId, {
+				flusher: "raw_events",
+				firstPrompt: "Keep this valid context",
+				promptCount: 1,
+				toolCount: 2,
+			});
+
+			insertRawEventSession(db, "opencode", validStreamId, now);
+			insertRawEvent(
+				db,
+				"opencode",
+				validStreamId,
+				1,
+				`${validStreamId}-event`,
+				"user_prompt",
+				{ type: "user_prompt", prompt_text: "Process clean candidates" },
+				1_700_000_000_000,
+			);
+			const validSessionId = insertSessionRow(db, "opencode", validStreamId, {
+				flusher: "raw_events",
+				promptCount: 0,
+				toolCount: 0,
+			});
+
+			await runSessionContextBackfillPass(db, { batchSize: 10 });
+
+			expect(readSessionContext(db, invalidSessionId)).toMatchObject({
+				firstPrompt: "Keep this valid context",
+				promptCount: 1,
+				toolCount: 2,
+			});
+			expect(readSessionContext(db, validSessionId)).toMatchObject({
+				firstPrompt: "Process clean candidates",
+				promptCount: 1,
+			});
+			expect(getMaintenanceJob(db, SESSION_CONTEXT_BACKFILL_JOB)?.metadata).toMatchObject({
+				skipped_invalid_payload: 1,
+				rewritten_sessions: 1,
+			});
+		},
+	);
 
 	it("ignores sessions not flushed via raw_events", async () => {
 		// Non-raw-events session should not be enqueued at all.

--- a/packages/core/src/session-context-backfill.ts
+++ b/packages/core/src/session-context-backfill.ts
@@ -28,7 +28,7 @@ import {
 	updateMaintenanceJob,
 } from "./maintenance-jobs.js";
 import {
-	hydrateRawEvent,
+	hydrateRawEventStrict,
 	type RawEventContextRow,
 	rawEventCaptureContextProjection,
 } from "./raw-event-context.js";
@@ -43,6 +43,7 @@ type SessionContextBackfillMetadata = {
 	rewritten_sessions?: number;
 	skipped_no_events?: number;
 	skipped_no_bridge?: number;
+	skipped_invalid_payload?: number;
 	unchanged_sessions?: number;
 };
 
@@ -111,12 +112,12 @@ function selectCandidateBatch(
 		.all(afterId, batchSize) as CandidateSessionRow[];
 }
 
-function loadRawEventsForStream(
+function loadRawEventRowsForStream(
 	db: SqliteDatabase,
 	source: string,
 	streamId: string,
-): Record<string, unknown>[] {
-	const rows = db
+): RawEventContextRow[] {
+	return db
 		.prepare(
 			`SELECT event_seq, event_type, ts_wall_ms, ts_mono_ms, payload_json, event_id,
 			 ${rawEventCaptureContextProjection(db)}
@@ -125,7 +126,21 @@ function loadRawEventsForStream(
 			 ORDER BY event_seq ASC`,
 		)
 		.all(source, streamId) as RawEventContextRow[];
-	return rows.map((row) => hydrateRawEvent(row, { source, streamId }));
+}
+
+function hydrateBackfillEvents(
+	rows: RawEventContextRow[],
+	identity: { sessionId: number; source: string; streamId: string },
+): Record<string, unknown>[] | null {
+	try {
+		return rows.map((row) => hydrateRawEventStrict(row, identity));
+	} catch (error) {
+		console.warn(
+			`[codemem] Session-context backfill: skipping session ${identity.sessionId} (${identity.source}/${identity.streamId}) with invalid raw-event payload`,
+			error,
+		);
+		return null;
+	}
 }
 
 function parseSessionMetadata(value: string | null): Record<string, unknown> {
@@ -178,6 +193,7 @@ interface BatchResult {
 	rewritten: number;
 	skippedNoEvents: number;
 	skippedNoBridge: number;
+	skippedInvalidPayload: number;
 	unchanged: number;
 	lastCursorId: number;
 	exhausted: boolean;
@@ -191,6 +207,7 @@ function processCandidateBatch(
 	let rewritten = 0;
 	let skippedNoEvents = 0;
 	let skippedNoBridge = 0;
+	let skippedInvalidPayload = 0;
 	let unchanged = 0;
 	let lastCursorId = candidates.at(-1)?.id ?? 0;
 
@@ -202,9 +219,16 @@ function processCandidateBatch(
 			skippedNoBridge += 1;
 			continue;
 		}
-		const events = loadRawEventsForStream(db, row.source, row.stream_id);
-		if (events.length === 0) {
+		const source = row.source;
+		const streamId = row.stream_id;
+		const eventRows = loadRawEventRowsForStream(db, source, streamId);
+		if (eventRows.length === 0) {
 			skippedNoEvents += 1;
+			continue;
+		}
+		const events = hydrateBackfillEvents(eventRows, { sessionId: row.id, source, streamId });
+		if (!events) {
+			skippedInvalidPayload += 1;
 			continue;
 		}
 		const normalized = normalizeEventsForSessionContext(events);
@@ -230,6 +254,7 @@ function processCandidateBatch(
 		rewritten,
 		skippedNoEvents,
 		skippedNoBridge,
+		skippedInvalidPayload,
 		unchanged,
 		lastCursorId,
 		exhausted: candidates.length < batchSize,
@@ -275,6 +300,7 @@ export async function runSessionContextBackfillPass(
 				rewritten_sessions: 0,
 				skipped_no_events: 0,
 				skipped_no_bridge: 0,
+				skipped_invalid_payload: 0,
 				unchanged_sessions: 0,
 			},
 		});
@@ -305,6 +331,8 @@ export async function runSessionContextBackfillPass(
 		Number(metadataBefore.skipped_no_events ?? 0) + batchResult.skippedNoEvents;
 	const skippedNoBridge =
 		Number(metadataBefore.skipped_no_bridge ?? 0) + batchResult.skippedNoBridge;
+	const skippedInvalidPayload =
+		Number(metadataBefore.skipped_invalid_payload ?? 0) + batchResult.skippedInvalidPayload;
 	const unchangedSessions = Number(metadataBefore.unchanged_sessions ?? 0) + batchResult.unchanged;
 	const nextMetadata: SessionContextBackfillMetadata = {
 		last_cursor_id: batchResult.lastCursorId,
@@ -313,6 +341,7 @@ export async function runSessionContextBackfillPass(
 		rewritten_sessions: rewrittenSessions,
 		skipped_no_events: skippedNoEvents,
 		skipped_no_bridge: skippedNoBridge,
+		skipped_invalid_payload: skippedInvalidPayload,
 		unchanged_sessions: unchangedSessions,
 	};
 
@@ -339,7 +368,10 @@ export async function runSessionContextBackfillPass(
 function summarizeCompletion(metadata: SessionContextBackfillMetadata): string {
 	const rewritten = Number(metadata.rewritten_sessions ?? 0);
 	const processed = Number(metadata.processed_sessions ?? 0);
-	const skipped = Number(metadata.skipped_no_events ?? 0) + Number(metadata.skipped_no_bridge ?? 0);
+	const skipped =
+		Number(metadata.skipped_no_events ?? 0) +
+		Number(metadata.skipped_no_bridge ?? 0) +
+		Number(metadata.skipped_invalid_payload ?? 0);
 	if (processed === 0) {
 		return "No raw-event sessions required session_context backfill";
 	}


### PR DESCRIPTION
## Description
Reject malformed, empty, scalar, array, and null raw-event payloads before the mutating session-context backfill can rewrite derived metadata. Invalid candidates are skipped and logged while clean candidates continue through the same pass.

## Type of Change
- [x] 🐛 Bug fix (fixes an issue)
- [x] 🧪 Testing (test-only changes)

## Testing
- [x] Relevant checks pass locally (`pnpm run tsc`, `pnpm run lint`, `pnpm run test`)
- [x] Added/updated tests for changes

Targeted backfill suite: 11 passed. Core suite review run: 4,167 passed. `pnpm run tsc` passed; touched-file Biome checks introduced no diagnostics.

## Checklist
- [x] Code follows project style (`pnpm run lint` passes for touched files)
- [x] Self-review completed
- [x] Documentation updated (not needed)
- [x] No new warnings introduced